### PR TITLE
Added godot-mono scoop install option

### DIFF
--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -37,6 +37,7 @@ is_hidden = 0
 		<li> 
 			<pre><code>scoop bucket add extras</code></pre>
 			<pre><code>scoop install godot</code></pre> 
+			<pre><code>scoop install godot-mono</code></pre>
 		</li>
 	</ul>
 {% endput %}


### PR DESCRIPTION
I added the Mono version of Godot to scoop's extras bucket so here's a PR to put it up on the site if you think people would be interested in it.

Maybe should have some text about it being a different install as it might look like it should be installed after godot?