### PR TITLE
Remove unfinished Roadmap page

### DIFF
--- a/themes/godotengine/pages/roadmap.htm
+++ b/themes/godotengine/pages/roadmap.htm
@@ -1,6 +1,0 @@
-title = "Roadmap"
-url = "/roadmap"
-layout = "default"
-is_hidden = 0
-==
-## Coming Soon.


### PR DESCRIPTION
The page was never finished and didn't have any links. The [godot-roadmap](https://github.com/godotengine/godot-roadmap) GitHub repository is currently outdated, but it stands higher chances to be eventually updated right now.