### PR TITLE
Improve styling of articles for better readability

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -22,6 +22,9 @@
   --more-shadow: 0 2px 10px rgba(0, 0, 0, .2);
 
   --accent-color: #f57389;
+  --background-color: #d5daea;
+  --footer-background-color: #414d69;
+  --code-background-color: #d0dada;
 }
 
 

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -11,14 +11,31 @@ categoryPage = "article"
 {% partial "header" %}
 
 <style>
+  body {
+    background-color: var(--background-color);
+  }
+
   h1 {
     margin-bottom: 8px;
     margin-top: 32px;
   }
 
+  code {
+    background: var(--code-background-color);
+    padding: 1px 4px;
+    font-weight: 600;
+    font-size: 0.95em;
+    border-radius: 3px;
+  }
+
   .date-big {
     line-height: 2;
     margin-left: 32px;
+  }
+
+  article {
+    background-color: var(--base-color);
+    box-shadow: 0px 3px 2px 0px rgba(0, 0, 0, 0.15);
   }
 
   article img, article video {
@@ -27,6 +44,9 @@ categoryPage = "article"
     margin: auto;
     margin-top: 16px;
     margin-bottom: 16px;
+  }
+  article img:first-child, article video:first-child {
+    max-width: 70%;
   }
 
   article h1 {
@@ -37,6 +57,17 @@ categoryPage = "article"
     margin-top: 42px;
   }
 
+  footer {
+    background-color: var(--footer-background-color);
+    border-top: none;
+    margin-top: 64px;
+    font-size: 0.9em;
+  }
+
+  footer #sitemap li {
+    margin-bottom: 10px;
+  }
+
   .author {
     margin-top: 0px;
     margin-bottom: 64px;
@@ -44,8 +75,21 @@ categoryPage = "article"
 
   @media screen and (min-width: 900px) {
     article .content {
-      width: 60%;
+      width: 70%;
       margin: auto;
+    }
+  }
+
+  @media (max-width: 900px) {
+    body {
+      background-color: var(--base-color);
+    }
+    article {
+      background-color: transparent;
+      box-shadow: none;
+    }
+    article img:first-child, article video:first-child {
+      max-width: 100%;
     }
   }
 </style>


### PR DESCRIPTION
Whenever I look at one of the news on the main website I notice at least three things that bother me:
* Articles take very little horizontal space, making them harder to comprehend;
* The empty space around the text doesn't anchor your eyesight very well: by the middle of any article the text kind of floats somewhere in the middle of the page;
* `<code>` tag is not styled beyond using monospaced font.

I've tried to address all of the concerns mentioned. As I am not familiar with this project, I've tried to reduce the impact of the changes by packing everything into the article template, but I think some of the changes can be applied to other pages as well. If these changes are undesired or require some adjustments in the implementation, please let me know.

Here are some comparisons:
**Top of the page**:
[Before](https://user-images.githubusercontent.com/11782833/89535604-4efc2080-d7ff-11ea-8182-9abf225c8045.png) | [After](https://user-images.githubusercontent.com/11782833/89535651-5fac9680-d7ff-11ea-9905-b396f881bc3b.png)

**Middle of the article**:
[Before](https://user-images.githubusercontent.com/11782833/89535753-84087300-d7ff-11ea-9e15-e59a97eaf10d.png) | [After](https://user-images.githubusercontent.com/11782833/89535764-89fe5400-d7ff-11ea-86a0-3016c106a339.png)

**More code tags**:
[Before](https://user-images.githubusercontent.com/11782833/89535812-9b476080-d7ff-11ea-9f48-d4ecd1f17234.png) | [After](https://user-images.githubusercontent.com/11782833/89535827-a00c1480-d7ff-11ea-961f-cf01e102e6fe.png)

**Footer**:
[Before](https://user-images.githubusercontent.com/11782833/89535840-a8fce600-d7ff-11ea-83c5-b9b5d046b4f9.png) | [After](https://user-images.githubusercontent.com/11782833/89535854-ae5a3080-d7ff-11ea-8298-1ad73b0394af.png)

PS. Due to a rather complex setup I wasn't able to test it live, but I took care to test it as best as possible with Chrome devtools.
