### PR TITLE
Apply the theme's line height change to ordered lists

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -327,7 +327,7 @@ svg.icon {
   width: 42px;
 }
 
-p, ul {
+p, ul, ol {
   text-rendering: optimizeLegibility;
   line-height: 1.5;
 }


### PR DESCRIPTION
Articles like <https://godotengine.org/article/godot-editor-running-web-browser> use ordered lists, but the line height was previously only applied to paragraphs and unordered lists.

## Preview

### Before

![image](https://user-images.githubusercontent.com/180032/83361310-2e8b9200-a388-11ea-9eb1-bedf148fad60.png)

### After

![image](https://user-images.githubusercontent.com/180032/83361304-27648400-a388-11ea-9cfa-a40834a85c17.png)