### PR TITLE
Update Link to Godot Developers forum

### DIFF
--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -150,7 +150,7 @@ is_hidden = 0
 		<div class="card">
 			<a href="http://godotdevelopers.org"><img src="{{ 'assets/community/icon_forum.png'|theme }}" width="100%" alt=""></a>
       <div class="base-padding">
-      	<h3><a href="http://godotdevelopers.org">Forum</a></h3>
+      	<h3><a href="https://godotdevelopers.browse-tutorials.com/forum/">Forum</a></h3>
       	<p>Community forum for all Godot developers.</p>
     	</div>
   	</div>


### PR DESCRIPTION
I don't know why the URL changed, but it did. I'm fixing this so that those that want to use the forum are still able to find it without searching around.