### PR TITLE
Fixed text on the downloads page's 'Extras' section turning white on hover

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -473,7 +473,7 @@ a.card {
   text-decoration: none;
   display: flex;
 }
-a.card:hover {
+.steam-download:hover {
   color: hsla(0, 0%, 100%);
 }
 


### PR DESCRIPTION
This closes #148, which was previously broken by https://github.com/godotengine/godot-website/commit/f81e55551a26a920da88bf622d66d0c54286b669