### PR TITLE
Fix inline code styling

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -20,7 +20,7 @@ categoryPage = "article"
     margin-top: 32px;
   }
 
-  code:not(pre code) {
+  :not(pre) > code {
     background: var(--code-background-color);
     padding: 1px 4px;
     font-weight: 600;


### PR DESCRIPTION
I think I misjudged some CSS features while doing #167, sorry for that.

This should restore the styling for inline code (depicted below) while not breaking code blocks:
![image](https://user-images.githubusercontent.com/11782833/91438931-d3791680-e874-11ea-9d2f-f33492597fd4.png)
