### PR TITLE
Add `rel=noopener` to `target=_blank` external links to improve security

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -251,7 +251,7 @@ postPage = "{{ :slug }}"
       <p>
         If you know how to code, and enjoy fun and challenging problems, you can help by fixing bugs or creating cool new features.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn flat" target="_blank"> Learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn flat" target="_blank" rel="noopener"> Learn more </a>
     </div>
 
     <div class="text-center base-padding">
@@ -260,7 +260,7 @@ postPage = "{{ :slug }}"
       <p>
         Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn flat" target="_blank"> Learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn flat" target="_blank" rel="noopener"> Learn more </a>
     </div>
 
     <div class="text-center base-padding">
@@ -269,7 +269,7 @@ postPage = "{{ :slug }}"
       <p>
         Found a problem with the engine? Don't forget to report it so that developers can track it down.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn flat" target="_blank"> Learn more </a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn flat" target="_blank" rel="noopener"> Learn more </a>
     </div>
 
   </div>
@@ -292,18 +292,18 @@ postPage = "{{ :slug }}"
     <h2 class="text-center">Sponsored by</h2>
 
     <div class="platinum flex">
-      <a class="sponsor card base-padding" href="https://heroiclabs.com/" target="_blank">
+      <a class="sponsor card base-padding" href="https://heroiclabs.com/" target="_blank" rel="noopener">
         <img src="{{ 'assets/home/sponsors/heroiclabs.png' | theme }}" alt="Heroic Labs">
       </a>
-      <a class="sponsor card base-padding" href="https://www.interblockgaming.com/" target="_blank">
+      <a class="sponsor card base-padding" href="https://www.interblockgaming.com/" target="_blank" rel="noopener">
         <img src="{{ 'assets/home/sponsors/interblock.png' | theme }}" alt="Interblock">
       </a>
     </div>
     <div class="gold flex">
-      <a class="sponsor card base-padding" href="https://www.gamblify.com/" target="_blank">
+      <a class="sponsor card base-padding" href="https://www.gamblify.com/" target="_blank" rel="noopener">
         <img src="{{ 'assets/home/sponsors/gamblify.png' | theme }}" alt="Gamblify">
       </a>
-      <a class="sponsor card" href="https://www.moonwards.com/" target="_blank">
+      <a class="sponsor card" href="https://www.moonwards.com/" target="_blank" rel="noopener">
         <img src="{{ 'assets/home/sponsors/moonwards.png' | theme }}" alt="Moonwards">
       </a>
     </div>

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -5,9 +5,9 @@ description = "footer partial"
   <div class="container flex">
     <div id="copyright">
       <p>
-        © 2007-2020 Juan Linietsky, Ariel Manzur and <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank">contributors</a><br>
-        Godot is a member of the <a href="https://sfconservancy.org/" target_="_blank">Software Freedom Conservancy</a><br>
-        Kindly hosted by <a href="https://tuxfamily.org" target="_blank">TuxFamily.org</a>.
+        © 2007-2020 Juan Linietsky, Ariel Manzur and <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank" rel="noopener">contributors</a><br>
+        Godot is a member of the <a href="https://sfconservancy.org/" target_="_blank" rel="noopener">Software Freedom Conservancy</a><br>
+        Kindly hosted by <a href="https://tuxfamily.org" target="_blank" rel="noopener">TuxFamily.org</a>.
       </p>
       <p><a href="/privacy-policy">Privacy Policy</a> &ndash; <a href="/code-of-conduct">Code of Conduct</a></p>
     </div>
@@ -22,20 +22,20 @@ description = "footer partial"
     <div id="social">
       <h4 class="text-right"><a href="/contact">Contact us</a></h4>
       <div class="flex justify-space-between">
-        <a href="https://github.com/godotengine" target="_blank">
+        <a href="https://github.com/godotengine" target="_blank" rel="noopener">
           <img src="{{ 'assets/footer/github_logo.svg' | theme }}" alt="GitHub">
         </a>
-        <a href="https://twitter.com/godotengine" target="_blank">
+        <a href="https://twitter.com/godotengine" target="_blank" rel="noopener">
           <img src="{{ 'assets/footer/twitter_logo.svg' | theme }}" alt="Twitter">
         </a>
-        <a href="https://www.facebook.com/groups/godotengine/" target="_blank">
+        <a href="https://www.facebook.com/groups/godotengine/" target="_blank" rel="noopener">
           <img src="{{ 'assets/footer/facebook_logo.svg' | theme }}" alt="Facebook">
         </a>
-        <a href="https://www.reddit.com/r/godot" target="_blank">
+        <a href="https://www.reddit.com/r/godot" target="_blank" rel="noopener">
           <!-- Zero-width space in the `alt` text to prevent content blockers from blocking the icon -->
           <img src="{{ 'assets/footer/reddit_logo.svg' | theme }}" alt="Red​dit">
         </a>
-        <a href="/rss.xml" target="_blank">
+        <a href="/rss.xml" target="_blank" rel="noopener">
           <!-- Icon is called `feed` instead of `rss` to prevent content blockers from blocking the icon -->
           <img src="{{ 'assets/footer/feed_logo.svg' | theme }}" alt="RSS feed">
         </a>


### PR DESCRIPTION
This improves performance and security by preventing the opened website from accessing `window.opener` and potentially doing malicious stuff with it.

See https://mathiasbynens.github.io/rel-noopener/.