### PR TITLE
Make the footer dark on every page

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -249,9 +249,10 @@ ul li {
 
 
 footer {
-  border-top: 1px dashed rgba(192, 196, 213, .6);
+  background-color: var(--footer-background-color);
   color: rgb(192, 196, 213);
-  margin-top: 128px;
+  font-size: 0.9em;
+  margin-top: 64px;
   padding-top: 32px;
   padding-bottom: 32px;
 }
@@ -276,6 +277,9 @@ footer a:hover {
 }
 #sitemap {
   flex: 2;
+}
+#sitemap li {
+  margin-bottom: 10px;
 }
 #social {
   flex: 1;

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -57,17 +57,6 @@ categoryPage = "article"
     margin-top: 42px;
   }
 
-  footer {
-    background-color: var(--footer-background-color);
-    border-top: none;
-    margin-top: 64px;
-    font-size: 0.9em;
-  }
-
-  footer #sitemap li {
-    margin-bottom: 10px;
-  }
-
   .author {
     margin-top: 0px;
     margin-bottom: 64px;

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -46,12 +46,6 @@ postPage = "{{ :slug }}"
     color: var(--dark-color-text-title);
   }
 
-  #sponsors {
-    background-color: #e3e6ec;
-    box-shadow: inset 0 0 12px rgba(0, 0, 0, .2);
-    border: 1px solid rgba(0, 0, 0, .2);
-  }
-
   #sponsors .sponsor {
     overflow: auto;
     display: flex;


### PR DESCRIPTION
Makes the footer styles implemented in #164 apply to every page. I had to adjust the look of the sponsors block on the home page a bit, but otherwise it just fitted right in.

For example, here's the [home page](https://user-images.githubusercontent.com/11782833/90960889-8defce80-e4ad-11ea-9143-6200cac79cff.png).
