### PR TITLE
Delete duplicated dot in features.htm

### DIFF
--- a/themes/godotengine/layouts/features.htm
+++ b/themes/godotengine/layouts/features.htm
@@ -173,7 +173,7 @@ description = "Features layout"
       <h2>Multi-platform editor</h2>
       <em>Create games on any desktop OS.</em>
       <ul>
-        <li><b>Works on Windows, OS X, Linux, FreeBSD, OpenBSD and Haiku.</b>. The editor runs in 32-bit and 64-bit, in all platforms.</li>
+        <li><b>Works on Windows, OS X, Linux, FreeBSD, OpenBSD and Haiku.</b> The editor runs in 32-bit and 64-bit, in all platforms.</li>
         <li><b>Small download</b> (around 20 MB), and you are ready to go.</li>
         <li><b>Very easy to compile</b> in any platform (no dependency hell).</li>
       </ul>


### PR DESCRIPTION
Duplicated dot:
<b>Works on Windows, OS X, Linux, FreeBSD, OpenBSD and Haiku.</b>.