### PR TITLE
Use the `font-display: swap` property with Google Fonts

### DIFF
--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -31,6 +31,6 @@ categoryPage = "blog/category"
   {% endif %}
   <link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml"/>
   <link rel="icon" href="{{ 'assets/favicon.png'|theme }}">
-  <link href="https://fonts.googleapis.com/css?family=Montserrat:700,800" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:700,800&display=swap">
   <link rel="stylesheet" href="{{ 'assets/css/main.css' | theme }}">
 </head>


### PR DESCRIPTION
This makes a fallback font display instantly, making the page readable as soon as it's loaded.