### PR TITLE
Don't capitalize page titles automatically

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -77,7 +77,6 @@ h4 {
 }
 
 .intro-title {
-  text-transform: capitalize;
   margin-top: 48px;
   margin-bottom: 48px;
 }


### PR DESCRIPTION
The CSS capitalize property doesn't take stop words into account, so it's probably not a good idea to rely on it. Moreover, we prefer capitalizing only the first word instead of doing so for every word.