### PR TITLE
Tweak the text about headless versus server builds on the Download page

### DIFF
--- a/themes/godotengine/pages/download/server.htm
+++ b/themes/godotengine/pages/download/server.htm
@@ -38,12 +38,12 @@ is_hidden = 0
 {% put instructions %}
     <ul>
       <li>
-        <em>Headless</em> is a Linux 64-bit build of the editor tools to run on headless environment.
-        It is used from the command line to run tests or export projects.
+        The <em>headless</em> build includes the editor tool functionality that
+        enables it to run tests and export projects in an automated manner.
       </li>
       <li>
-        <em>Server</em> is a Linux 64-bit build of the export template running
-        without graphics and audio, useful to host server instances for Godot games.
+        The <em>server</em> build is optimized to run dedicated game servers and
+        does not include editor tools, graphics or audio support.
       </li>
     </ul>
 {% endput %}


### PR DESCRIPTION
See https://github.com/godotengine/godot-docs/pull/3557#issuecomment-633089196. Thanks @follower for the suggestion :slightly_smiling_face: