### PR TITLE
Adverb + plural possessive

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -179,7 +179,7 @@ postPage = "{{ :slug }}"
       <img src="{{ 'assets/home/features/oss.svg' | theme }}" alt="" width="100%">
       <div class="dark base-padding">
         <h4>Open Source</h4>
-        <p>True open development: anyone who contributes to Godot benefits equally from other’s contributions.</p>
+        <p>Truly open development: anyone who contributes to Godot benefits equally from others’ contributions.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- "Truly" instead of "True." Truly is an adverb, which emphasizes how open Godot's development is.
- "others'" instead of "other's". An apostrophe between the word and letter "s" indicates a singular possessive, whereas putting the apostrophe _after_ the "s" indicates a plural possessive. This is the correct usage.