### PR TITLE
Rewrote Features page to fix grammar

### DIFF
--- a/themes/godotengine/layouts/features.htm
+++ b/themes/godotengine/layouts/features.htm
@@ -55,7 +55,7 @@ description = "Features layout"
       <p>
         <em>Create games with ease, using Godot's unique approach to game development.</em>
         <ul class="text-left">
-          <li><b>There is a node for that.</b> Godot comes with hundreds of built-in nodes that make game design a breeze. You can also create your own for custom behaviors, editors and much more.</li>
+          <li><b>Nodes for all your needs.</b> Godot comes with hundreds of built-in nodes that make game design a breeze. You can also create your own for custom behaviors, editors and much more.</li>
           <li><b>Flexible scene system.</b> Create node compositions with support for instancing and inheritance.</li>
           <li><b>Visual editor</b> with all the tools you need packed into a beautiful and uncluttered context-sensitive UI.</li>
           <li><b>Friendly content creation pipeline</b> for artists, level designers, animators and everything in between.</li>
@@ -100,7 +100,7 @@ description = "Features layout"
 
   <div class="title-padded base-padding">
     <h2>Create 2D games with ease</h2>
-    <em> Godot comes with a fully dedicated 2D engine packed with helpful features. </em>
+    <em> Godot comes with a fully dedicated 2D engine packed with features. </em>
   </div>
   <div class="flex eqsize responsive base-padding">
     <ul>
@@ -185,8 +185,8 @@ description = "Features layout"
       <h2>Multi-platform deploy</h2>
       <em>Deploy games everywhere!</em>
       <ul>
-        <li><b>Mobile platforms:</b> iOS, Android, BlackBerry OS</li>
-        <li><b>Desktop platforms:</b> Windows, UWP, MacOS, Linux, *BSD and Haiku</li>
+        <li><b>Mobile platforms:</b> iOS, Android</li>
+        <li><b>Desktop platforms:</b> Windows, macOS, Linux, UWP, *BSD, Haiku</li>
         <li><b>Export to the web</b> using HTML and Web Assembly</li>
         <!--<li>Consoles: PlayStation 3, PlayStation 4 and PlayStation Vita (only with license from Sony).</li>-->
         <li><b>One-click deploy &amp; export</b> to most platforms. Easy to create custom builds too.</li>

--- a/themes/godotengine/layouts/features.htm
+++ b/themes/godotengine/layouts/features.htm
@@ -55,12 +55,12 @@ description = "Features layout"
       <p>
         <em>Create games with ease, using Godot's unique approach to game development.</em>
         <ul class="text-left">
-          <li><b>There is a node for that</b>, godot comes with hundreds of built-in nodes that make game design a breeze, you can also create you own, with custom behaviors, editors and much more.</li>
-          <li><b>Amazing scene system</b>, create node compositions with support for instancing and inheritance.</li>
-          <li><b>Visual editor</b>, with all the tools you need packed into a beautiful and uncluttered context-sensitive UI.</li>
+          <li><b>There is a node for that.</b> Godot comes with hundreds of built-in nodes that make game design a breeze. You can also create your own for custom behaviors, editors and much more.</li>
+          <li><b>Flexible scene system.</b> Create node compositions with support for instancing and inheritance.</li>
+          <li><b>Visual editor</b> with all the tools you need packed into a beautiful and uncluttered context-sensitive UI.</li>
           <li><b>Friendly content creation pipeline</b> for artists, level designers, animators and everything in between.</li>
-          <li><b>Persistent live editing</b> (changes are not lost after stopping the game). Live editing on mobile devices!</li>
-          <li><b>Create your own custom tools</b> with ease making use of the incredible tool system.</li>
+          <li><b>Persistent live editing</b> where changes are not lost after stopping the game. It even works on mobile devices!</li>
+          <li><b>Create your own custom tools</b> with ease using the incredible tool system.</li>
         </ul>
       </p>
     </div>
@@ -73,19 +73,19 @@ description = "Features layout"
   <img src="{{ 'assets/features/3dgames.jpg' | theme }}" alt="">
 
   <div class="title-padded base-padding">
-    <h2>One of the best looking 3D engines out there</h2>
+    <h2>Gorgeous 3D Graphics</h2>
     <em>
-      The whole new physically based renderer comes with a bunch features that will make your games look incredible.
+      The brand new physically based renderer comes with a ton of features that will make your games look incredible.
     </em>
   </div>
   <div class="flex eqsize responsive base-padding">
     <ul>
-      <li><b>Innovative architecture</b>, that combines the best of forward rendering with the efficiency of deferred rendering.</li>
+      <li><b>Innovative architecture</b> that combines the best of forward rendering with the efficiency of deferred rendering.</li>
       <li><b>Physically-based rendering</b> with full MSAA support</li>
       <li><b>Full principled BSDF</b> with Subsurface Scattering, reflection, refraction, anisotropy, clearcoat, transmittance and more.</li>
     </ul>
     <ul>
-      <li><b>Global illumination</b> real-time for gorgeous graphics and baked for good results even on low end devices.</li>
+      <li><b>Global illumination</b> for real-time gorgeous graphics. It can also be pre-baked for beautiful results even on low end devices.</li>
       <li><b>Mid and Post processing effects</b> including a new tonemapper that supports HDR, multiple standard curves and auto exposure, screen-space reflections, fog, bloom, depth of field and much more.</li>
       <li><b>Easy-to-use shader language</b> based on GLSL, with built-in editor and code completion.</li>
     </ul>
@@ -100,13 +100,13 @@ description = "Features layout"
 
   <div class="title-padded base-padding">
     <h2>Create 2D games with ease</h2>
-    <em> Godot comes with a fully dedicated 2D engine packed with a ton of features. </em>
+    <em> Godot comes with a fully dedicated 2D engine packed with helpful features. </em>
   </div>
   <div class="flex eqsize responsive base-padding">
     <ul>
       <li><b>Work in pixels as your units</b>, but scale to any screen size and aspect ratio.</li>
-      <li><b>Tile map editor</b>, with auto-tiling, rotation, custom grid shapes and multiple layers.</li>
-      <li><b>2D lights and normal maps</b>, give your 2D games a more realistic look. </li>
+      <li><b>Tile map editor</b> with auto-tiling, rotation, custom grid shapes and multiple layers.</li>
+      <li><b>2D lights and normal maps</b> to give your 2D games a more realistic look. </li>
     </ul>
     <ul>
       <li><b>Animate your games</b> using cut-out or sprite based animation. </li>
@@ -126,7 +126,7 @@ description = "Features layout"
     <em>The most flexible animation system.</em>
     <ul>
       <li><b>Animate literaly everything</b>, from bones and objects to function calls.</li>
-      <li><b>Use custom transition curves and tweens</b>, and create incredible animations.</li>
+      <li><b>Use custom transition curves and tweens</b> to create incredible animations.</li>
       <li><b>Helpers to animate 2D rigs</b>, with skeletons and IK.</li>
       <li><b>Efficient optimizer</b> to pack imported 3D animations.</li>
     </ul>
@@ -144,9 +144,9 @@ description = "Features layout"
         <li><b>Full C# 7.0 support</b> using Mono.</li>
         <li><b>Full C++ support</b> without needing to recompile the engine.</li>
         <li><b>Visual scripting</b> using blocks and connections.</li>
-        <li><b>Additional languages</b>, Community-provided support for Python, Nim, D and other languages.</li>
+        <li><b>Additional languages</b> with community-provided support for Python, Nim, D and other languages.</li>
         <li><b>Built-in editor</b> with syntax highlighting, real-time parser and code completion.</li>
-        <li><b>Integrated documentation</b>, browser and search the whole API offline, whithout leaving the editor.</li>
+        <li><b>Integrated documentation.</b> Browse and search the whole API offline, whithout leaving the editor.</li>
       </ul>
     </div>
   </section>
@@ -156,9 +156,9 @@ description = "Features layout"
       <h2>Debug & Optimize</h2>
       <em>Solve bugs and performance bottlenecks with the built-in debugger.</em>
       <ul>
-        <li><b>Explore and modify</b> your project while it's being run, even on mobile devices.</li>
+        <li><b>Explore and modify</b> your project while it's running, even on mobile devices.</li>
         <li><b>Keeps changes</b> by default after closing the project.</li>
-        <li><b>Built-in profiler</b>, with graph plotting and time seeking.</li>
+        <li><b>Built-in profiler</b> with graph plotting and time seeking.</li>
         <li>Video memory debugger.</li>
         <li><b>Error logger</b> with full stack traces.</li>
       </ul>
@@ -185,8 +185,8 @@ description = "Features layout"
       <h2>Multi-platform deploy</h2>
       <em>Deploy games everywhere!</em>
       <ul>
-        <li><b>Mobile platforms</b>, iOS, Android, BlackBerry OS</li>
-        <li><b>Desktop platforms</b> Windows (also UWP), OS X, Linux, *BSD and Haiku</li>
+        <li><b>Mobile platforms:</b> iOS, Android, BlackBerry OS</li>
+        <li><b>Desktop platforms:</b> Windows, UWP, MacOS, Linux, *BSD and Haiku</li>
         <li><b>Export to the web</b> using HTML and Web Assembly</li>
         <!--<li>Consoles: PlayStation 3, PlayStation 4 and PlayStation Vita (only with license from Sony).</li>-->
         <li><b>One-click deploy &amp; export</b> to most platforms. Easy to create custom builds too.</li>
@@ -203,8 +203,8 @@ description = "Features layout"
     <p>Godot is designed from the ground up for smooth teamwork.</p>
 
     <ul>
-      <li><b>Friendly filesystem usage</b>, works great with version control systems like Git, Subversion, Mercurial, PlasticSCM, Perforce, you name it.</li>
-      <li><b>Scene instancing</b> makes teamwork a breeze, every team member can focus on their own scene. Be it a character, level, etc. and edit without stepping on each other's toes.</li>
+      <li><b>Friendly filesystem usage</b> that works great with version control systems like Git, Subversion, Mercurial, PlasticSCM, Perforce, you name it.</li>
+      <li><b>Scene instancing</b> makes teamwork a breeze. Every team member can focus on their own scene, be it a character, level, etc., and edit without stepping on each other's toes.</li>
       <li>Text-based descriptive and optimal scene format.</li>
       <li>Script syntax supported by GitHub.</li>
     </ul>


### PR DESCRIPTION
I noticed some of the text on the new Features page didn't seem quite right to me as a native English speaker, so I fixed all the grammatical issues I could find. I also modified some of the feature headlines that sounded a bit strange.

Any ideas for an improved, succinct tagline for the 3D Rendering features? I feel like we could do better than "One of the best looking 3D engines out there" or my temporary replacement "Gorgeous 3D Graphics".