### PR TITLE
Mention console support via third-party providers on the Features page

### DIFF
--- a/themes/godotengine/layouts/features.htm
+++ b/themes/godotengine/layouts/features.htm
@@ -166,7 +166,7 @@ description = "Features layout"
       <h2>Multi-platform editor</h2>
       <em>Create games on any desktop OS.</em>
       <ul>
-        <li><strong>Works on Windows, macOS, Linux, FreeBSD, OpenBSD and Haiku.</strong> The editor runs in 32-bit and 64-bit on all platforms.</li>
+        <li><strong>Works on Windows, macOS, Linux, FreeBSD and OpenBSD.</strong> The editor runs in 32-bit and 64-bit on all platforms.</li>
         <li><strong>Small download</strong> (around 25 MB), and you are ready to go.</li>
         <li><strong>Very easy to compile</strong> on any platform (no dependency hell).</li>
       </ul>
@@ -178,10 +178,13 @@ description = "Features layout"
       <h2>Multi-platform deploy</h2>
       <em>Deploy games everywhere!</em>
       <ul>
+        <li><strong>Desktop platforms:</strong> Windows, macOS, Linux, UWP, *BSD</li>
         <li><strong>Mobile platforms:</strong> iOS, Android</li>
-        <li><strong>Desktop platforms:</strong> Windows, macOS, Linux, UWP, *BSD, Haiku</li>
+        <li>
+          <strong>Consoles:</strong> Nintendo Switch, PlayStation 4, Xbox One via third-party providers
+          <a href="https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html">(read more)</a>
+        </li>
         <li><strong>Export to the web</strong> using HTML5 and WebAssembly</li>
-        <!--<li>Consoles: PlayStation 3, PlayStation 4 and PlayStation Vita (only with license from Sony).</li>-->
         <li><strong>One-click deploy &amp; export</strong> to most platforms. Easily create custom builds as well.</li>
       </ul>
     </div>


### PR DESCRIPTION
This also removes the mention of Haiku support for the Godot editor, as it has been broken since Godot 3.0's release.

See https://github.com/godotengine/godot-docs/issues/3516.