### PR TITLE
Decrease the vertical margin for the version overview on Download page

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -70,7 +70,7 @@ description = "Download layout"
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    margin-top: 50px;
   }
 
   .version-overview h2 {


### PR DESCRIPTION
This closes #141.

## Preview

### Before

![Download page](https://user-images.githubusercontent.com/180032/84300354-795c9500-ab52-11ea-9f25-d116817a0aa2.png)

### After

![Download page](https://user-images.githubusercontent.com/180032/84300352-78c3fe80-ab52-11ea-8311-dd290dd17810.png)