### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ October instance.
 ### Dependencies
 
 - [Docker](https://docker.com)
-- [Node.js](https://nodejs.org/) (6.x or newer)
+- [Node.js](https://nodejs.org/) (8.x or newer)
   - If you cannot get a recent version from your distribution's repositories,
-    try using [nvm](https://github.com/creationix/nvm).
+    try using [fnm](https://github.com/Schniz/fnm).
 - [Yarn](https://yarnpkg.com/)
 
 ### Running the site
 
-- Clone this repo
-- Put a database dump (if you have one) into the `/docker/mariadb/init` folder
-    - Make sure that your script starts with the line `USE october;` and that the file extension is `.sql`
-- Run the `./docker/restart.sh` script (this will take a while the first time)
-- You might need to reinstall some plugins `/docker/php/install-plugin.sh author.name`
-    - Replace `author.name` with the names in the `/plugins/[author]/[name]` folders
-- See the website at [http://localhost:8080](http://localhost:8080)
+- Clone this repository.
+- Put a database dump (if you have one) into the `/docker/mariadb/init` folder.
+  - Make sure that your script starts with the line `USE october;` and that the file extension is `.sql`.
+- Run the `./docker/restart.sh` script (this will take a while the first time).
+- You might need to reinstall some plugins `/docker/php/install-plugin.sh author.name`.
+  - Replace `author.name` with the names in the `/plugins/[author]/[name]` folders.
+- See the website at [http://localhost:8080](http://localhost:8080).
 
 ### Restoring a database
 
@@ -34,6 +34,7 @@ October instance.
 ### Interfacing with the Docker containers
 
 You can use the standard `docker exec -it godotengine-org--[php|mariadb] [command]` syntax or the following scripts:
+
 - `./docker/php/bash.sh`
 - `./docker/php/install-plugin.sh`
 - `./docker/php/log.sh`
@@ -58,8 +59,8 @@ You can use the standard `docker exec -it godotengine-org--[php|mariadb] [comman
 Deploying is of course only possible to people who have access to our
 production server. Most contributors should submit a pull request instead.
 
-- Copy example_conf.json: `cp example_conf.json conf.json`
-- Fill out your credentials in `conf.json`
+- Copy example_conf.json: `cp example_conf.json conf.json`.
+- Fill out your credentials in `conf.json`.
 - Run `yarn deploy`.
 
 This will copy all the compiled assets from the `godotengine/assets/packed`


### PR DESCRIPTION
- Increase the required Node.js version to 8.x.
- Recommend using fnm as it's much faster to initialize compared to nvm.
- Fix warnings reported by markdownlint.