### PR TITLE
Removed horizontal padding on code snippets

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -508,8 +508,6 @@ a.card:hover {
 
 code {
   font-family: monospace;
-  padding-left: 8px;
-  padding-right: 8px;
 }
 pre {
   font-family: monospace;


### PR DESCRIPTION
Fixes #48, improving readability in blog posts and any other place where the `<code>` tag is used to display code in a block of text.