### PR TITLE
Fix reflows when loading the Community and Download pages

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -122,7 +122,7 @@ description = "Download layout"
 
   <div class="flex responsive eqsize">
     <div class="version-overview">
-      <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" height=200>
+      <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" width="200" height="200">
       <h2>Godot <em>{{stable_version}}</em></h2>
       <i class="date">released June 26, 2020</i>
       <p></p>
@@ -164,11 +164,11 @@ description = "Download layout"
       </div>
 
       <a class="steam-download base-padding card" href="https://godotengine.itch.io/godot" title="Godot Engine on itch.io">
-        <img src="{{ 'assets/download/itch_logo.svg' | theme }}" height=42>
+        <img src="{{ 'assets/download/itch_logo.svg' | theme }}" width="42" height="42">
         Available on <strong>itch.io</strong>.
       </a>
       <a class="steam-download base-padding card" href="https://store.steampowered.com/app/404790" title="Godot Engine on Steam">
-        <img src="{{ 'assets/download/steam_logo.svg' | theme }}" height=42>
+        <img src="{{ 'assets/download/steam_logo.svg' | theme }}" width="42" height="42">
         Available on <strong>Steam</strong>.
       </a>
     </div>
@@ -246,7 +246,7 @@ description = "Download layout"
     </div>
 
     <div class="text-center base-padding">
-      <img class="flex-center" src="{{ 'assets/download/dl_icon_github.png' | theme }}">
+      <img class="flex-center" src="{{ 'assets/download/dl_icon_github.png' | theme }}" width="200" height="200">
       <p>
         Godot's development is <strong>open</strong>. This means that you can
         fix or improve any part of the engine yourself and choose

--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -22,6 +22,13 @@ is_hidden = 0
     text-decoration: none;
   }
 
+  .card img {
+    /* Use a visible background color while the image is loading. */
+    background-color: #607080;
+    width: 100%;
+    height: auto;
+  }
+
   h3 a {
     text-decoration: none;
   }
@@ -70,7 +77,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="/qa/"><img src="{{ 'assets/community/icon_qa.png'|theme }}" width="100%" alt=""></a>
+      <a href="/qa/"><img src="{{ 'assets/community/icon_qa.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="/qa">Questions &amp; Answers</a></h3>
         <p>Place to ask questions and search for answers from the community.</p>
@@ -80,7 +87,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://webchat.freenode.net/?channels=#godotengine"><img src="{{ 'assets/community/icon_irc.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://webchat.freenode.net/?channels=#godotengine"><img src="{{ 'assets/community/icon_irc.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://webchat.freenode.net/?channels=#godotengine">IRC</a></h3>
         <p>Old fashioned but reliable, the main discussion platform of core developers.</p>
@@ -91,7 +98,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://discord.gg/4JBkykG"><img src="{{ 'assets/community/icon_discord.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://discord.gg/4JBkykG"><img src="{{ 'assets/community/icon_discord.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://discord.gg/4JBkykG">Discord</a></h3>
         <p>A vibrant community for discussion, user support, showcases... and custom emotes!</p>
@@ -101,7 +108,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://matrix.to/#/#godotengine:matrix.org"><img src="{{ 'assets/community/icon_matrix.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://matrix.to/#/#godotengine:matrix.org"><img src="{{ 'assets/community/icon_matrix.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://matrix.to/#/#godotengine:matrix.org">Matrix</a></h3>
         <p>Libre decentralized chat with advanced features, compatible with IRC.</p>
@@ -111,7 +118,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://www.facebook.com/groups/godotengine/"><img src="{{ 'assets/community/icon_facebook.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://www.facebook.com/groups/godotengine/"><img src="{{ 'assets/community/icon_facebook.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://www.facebook.com/groups/godotengine/">Facebook</a></h3>
         <p>Large community for discussions around Godot.</p>
@@ -121,7 +128,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://www.reddit.com/r/godot"><img src="{{ 'assets/community/icon_reddit.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://www.reddit.com/r/godot"><img src="{{ 'assets/community/icon_reddit.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://www.reddit.com/r/godot">Reddit</a></h3>
         <p>For the anti-imperialist resistance to Facebook.</p>
@@ -131,7 +138,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://github.com/godotengine/"><img src="{{ 'assets/community/icon_github.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://github.com/godotengine/"><img src="{{ 'assets/community/icon_github.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://github.com/godotengine/">GitHub</a></h3>
         <p>Send potential bugs and feature requests here.</p>
@@ -141,7 +148,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://twitter.com/godotengine"><img src="{{ 'assets/community/icon_twitter.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://twitter.com/godotengine"><img src="{{ 'assets/community/icon_twitter.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://twitter.com/godotengine">Twitter</a></h3>
         <p>Get small bits of development news.</p>
@@ -151,7 +158,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://godotforums.org"><img src="{{ 'assets/community/icon_forum.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://godotforums.org"><img src="{{ 'assets/community/icon_forum.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://godotforums.org">Forum</a></h3>
         <p>Community forum for all Godot developers.</p>
@@ -161,7 +168,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://steamcommunity.com/app/404790"><img src="{{ 'assets/community/icon_steam.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://steamcommunity.com/app/404790"><img src="{{ 'assets/community/icon_steam.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://steamcommunity.com/app/404790">Steam Community</a></h3>
         <p>Discuss and share tips with other developers on Steam.</p>
@@ -171,7 +178,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://www.youtube.com/c/GodotEngineOfficial"><img src="{{ 'assets/community/icon_youtube.png'|theme }}" width="100%" alt=""></a>
+      <a href="https://www.youtube.com/c/GodotEngineOfficial"><img src="{{ 'assets/community/icon_youtube.png'|theme }}" width="350" height="215" alt=""></a>
       <div class="base-padding">
         <h3><a href="https://www.youtube.com/c/GodotEngineOfficial">YouTube</a></h3>
         <p>Channel for official Godot videos.</p>


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-website/pull/158.

Specifying the image widths and heights in advance makes it possible for the browser to reserve the space while the page is loading.

This improves the user experience while decreasing CPU usage.