### PR TITLE
Add privacy policy, drafted with Conservancy

### DIFF
--- a/themes/godotengine/layouts/more.htm
+++ b/themes/godotengine/layouts/more.htm
@@ -17,6 +17,9 @@ description = "More layout"
       <a href="/contact" class="title-font {% if this.page.id == 'contact' %} active {% endif %}">
         Contact
       </a>
+      <a href="/privacy-policy" class="title-font {% if this.page.id == 'privacy-policy' %} active {% endif %}">
+        Privacy
+      </a>
       <a href="/code-of-conduct" class="title-font {% if this.page.id == 'code-of-conduct' %} active {% endif %}">
         Code of Conduct
       </a>

--- a/themes/godotengine/pages/privacy-policy.htm
+++ b/themes/godotengine/pages/privacy-policy.htm
@@ -1,0 +1,183 @@
+title = "Privacy Policy"
+url = "/privacy-policy"
+layout = "more"
+description = "Privacy statement for Godot Engine"
+is_hidden = 0
+==
+
+{% put title %} Privacy policy {% endput %}
+
+<div class="container">
+
+  <h3 class="title">Scope of This Notice</h3>
+
+  <p>This Privacy Statement is intended to describe Godot Engine's privacy practices and provide information about the choices you have regarding the ways in which information collected by Godot Engine is used and disclosed. Godot Engine, a member project of the <a href="https://sfconservancy.org/">Software Freedom Conservancy</a>, is referred to in this document as "Godot".</p>
+
+  <p>It covers both online platforms of the Godot project and the use of the Godot Engine application.</p>
+
+  <h3 class="title">Our Commitment to Privacy</h3>
+
+  <p>Your privacy is important to Godot and Software Freedom Conservancy. To better protect your privacy and to comply with various laws and regulations, we have provided this Statement explaining our information practices and the choices you can make about the way your personal information is collected, used and disclosed. To make this Statement easy to find, we have made it available on our <a href="/privacy-policy">homepage</a> and at many of the locations where personally-identifiable information may be requested.</p>
+
+  <h3 class="title">The Information We Collect</h3>
+
+  <p>This Privacy Statement applies to all information collected by or submitted to Godot, including personal data. "Personal data" is data that can be used to identify an individual.</p>
+
+  <p>Godot collects personal data when:</p>
+
+  <ul>
+    <li>you visit the Godot web site (<a href="https://godotengine.org">godotengine.org</a>), hosted by <a href="https://www.tuxfamily.org/">TuxFamily</a> (see the TuxFamily privacy policy: <a href="https://faq.tuxfamily.org/Privacy/En">https://faq.tuxfamily.org/Privacy/En</a>);</li>
+    <li>you access the Asset Library in the Godot editor application to browse or download assets;</li>
+    <li>you sign up as a Godot Patreon (<a href="https://patreon.com/godotengine">https://patreon.com/godotengine</a>) or otherwise donate to Godot (<a href="https://godotengine.org/donate">https://godotengine.org/donate</a>);</li>
+    <li>you sign up and log in to an account on Godot's Q&amp;A site (<a href="https://godotengine.org/qa">https://godotengine.org/qa</a>), and use it to ask or answer questions;</li>
+    <li>you sign up and log in to an account on Godot's Asset Library (<a href="https://godotengine.org/asset-library">https://godotengine.org/asset-library</a>), and use it to submit content;</li>
+    <li>you use one of Godot's publicly logged project IRC channels (#godotengine-atelier, #godotengine-devel, #godotengine-meeting) on the Freenode IRC network;</li>
+    <li>you sign up for one of our public mailing lists hosted by TuxFamily;</li>
+    <li>you participate in surveys or evaluations;</li>
+    <li>you submit questions or comments to us.</li>
+  </ul>
+
+  <p>When you use the Asset Library in the Godot Engine application, HTTPS requests are made to the Asset Library website, and may contain: Godot Engine version, search query, selected assets, and user IP. The Asset Library processes this data without storing it, but our TuxFamily hosting's HTTP server may log these requests. Such logs are subject to TuxFamily's privacy policy (<a href="https://faq.tuxfamily.org/Privacy/En">https://faq.tuxfamily.org/Privacy/En</a>).<br>
+  This is the only personal data collected by the Godot Engine application.</p>
+
+  <p>When you create an account on the Godot website (including the Q&amp;A platform, the Asset Library and October CMS), it collects your username and email address for authentication. Additional information may be collected if you choose to fill in optional fields in your user profile (e.g. full name, location, profile picture).</p>
+
+  <p>When you join or send messages to any of the IRC channels listed above, that activity is logged and published publicly for others interested in the project. This logging includes the user nickname specified when connecting to Freenode and your messages in those public channels.</p>
+
+  <p>Third party services that Godot uses may also collect data from you and have their own privacy policies which specify what they do with the data they collect.</p>
+
+  <p>Anonymized site visit statistics (<a href="https://stats.tuxfamily.org/godotengine.org">https://stats.tuxfamily.org/godotengine.org</a>) and download statistics (<a href="https://stats.download.tuxfamily.org/godotengine">https://stats.download.tuxfamily.org/godotengine</a>) are collected and published publicly by our TuxFamily hosting.</p>
+
+  <p>Godot may also collect personal data from individuals (with their consent) at conventions, trade shows and expositions. The types of personal data collected may include (but are not limited to):</p>
+
+  <ul>
+    <li>your first and last name;</li>
+    <li>your title and your company's name;</li>
+    <li>your home, billing, or other physical address (including street name, name of a city or town, state/province);</li>
+    <li>your country code;</li>
+    <li>your e-mail address;</li>
+    <li>your telephone number;</li>
+    <li>any other identifier that permits Godot to make physical or online contact with you;</li>
+  </ul>
+
+  <h3 class="title">Using (Processing) Your Personal Data</h3>
+
+  <p>Godot uses the personal data you provide to:</p>
+
+  <ul>
+    <li>create and maintain your accounts;</li>
+    <li>identify and authenticate you;</li>
+    <li>attribute data and content you produce directly and indirectly in our public-facing services;</li>
+    <li>answer your questions;</li>
+    <li>send you information;</li>
+    <li>for research activities, including the production of statistical reports (such aggregated information is not used to contact the subjects of the report);</li>
+    <li>send you surveys;</li>
+    <li>maintain our servers.</li>
+  </ul>
+
+  <p>We also use this personal data to provide you with information related to your account and the educational materials, software and services you acquire from us, to better understand your needs and interests, to improve what we do for you and the public, to personalize communications, and to comply with or fulfill any contractual obligations to you. It is in Godot’s legitimate business interests to provide you with the information, communications, and services you request; to create a public record of the data and content produced by Godot’s services; and to maintain the integrity of that data and content for historical, scientific, and research purposes.</p>
+
+  <h3 class="title">Sharing Your Personal Data</h3>
+
+  <p>Unless you consent, Godot will never process or share the personal data you provide to us except as described below.</p>
+
+  <p>Godot may share your personal data with third parties under any of the following circumstances:</p>
+
+  <ul>
+    <li>To attribute your contributions to source repositories, forums, and IRC channels.</li>
+    <li>As required to provide service, and for e-mail housing (as a consequence of uses already described in this Privacy Statement). It is in Godot’s legitimate business interest to provide all users an accurate record of data and content provided by Godot’s services, and to maintain the integrity of that data and content for historical, scientific, and research purposes. This data and content may include but is not limited to email, code changes, comments, and artifacts.</li>
+    <li>As required by law (such as responding to a valid subpoena, warrant, audit, or agency action, or to prevent fraud).</li>
+    <li>For research activities, including the production of statistical reports (such aggregated information is used to describe our services and is not used to contact the subjects of the report).</li>
+  </ul>
+
+  <h3 class="title">Donations</h3>
+
+  <p>We receive personal information from third party services when you donate to us via online payment mechanisms. We do not sell or distribute this information to third parties. Godot uses this information to acknowledge your donation and send you occasional solicitations and newsletters. Donors can opt out of all contact by emailing <a href="mailto:privacy@godotengine.org">privacy@godotengine.org</a>. Donor names (as registered on Patreon) are posted on <a href="https://github.com/godotengine/godot/blob/master/DONORS.md">https://github.com/godotengine/godot/blob/master/DONORS.md</a> and included in the Godot editor application's "About" dialog as a recognition of their support. At the time of the donation, the donor can ask to be anonymous, so that their name will not be publicly recognized.</p>
+
+  <h3 class="title">Receiving E-Mail</h3>
+
+  <p>Godot may send you e-mail to authorize accounts you create on our site, to inform you of important upcoming Godot events, to send occasional solicitations in connection with our donor programs as described above or in response to your questions. For your protection, Godot may contact you in the event that we find an issue that requires your immediate attention. Godot processes your personal data in these cases to fulfill and comply with its contractual obligations to you, to provide the services you have requested, and to ensure the security of your account.</p>
+
+  <h3 class="title">Cookies and Other Browser Information</h3>
+
+  <p>Godot's online services automatically capture IP addresses. We use IP addresses to help diagnose problems with our servers, to administer our website, and to help ensure the security of your interaction with our services.</p>
+
+  <p>As part of offering and providing customizable and personalized services, Godot uses cookies to store and sometimes track information about you. A cookie is a small amount of data that is sent to your browser from a Web server and stored on your computer's hard drive. All sections of godotengine.org where you are prompted to log in or that are customizable require your browser to accept cookies.</p>
+
+  <p>Generally, we use cookies to remind us of who you are and to access your account information (stored on our computers) in order to provide a better and more personalized service. This cookie is set when you register or "sign in" and is modified when you "sign out" of our services.</p>
+
+  <p>If you do not want your personal information to be stored by cookies, you can configure your browser so that it always rejects these cookies or asks you each time if you accept them or not. However, you must understand that the use of cookies may be necessary to provide certain services, and choosing to reject cookies will reduce the performance and functionality of the site. Your browser documentation includes instructions explaining how to enable, disable or delete cookies at the browser level (usually located in the “Help”, “Tools” or “Edit” facility).</p>
+
+  <h3 class="title">Our Commitment to Data Security</h3>
+
+  <p>Godot trains its administrators on our privacy policy guidelines and makes our privacy policy available to our partners. Our website uses Secure Socket Layer (SSL) technology, which encrypts your personal data when you send your personal information on our website. In addition, Godot and its partners enter into confidentiality agreements which require that care and precautions be taken to prevent loss, misuse, or disclosure of your personal data.</p>
+
+  <h3 class="title">Public Forums Reminder</h3>
+
+  <p>Godot often makes mailing lists, source repositories, issue trackers, Etherpads, forums, and IRC logs available to the public. Please remember that any information that is disclosed in these areas becomes public information. Please think carefully about your desired level of anonymity before you disclose personal information. Although we value individual ideas and encourage free expression, Godot reserves the right to take necessary action to preserve the integrity of these areas, such as removing any posting that is vulgar or inappropriate. It is in Godot’s legitimate business interests to provide all users an accurate record of data and content provided in the public forums it maintains and uses; to maintain the integrity of that data and content for historical, scientific, and research purposes; and to provide an environment for the free exchange of ideas relevant and constructive to the development and propagation of software freedom.</p>
+
+  <h3 class="title">Our Commitment to Children's Online Privacy</h3>
+
+  <p>Out of special concern for children's privacy, Godot does not knowingly accept online personal information from children under the age of 13. Godot does not knowingly allow children under the age of 13 to become registered members of our sites. Godot does not knowingly collect or solicit personal information about children under 13.</p>
+
+  <p>In the event that Godot ever decides to expand its intended site audience to include children under the age of 13, those specific web pages will, in accordance with the requirements of the Children's Online Privacy Protection Act (COPPA), be clearly identified and provide an explicit privacy notice addressed to children under 13. In addition, Godot will provide an appropriate mechanism to obtain parental approval, allow parents to subsequently make changes to or request removal of their children's personal information, and provide access to any other information as required by law.</p>
+
+  <p>Additionally, EU residents under the age of 16 should not submit their personal data for subscribing to our email solicitations and we will delete any such data if we become aware of it.</p>
+
+  <h3 class="title">About Links to Other Sites</h3>
+
+  <p>This site contains links to other sites. Godot does not control the information collection of sites that can be reached through links from godotengine.org. If you have questions about the data collection procedures of linked sites, please contact those sites directly.</p>
+
+  <h3 class="title">Your Rights and Choices in the EEA and Around the World</h3>
+
+  <p>Where the EU General Data Protection Regulation 2016/679 (“GDPR”) applies to the processing of your personal data, especially when you access the website from a country in the European Economic Area (“EEA”), you have the following rights, subject to some limitations, against Godot:</p>
+
+  <ul>
+    <li>The right to access your personal data;</li>
+    <li>The right to rectify the personal data we hold about you;</li>
+    <li>The right to erase your personal data;</li>
+    <li>The right to restrict our use of your personal data;</li>
+    <li>The right to object to our use of your personal data;</li>
+    <li>The right to receive your personal data in a usable electronic format and transmit it to a third party (also known as the right of data portability); and</li>
+    <li>The right to lodge a complaint with your local data protection authority.</li>
+  </ul>
+
+  <p>If you would like to exercise any of these rights, you may do so by mailing <a href="mailto:privacy@godotengine.org">privacy@godotengine.org</a>. Please understand, however, the rights enumerated above are not absolute in all cases.</p>
+
+  <p>Where the GDPR applies, you also have the right to withdraw any consent you have given to uses of your personal data. If you wish to withdraw consent that you have previously provided to Godot, you may do so by mailing <a href="mailto:privacy@godotengine.org">privacy@godotengine.org</a>. However, the withdrawal of consent will not affect the lawfulness of processing based on consent before its withdrawal.</p>
+
+  <p>Godot will undertake best efforts to provide these rights to people outside of the EEA as well.</p>
+
+  <h3 class="title">How to Access, Modify or Update Your Information</h3>
+
+  <p>Godot gives you the ability to access, modify or update your personal data at any time. On sites where you can create accounts (Q&amp;A, Asset Library), you may log in and make changes to your login information (change your password), your contact information, your general preferences and your personalization settings. If necessary, you may also contact us and describe the changes you want made to the personal data you have previously provided by mailing <a href="mailto:privacy@godotengine.org">privacy@godotengine.org</a>.</p>
+
+  <p>If you wish to remove your personal data from Godot, you may contact us at <a href="mailto:privacy@godotengine.org">privacy@godotengine.org</a> and request that we remove this information from the Godot System. Other locations where you may have used your personal data as an identifier (e.g. mailing list and forum postings in the archives, repository changelogs, and IRC logs) will not be altered.</p>
+
+  <h3 class="title">How to Contact Us</h3>
+
+  <p>If you have any questions about any of these practices or Godot's use of your personal information, please feel free to contact us by email at:</p>
+
+  <p><a href="mailto:privacy@godotengine.org">privacy@godotengine.org</a></p>
+
+  <p>Godot will work with you to resolve any concerns you may have about this Statement.</p>
+
+  <h3 class="title">Changes to this Privacy Statement</h3>
+
+  <p>Godot reserves the right to change this policy from time to time. If we do make changes, the revised Privacy Statement will be posted on this site. A notice will be posted on our homepage for 30 days whenever this privacy statement is changed in a material way.</p>
+
+  <p>This Privacy Statement was last amended on 2020-06-30.<br>
+  You can review the change history at <a href="https://github.com/godotengine/godot-website/commits/master/themes/godotengine/pages/privacy-policy.htm">https://github.com/godotengine/godot-website/commits/master/themes/godotengine/pages/privacy-policy.htm</a>.</p>
+
+  <h3 class="title">Attribution and License</h3>
+
+  <p>This Privacy Policy is licensed under Attribution-ShareAlike 4.0 International (CC BY-SA 4.0). It is a derivative work of:</p>
+
+  <ul>
+    <li>Software Freedom Conservancy's Privacy Policy, used under Attribute-Share Alike 4.0. <a href="https://sfconservancy.org/privacy-policy">https://sfconservancy.org/privacy-policy</a></li>
+    <li>Red Hat's Privacy Policy for the Fedora Project, used under Attribution-Share Alike 3.0 Unported. <a href="https://fedoraproject.org/wiki/Legal:PrivacyPolicy">https://fedoraproject.org/wiki/Legal:PrivacyPolicy</a></li>
+    <li>The Free Software Foundation's Privacy Policy, used under Attribution-ShareAlike 4.0 International (CC BY-SA 4.0). <a href="https://www.fsf.org/about/free-software-foundation-privacy-policy">https://www.fsf.org/about/free-software-foundation-privacy-policy</a></li>
+    <li>WordPress.org's Privacy Policy, used under Attribution-ShareAlike 2.5 Generic (CC BY-SA 2.5). <a href="https://wordpress.org/about/privacy">https://wordpress.org/about/privacy</a></li>
+  </ul>
+
+</div>

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -4,9 +4,12 @@ description = "footer partial"
 <footer>
   <div class="container flex">
     <div id="copyright">
-      © 2007-2020 Juan Linietsky, Ariel Manzur and <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank">contributors</a><br>
-      Godot is a member of the <a href="https://sfconservancy.org/" target_="_blank">Software Freedom Conservancy</a><br>
-      Kindly hosted by <a href="https://tuxfamily.org" target="_blank">TuxFamily.org</a>
+      <p>
+        © 2007-2020 Juan Linietsky, Ariel Manzur and <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank">contributors</a><br>
+        Godot is a member of the <a href="https://sfconservancy.org/" target_="_blank">Software Freedom Conservancy</a><br>
+        Kindly hosted by <a href="https://tuxfamily.org" target="_blank">TuxFamily.org</a>.
+      </p>
+      <p><a href="/privacy-policy">Privacy Policy</a> &ndash; <a href="/code-of-conduct">Code of Conduct</a></p>
     </div>
     <ul id="sitemap">
       <li><a href="/news">News</a></li>
@@ -19,14 +22,14 @@ description = "footer partial"
     <div id="social">
       <h4 class="text-right"><a href="/contact">Contact us</a></h4>
       <div class="flex justify-space-between">
-        <a href="https://www.facebook.com/groups/godotengine/" target="_blank">
-          <img src="{{ 'assets/footer/facebook_logo.svg' | theme }}" alt="Facebook">
+        <a href="https://github.com/godotengine" target="_blank">
+          <img src="{{ 'assets/footer/github_logo.svg' | theme }}" alt="GitHub">
         </a>
         <a href="https://twitter.com/godotengine" target="_blank">
           <img src="{{ 'assets/footer/twitter_logo.svg' | theme }}" alt="Twitter">
         </a>
-        <a href="https://github.com/godotengine" target="_blank">
-          <img src="{{ 'assets/footer/github_logo.svg' | theme }}" alt="GitHub">
+        <a href="https://www.facebook.com/groups/godotengine/" target="_blank">
+          <img src="{{ 'assets/footer/facebook_logo.svg' | theme }}" alt="Facebook">
         </a>
         <a href="https://www.reddit.com/r/godot" target="_blank">
           <!-- Zero-width space in the `alt` text to prevent content blockers from blocking the icon -->


### PR DESCRIPTION
I couldn't test it locally yet as I'm having trouble setting things up with `docker-compose`:
```
Loading composer repositories with package information                                                                                                                                                              
Updating dependencies (including require-dev)                                                                                                                                                                       
  [merge-plugin] Adding dependency october/demo-plugin requires php (>= 5.4.0.0-dev)                                                                                                                                

Fatal error: Allowed memory size of 1610612736 bytes exhausted (tried to allocate 20480 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/DefaultPolicy.php on line 73
```
Trying to find a workaround for this (currently trying to set `COMPOSER_MEMORY_LIMIT=-1` in the docker env).

----

The text is more or less ready but a proofreading would be good, especially to see if there's anything missing or irrelevant for us. Note that the policy is based off [Conservancy's](https://sfconservancy.org/privacy-policy/) and we've aimed not to stray to far from it, as it's a legal document so it's best to use what has already been approved by lawyers.