### PR TITLE
Use HTTPS for links to docs.godotengine.org

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -20,7 +20,7 @@ description = "Download layout"
   }
   .btn.download a {
     color: white;
-    text-decoration: none; 
+    text-decoration: none;
   }
   .btn.download a:hover {
     color: var(--accent-color);
@@ -112,7 +112,7 @@ description = "Download layout"
 <div class="container">
   <div class="flex responsive eqsize">
     <div class="version-overview">
-      
+
       <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" height=200>
 
       <h2>Godot <em>{{stable_version}}</em></h2>
@@ -132,7 +132,7 @@ description = "Download layout"
           {% placeholder mono_downloads %}
         </div>
 
-        
+
         <hr>
 
         <div class="base-padding">
@@ -190,7 +190,7 @@ description = "Download layout"
         </div>
       </a>
 
-      <a class="card" href="http://docs.godotengine.org/en/3.0/getting_started/step_by_step/">
+      <a class="card" href="https://docs.godotengine.org/en/3.0/getting_started/step_by_step/">
         <div class="base-padding">
           <h3>learn godot</h3>
           <p>Start learning godot.</p>
@@ -220,7 +220,7 @@ description = "Download layout"
       <p>Godot development is <strong>open</strong>. This means you can fix or improve any part of the engine yourself and choose whether to contribute it back or to keep it private. New features are always available to use and test, without the need of having to wait for the next major release. Compiling Godot from source is <em>very easy</em> (it has no common dependencies) and the process (for each platform) is well-documented on the wiki. To obtain the source code (and consulting the documentation), please visit the <a href="https://github.com/godotengine/godot">GitHub project page</a>.</p>
 
     </div>
-    
+
   </div>
 
 </div>

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -132,7 +132,7 @@ postPage = "{{ :slug }}"
     <div class="base-padding full-graphic text-right">
       <img src=" {{ 'assets/home/graphic.svg' | theme }} " alt="">
     </div>
-  </div>  
+  </div>
 </section>
 
 
@@ -229,14 +229,14 @@ postPage = "{{ :slug }}"
   </p>
 
   <div class="flex eqsize responsive">
-    
+
     <div class="text-center base-padding">
       <img src="{{ 'assets/home/code.svg' | theme }}" alt="">
       <h4>code</h4>
       <p>
         If you know how to code, and enjoy fun and challenging problems, you can help by fixing bugs or creating cool new features.
       </p>
-      <a href="http://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn flat" target="_blank"> learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn flat" target="_blank"> learn more </a>
     </div>
 
     <div class="text-center base-padding">
@@ -245,7 +245,7 @@ postPage = "{{ :slug }}"
       <p>
         Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections.
       </p>
-      <a href="http://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn flat" target="_blank"> learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn flat" target="_blank"> learn more </a>
     </div>
 
     <div class="text-center base-padding">
@@ -254,7 +254,7 @@ postPage = "{{ :slug }}"
       <p>
         Found a problem with the engine? Don't forget to report it so that developers can track it down.
       </p>
-      <a href="http://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn flat" target="_blank"> learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn flat" target="_blank"> learn more </a>
     </div>
 
   </div>
@@ -268,13 +268,13 @@ postPage = "{{ :slug }}"
     <img id="sfc_graphic" src=" {{ 'assets/home/sfc.svg' | theme }} " alt="">
     <h3 class="text-center">donate</h3>
     <p class="small auto-margin">
-      You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot Engine even more awesome! 
+      You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot Engine even more awesome!
     </p>
 
     <a href="/donate" class="btn flat">learn more</a>
 
   </div>
-  
+
 </section>
 
 <section id="sponsors">

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -11,7 +11,7 @@ description = "footer partial"
       <li><a href="/news">News</a></li>
       <li><a href="/community">Community</a></li>
       <li><a href="/features">Features</a></li>
-      <li><a href="http://docs.godotengine.org">Documentation</a></li>
+      <li><a href="https://docs.godotengine.org">Documentation</a></li>
       <li><a href="/download">Download</a></li>
       <li><a href="/donate">Donate</a></li>
     </ul>

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -12,7 +12,7 @@ description = "header partial"
         <img src="{{ 'assets/hamburger.svg' | theme }}" alt="">
       </label>
     </div>
-    
+
     <nav id="nav">
       <ul class="left">
         <li {% if selected == 'features' %} class="active" {% endif %}><a href="/features">Features</a></li>
@@ -23,7 +23,7 @@ description = "header partial"
 
       <ul class="right">
         <li {% if selected == 'download' %} class="active" {% endif %}><a href="/download">Download</a></li>
-        <li><a href="http://docs.godotengine.org">Learn</a></li>
+        <li><a href="https://docs.godotengine.org">Learn</a></li>
         <li><a href="https://godotengine.org/asset-library/asset" id="asset_lib">
           <img src="{{ 'assets/asset_lib.svg' | theme }}" alt="">
         </a></li>


### PR DESCRIPTION
By the way, all of the template files have their executable flag set. Is this intended?