### PR TITLE
Use a static navigation bar instead of a fixed one

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -36,7 +36,6 @@ body {
   width: 100vw;
   max-width: 100vw;
   overflow-x: hidden;
-  margin-top: 64px;
 }
 
 body a {
@@ -158,8 +157,6 @@ header {
   align-items: center;
   box-shadow: var(--base-shadow);
   z-index: 100;
-  position: fixed;
-  top: 0;
 }
 header > div.container {
   width: 100%;


### PR DESCRIPTION
Fixed navigation bars are frowned upon nowadays. It's a better idea to use a static navigation bar which requires less vertical space when scrolling.

This closes #33. This closes #77.