### PR TITLE
Add informations on code signed downloads for Windows and macOS

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -168,7 +168,7 @@ description = "Download layout"
         <img src="{{ 'assets/download/itch_logo.svg' | theme }}" height=42>
         Available on <strong>itch.io</strong>.
       </a>
-      <a class="steam-download base-padding card" href="http://store.steampowered.com/app/404790" title="Godot Engine on Steam">
+      <a class="steam-download base-padding card" href="https://store.steampowered.com/app/404790" title="Godot Engine on Steam">
         <img src="{{ 'assets/download/steam_logo.svg' | theme }}" height=42>
         Available on <strong>Steam</strong>.
       </a>

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -26,7 +26,16 @@ is_hidden = 0
 {% endput %}
 
 {% put instructions %}
-  <p>You can also get it with <a href="https://brew.sh/">Homebrew</a>.</p>
+  <p>
+    Godot is currently not code-signed for macOS. See the last section of
+    <a href="https://support.apple.com/en-us/HT202491">this page</a>
+    for instructions on allowing Godot to run anyway. Alternatively, you can install
+    <a href="https://store.steampowered.com/app/404790">Godot from Steam</a> to work around this.
+  </p>
+  <p>
+    You can also get Godot with <a href="https://brew.sh/">Homebrew</a>.
+    Note that the version available on Homebrew isn't code-signed either.
+  </p>
   <ul>
     <li><pre><code>brew cask install godot</code></pre></li>
   </ul>

--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -37,11 +37,12 @@ is_hidden = 0
 {% endput %}
 
 {% put instructions %}
-  <p>You can also get it with <a href="http://scoop.sh/">Scoop</a></p>
+  <p>You can also get Godot with <a href="https://scoop.sh/">Scoop</a>.</p>
   <ul>
     <li>
       <pre><code>scoop bucket add extras</code></pre>
       <pre><code>scoop install godot</code></pre>
     </li>
   </ul>
+  <p>Windows executables are code-signed by <em>Prehensile Tales B.V.</em></p>
 {% endput %}


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/11984.

This closes #131.