### PR TITLE
Add Docker config to setup and run the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,30 @@
-# exclude everything by default (this is a CMS!), and whitelist the safe stuff
+# Exclude everything by default (this is a CMS!), and whitelist the safe stuff
 /*
+!/README.md
+!/ISSUE_TEMPLATE.md
+!/LICENSE.txt
+
+# Vim
+*.swp
+*.swo
+
+# Git stuff
+!.gitattributes
+!.gitignore
+
+# October CMS
 packed
 node_modules
 conf.json
-!.gitattributes
-!.gitignore
-!LICENSE.txt
+
+# Plugins
 !/plugins
 /plugins/october/demo
+
+# Themes
 !/themes
 /themes/demo
+
+# Docker
+!/docker
+/docker/mariadb/storage

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,6 @@ conf.json
 
 # Docker
 !/docker
+!/docker/mariadb/init/000-setup.sql
+/docker/mariadb/init/*.sql
 /docker/mariadb/storage

--- a/README.md
+++ b/README.md
@@ -7,36 +7,39 @@ October instance.
 
 ### Dependencies
 
-- PHP 5 (version used in production)
-- [October](https://octobercms.com/)
-- Some database (MySQL is recommended)
+- [Docker](https://docker.com)
 - [Node.js](https://nodejs.org/) (6.x or newer)
   - If you cannot get a recent version from your distribution's repositories,
     try using [nvm](https://github.com/creationix/nvm).
 - [Yarn](https://yarnpkg.com/)
 
-### Installing October and the Godot theme & plugins
+### Running the site
 
-- Download and install [October](http://octobercms.com/).
-  - Note that you don't need to install Apache or nginx, as PHP has a built-in
-    development server. You can start it with `php -S localhost:8080` which
-    will host a server in the current directory.
-- If you have trouble with the installer, try to clone the repositories instead.
-  Running `composer install` then editing `config/database.php` with your
-  database credentials should get it up and running.
-- Once installed, clone this repository into your October directory (you'll have
-  to clone into an empty directory and then move it into the October directory).
-- Reassign the `active_theme` variable in `config/cms.php` to `godotengine`.
-- You may have some errors at this point, these are most likely due to plugins.
-  If an error is thrown, it should tell you which plugin caused it. Replace
-  `authorname` and `pluginname` with the plugin you wish to run the command on.
-  - Try installing the new plugin like so:
-    `php artisan plugin:install authorname.pluginname`
-  - Or refreshing the plugin like so:
-    `php artisan plugin:refresh authorname.pluginname`
-    (warning, this will erase all the database entries!)
-  - Plugins which might need these commands run on them are `RainLab.Blog` and
-    `PaulVonZimmerman.Patreon`
+- Clone this repo
+- Put a database dump (if you have one) into the `/docker/mariadb/init` folder
+    - Make sure that your script starts with the line `USE october;` and that the file extension is `.sql`
+- Run the `./docker/restart.sh` script (this will take a while the first time)
+- You might need to reinstall some plugins `/docker/php/install-plugin.sh author.name`
+    - Replace `author.name` with the names in the `/plugins/[author]/[name]` folders
+- See the website at [http://localhost:8080](http://localhost:8080)
+
+### Restoring a database
+
+- `mv /your/dump/backup-file.sql ./docker/mariadb/init`
+- `./docker/mariadb/bash.sh`
+- `cd /docker-entrypoint-initdb.d/`
+- `mysql < 000-setup.sql`
+- `mysql < backup-file.sql`
+
+### Interfacing with the Docker containers
+
+You can use the standard `docker exec -it godotengine-org--[php|mariadb] [command]` syntax or the following scripts:
+- `./docker/php/bash.sh`
+- `./docker/php/install-plugin.sh`
+- `./docker/php/log.sh`
+- `./docker/mariadb/bash.sh`
+- `./docker/mariadb/log.sh`
+- `./docker/mariadb/mysql.sh`
 
 ### Setting up the theme
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.4"
+
+networks:
+    godotengine-org--network: ~
+
+services:
+    php:
+        build:
+            context: ./php
+        container_name: "godotengine-org--php"
+        depends_on:
+            - mariadb
+        networks:
+            - godotengine-org--network
+        restart: unless-stopped
+        ports:
+            - "8080:80"
+        volumes:
+            - ../plugins:/var/www/html/plugins
+            - ../themes/godotengine:/var/www/html/themes/godotengine
+
+    mariadb:
+        image: mariadb
+        container_name: "godotengine-org--mariadb"
+        networks:
+            - godotengine-org--network
+        restart: unless-stopped
+        environment:
+            - MYSQL_ALLOW_EMPTY_PASSWORD=true
+            - MYSQL_USER=godot
+            - MYSQL_PASSWORD=godot
+        volumes:
+            - ./mariadb/storage:/var/lib/mysql
+            - ./mariadb/init:/docker-entrypoint-initdb.d

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     php:
         build:
             context: ./php
+            args:
+                # Fallback version is the one we deploy on the website.
+                october_version: "${OCTOBER_VERSION:-v1.0.458}"
         container_name: "godotengine-org--php"
         depends_on:
             - mariadb

--- a/docker/mariadb/bash.sh
+++ b/docker/mariadb/bash.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -it godotengine-org--mariadb /bin/bash

--- a/docker/mariadb/init/000-setup.sql
+++ b/docker/mariadb/init/000-setup.sql
@@ -1,0 +1,4 @@
+CREATE USER IF NOT EXISTS 'godot'@'localhost' IDENTIFIED BY 'godot';
+CREATE DATABASE IF NOT EXISTS october;
+
+GRANT ALL PRIVILEGES ON october.* TO 'godot'@'%';

--- a/docker/mariadb/log.sh
+++ b/docker/mariadb/log.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker logs -f godotengine-org--mariadb

--- a/docker/mariadb/mysql.sh
+++ b/docker/mariadb/mysql.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -it godotengine-org--mariadb mysql

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:apache
+
+# Settings
+WORKDIR /var/www/html
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Install server dependencies
+RUN apt-get update &&\
+    apt-get install -y git unzip vim zlib1g-dev libzip-dev libpng-dev
+
+# Install PHP extensions
+RUN docker-php-ext-install mysqli pdo pdo_mysql zip gd
+
+# Enable PHP modules
+RUN a2enmod rewrite
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer -o composer-setup.php &&\
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+
+# Install OctoberCMS
+RUN git init . &&\
+    git remote add origin https://github.com/octobercms/october.git &&\
+    git pull origin master &&\
+    composer install
+
+# Config
+RUN sed -i "s/'host'      => 'localhost'/'host'      => 'mariadb'/g" config/database.php
+RUN sed -i "s/'database'  => 'database'/'database'  => 'october'/g" config/database.php
+RUN sed -i "s/'username'  => 'root'/'username'  => 'godot'/g" config/database.php
+RUN sed -i "s/'password'  => ''/'password'  => 'godot'/g" config/database.php
+
+RUN sed -i "s/'activeTheme' => 'demo'/'activeTheme' => 'godotengine'/g" config/cms.php
+
+# Set permissions
+RUN chown www-data:www-data -R .

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -19,10 +19,13 @@ RUN curl -sS https://getcomposer.org/installer -o composer-setup.php &&\
     php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
 # Install OctoberCMS
-RUN git init . &&\
+ARG october_version
+RUN echo "Installing OctoberCMS version: ${october_version}" &&\
+    git init . &&\
     git remote add origin https://github.com/octobercms/october.git &&\
-    git pull origin master &&\
-    composer install
+    git fetch origin &&\
+    git checkout ${october_version} -b october-${october_version} &&\
+    composer install -v
 
 # Config
 RUN sed -i "s/'host'      => 'localhost'/'host'      => 'mariadb'/g" config/database.php

--- a/docker/php/bash.sh
+++ b/docker/php/bash.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker exec -it godotengine-org--php /bin/bash

--- a/docker/php/install-plugin.sh
+++ b/docker/php/install-plugin.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-docker exec -it godotengine-org--php /usr/local/bin/php artisan plugin:install "$1"
+USERID=${SUDO_UID}
+if [ -z "${USERID}" ]; then
+  USERID=${UID}
+fi
+
+sudo docker exec -it godotengine-org--php bash -c "/usr/local/bin/php artisan plugin:install \"$1\" && chown ${USERID}:${USERID} -R plugins/"

--- a/docker/php/install-plugin.sh
+++ b/docker/php/install-plugin.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -it godotengine-org--php /usr/local/bin/php artisan plugin:install "$1"

--- a/docker/php/log.sh
+++ b/docker/php/log.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker logs -f godotengine-org--php

--- a/docker/restart.sh
+++ b/docker/restart.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo docker-compose down && sudo docker-compose up --build -d
+sudo docker-compose down && sudo OCTOBER_VERSION=${OCTOBER_VERSION} docker-compose up --build -d

--- a/docker/restart.sh
+++ b/docker/restart.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker-compose down && sudo docker-compose up --build -d


### PR DESCRIPTION
This simplifies setting up the dev environment to run the website
(possibly with a database dump) and test changes before deploying
to the live instance.

---

First part of the work done by @mrzapp in https://github.com/mrzapp/godot-website, but rebased to squash commits together, improve the commit description, separate the Docker addition from the CMS plugins update, rebase on the master branch and fix line ending issues.

I'll make a second PR with the CMS plugins update, but we should likely test and validate the Docker setup first.