### PR TITLE
Fix unordered list of scoop install commands

### DIFF
--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -41,6 +41,8 @@ is_hidden = 0
   <ul>
     <li>
       <pre><code>scoop bucket add extras</code></pre>
+    </li>
+    <li>
       <pre><code>scoop install godot</code></pre>
     </li>
   </ul>


### PR DESCRIPTION
Closes #145 - there are two scoop install commands in the same unordered list element.