### PR TITLE
Use standard case for headings instead of uppercase

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -53,7 +53,6 @@ body a:hover, a.btn.flat:hover {
 h1, h2, h3, h4, nav a, .btn, a.btn, .title-font {
   font-family: 'Montserrat', sans-serif;
   font-weight: 800;
-  text-transform: uppercase;
   color: var(--base-color-text-title);
   margin-top: 0px;
 }
@@ -78,6 +77,7 @@ h4 {
 }
 
 .intro-title {
+  text-transform: capitalize;
   margin-top: 48px;
   margin-bottom: 48px;
 }
@@ -206,9 +206,6 @@ nav > ul > :first-child {
 }
 nav > ul > :last-child {
   padding-right: 0px;
-}
-nav li {
-  text-transform: uppercase;
 }
 nav > ul > li {
   padding-left: 16px;

--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -111,7 +111,7 @@ description = "Download layout"
     </div>
     <div class="tabs">
       <a href="/download/linux" class="title-font {% if platform == 'linux' %} active {% endif %}">Linux</a>
-      <a href="/download/osx" class="title-font {% if platform == 'osx' %} active {% endif %}">mac os</a>
+      <a href="/download/osx" class="title-font {% if platform == 'osx' %} active {% endif %}">macOS</a>
       <a href="/download/windows" class="title-font {% if platform == 'windows' %} active {% endif %}">Windows</a>
       <a href="/download/server" class="title-font {% if platform == 'server' %} active {% endif %}">Server</a>
     </div>

--- a/themes/godotengine/layouts/events.htm
+++ b/themes/godotengine/layouts/events.htm
@@ -27,8 +27,8 @@ description = "Events layout"
       <h1 class="intro-title">Events</h1>
     </div>
     <div class="tabs">
-      <a href="/events/" class="title-font {% if this.page.id == 'events' %} active {% endif %}">upcoming</a>
-      <a href="/events/past" class="title-font {% if this.page.id == 'events-past' %} active {% endif %}">past</a>
+      <a href="/events/" class="title-font {% if this.page.id == 'events' %} active {% endif %}">Upcoming</a>
+      <a href="/events/past" class="title-font {% if this.page.id == 'events-past' %} active {% endif %}">Past</a>
     </div>
   </div>
 </div>

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -131,7 +131,7 @@ postPage = "{{ :slug }}"
   <div class="container flex eqsize responsive">
 
     <div class="padded">
-      <h2>The game engine you waited for.</h2>
+      <h2>The game engine you waited&nbsp;for.</h2>
       <p>
         Godot provides a huge set of common tools, so you can just focus on
         making your game without reinventing the wheel.
@@ -166,7 +166,7 @@ postPage = "{{ :slug }}"
     </a>
 
     <div id="news">
-      <h3 class="base-padding no-margin-bottom">news</h3>
+      <h3 class="base-padding no-margin-bottom">News</h3>
       <hr class="">
       {% for post in posts %}
         {% if post != posts[0] %}
@@ -176,7 +176,7 @@ postPage = "{{ :slug }}"
           <hr>
         {% endif %}
       {% endfor %}
-      <div class="text-center base-padding"><a href="/news" class="btn flat no-margin">more</a></div>
+      <div class="text-center base-padding"><a href="/news" class="btn flat no-margin">More</a></div>
     </div>
 
   </div>
@@ -247,29 +247,29 @@ postPage = "{{ :slug }}"
 
     <div class="text-center base-padding">
       <img src="{{ 'assets/home/code.svg' | theme }}" alt="">
-      <h4>code</h4>
+      <h4>Code</h4>
       <p>
         If you know how to code, and enjoy fun and challenging problems, you can help by fixing bugs or creating cool new features.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn flat" target="_blank"> learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn flat" target="_blank"> Learn more </a>
     </div>
 
     <div class="text-center base-padding">
       <img src="{{ 'assets/home/document.svg' | theme }}" alt="">
-      <h4>document</h4>
+      <h4>Document</h4>
       <p>
         Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn flat" target="_blank"> learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn flat" target="_blank"> Learn more </a>
     </div>
 
     <div class="text-center base-padding">
       <img src="{{ 'assets/home/report.svg' | theme }}" alt="">
-      <h4>report</h4>
+      <h4>Report</h4>
       <p>
         Found a problem with the engine? Don't forget to report it so that developers can track it down.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn flat" target="_blank"> learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn flat" target="_blank"> Learn more </a>
     </div>
 
   </div>
@@ -278,7 +278,7 @@ postPage = "{{ :slug }}"
 <section id="donations" class="padded">
   <div class="container sm-full">
     <img id="sfc_graphic" src=" {{ 'assets/home/sfc.svg' | theme }} " alt="Software Freedom Conservancy">
-    <h3 class="text-center">donate</h3>
+    <h3 class="text-center">Donate</h3>
     <p class="small auto-margin">
       You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot Engine even more awesome!
     </p>

--- a/themes/godotengine/src/scss/main.scss
+++ b/themes/godotengine/src/scss/main.scss
@@ -107,7 +107,6 @@ a.slink:hover {
   color: #fff !important;
   font-family: "Roboto Condensed", sans-serif;
   font-weight: 700;
-  text-transform: uppercase;
   transition: 0.15s;
 }
 
@@ -164,7 +163,6 @@ a.slink:hover {
 
 .news-list h2 {
   margin-top: 25px;
-  text-transform: uppercase;
   color: #333;
   font-size: 22px;
 }
@@ -332,7 +330,6 @@ nav ul {
 
 nav a {
   color: #414141;
-  text-transform: uppercase;
   font-size: 1rem;
   display: inline-block;
   padding: 1rem 0.8rem 1rem 0.8rem;
@@ -655,7 +652,6 @@ footer h4 {
   margin-top: -1rem;
   margin-bottom: 1rem;
   font-size: 95%;
-  text-transform: uppercase;
 }
 
 .download-info {
@@ -738,7 +734,6 @@ h5,
 h6 {
   font-family: "Roboto Condensed", sans-serif;
   font-weight: 700;
-  text-transform: uppercase;
 }
 
 p,
@@ -772,6 +767,7 @@ a:active {
 }
 
 .intro-title {
+  text-transform: capitalize;
   margin-top: 6rem;
   margin-bottom: 25px;
   color: #4789bc;
@@ -799,7 +795,6 @@ a:active {
 }
 
 .date-small {
-  text-transform: uppercase;
   font-family: "Roboto Condensed", sans-serif;
   font-size:18px;
   font-weight:lighter;


### PR DESCRIPTION
Standard case is easier to read compared to uppercase. It tends to look better overall as well. For the record, I did this for the game titles in the [Godot 3.2 games showcase](https://www.youtube.com/watch?v=UEDEIksGEjQ).

The main page title now uses a non-breaking space between "waited" and "for" to prevent leaving just "for" on a new line.

## Preview

<details>
<summary>Various screenshots with the new case</summary>

![2020-05-23_18 02 17](https://user-images.githubusercontent.com/180032/82735390-ad962000-9d21-11ea-8157-a4df67a667dd.png)

![2020-05-23_18 02 35](https://user-images.githubusercontent.com/180032/82735391-aec74d00-9d21-11ea-9179-0a20ab727cc5.png)

![2020-05-23_18 04 15](https://user-images.githubusercontent.com/180032/82735392-af5fe380-9d21-11ea-9780-ec0235c136ea.png)
</details>

### Before (news article)

![2020-05-23_17 28 41](https://user-images.githubusercontent.com/180032/82735384-a8d16c00-9d21-11ea-970f-ea491f374a7a.png)

### After (news article)

![2020-05-23_17 28 51](https://user-images.githubusercontent.com/180032/82735388-ab33c600-9d21-11ea-9c51-05753f82a627.png)