### PR TITLE
Grammatical fix

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -138,7 +138,7 @@ postPage = "{{ :slug }}"
       <img src="{{ 'assets/home/features/innovative.png' | theme }}" alt="" width="100%">
       <div class="dark base-padding">
         <h4>Innovative Design</h4>
-        <p>Big or small ideas adapt seamlessly to Godot node based architecture, making your life easier.</p>
+        <p>Big or small ideas adapt seamlessly to Godot's node-based architecture, making your life easier.</p>
       </div>
     </div>
     <div class="feature">


### PR DESCRIPTION
- The node-based architecture _belongs_ to Godot, so Godot needs to be a possessive.
- Put a dash between "node" and "based". This is a compound adjective. 