### PR TITLE
Replace Donate page with more extensive Funding page

### DIFF
--- a/plugins/paulvonzimmerman/patreon/components/goal/_goal.htm
+++ b/plugins/paulvonzimmerman/patreon/components/goal/_goal.htm
@@ -1,3 +1,4 @@
+{##}
 <a class="patreonLink" href="{{ patreon_url }}">
   <div class="patreon">
     <div class="patreon-row">
@@ -13,7 +14,7 @@
           </div
       </div>
     </div>
-      <p class="patreon-uppercase">{{ amount_cents }}</p>
+      <p class="patreon-uppercase">$&nbsp;{{ (amount_cents / 100) | number_format(2, '.', ',') }}</p>
     </div>
   </div>
 </a>

--- a/plugins/paulvonzimmerman/patreon/controllers/Register.php
+++ b/plugins/paulvonzimmerman/patreon/controllers/Register.php
@@ -57,20 +57,14 @@ class Register extends Controller
                 if ($included != null) {
                     foreach ($included as $obj) {
                         if ($obj["type"] == "goal") {
-                            $pledge = $obj;
-                            $amount_cents = $pledge['attributes']['amount_cents'];
-                            $amount_dollars = $amount_cents / 100;
-                            $amount_cents = $amount_cents % 100;
-                            if ($amount_cents < 9) {
-                                $amount_cents = '0'.$amount_cents;
-                            }
-                            Settings::set('amount_cents', '$'.$amount_dollars.'.'.$amount_cents);
+                            $amount_cents = $obj['attributes']['amount_cents'];
+                            Settings::set('amount_cents', $amount_cents);
                             break;
                         }
                     }
                 }
             }
-        } 
+        }
         if(Settings::get('access_token') != null) {
             $register_client = new \Patreon\API(Settings::get('access_token'));
             $campaign_response = $register_client->fetch_campaign();

--- a/plugins/paulvonzimmerman/patreon/updates/add_patron_count.php
+++ b/plugins/paulvonzimmerman/patreon/updates/add_patron_count.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PaulVonZimmerman\Patreon\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class AddPatronCount extends Migration
+{
+    public function up()
+    {
+        Schema::table('paulvonzimmerman_patreon_system_settings', function ($table) {
+            $table->integer('patron_count')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('paulvonzimmerman_patreon_system_settings', function ($table) {
+            $table->dropColumn('patron_count');
+        });
+    }
+}

--- a/plugins/paulvonzimmerman/patreon/updates/builder_table_create_paul_patreon_system_settings.php
+++ b/plugins/paulvonzimmerman/patreon/updates/builder_table_create_paul_patreon_system_settings.php
@@ -3,7 +3,7 @@
 use Schema;
 use October\Rain\Database\Updates\Migration;
 
-class BuilderTableCreatePaulVonZimmermanPatreonSystemSettings extends Migration
+class BuilderTableCreatePaulPatreonSystemSettings extends Migration
 {
     public function up()
     {
@@ -20,7 +20,7 @@ class BuilderTableCreatePaulVonZimmermanPatreonSystemSettings extends Migration
             $table->integer('amount_cents')->nullable();
         });
     }
-    
+
     public function down()
     {
         Schema::dropIfExists('paulvonzimmerman_patreon_system_settings');

--- a/plugins/paulvonzimmerman/patreon/updates/version.yaml
+++ b/plugins/paulvonzimmerman/patreon/updates/version.yaml
@@ -1,7 +1,10 @@
 1.0.1: 'First version of Demo'
 1.0.2:
     - 'Created table paulvonzimmerman_patreon_system_settings'
-    - builder_table_create_paulvonzimmerman_patreon_system_settings.php
 1.0.3:
     - 'Add supuport for multiple goals'
     - 'Added commas to the amount displayed in the component'
+1.0.4:
+    - add_patron_count.php
+    - 'Add `patron_count` page variable which returns the total number of patrons'
+    - '`amount_cents` is now an integer, format it with the `number_format` Twig filter'

--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -42,6 +42,12 @@
   --code-background-color: #dcdfe2;
   --codeblock-background-color: #282b2e;
   --codeblock-color: #e0e2e4;
+
+  --fund-progress-background-color: #ddd;
+  --fund-corporate-color: #333f67;
+  --fund-individual-color: hsl(206, 58%, 52%);
+  --fund-options-table-background-color: #ddd;
+  --fund-options-table-popular-color: #dfefff;
 }
 
 .nav-logo.dark-logo {
@@ -100,6 +106,12 @@
     --code-background-color: #333639;
     --codeblock-background-color: #333639;
     --codeblock-color: hsla(0, 0%, 100%, 0.9);
+
+    --fund-progress-background-color: #444;
+    --fund-corporate-color: #436fb7;
+    --fund-individual-color: hsl(206, 78%, 62%);
+    --fund-options-table-background-color: #444;
+    --fund-options-table-popular-color: #2f4f5f;
   }
 
   /* Use logo with white text for dark navbar. */
@@ -377,6 +389,15 @@ nav > ul li {
 
 nav li.active > a {
   color: var(--navbar-link-current-color);
+}
+nav li.fund > a {
+  color: #ea8b20;
+}
+nav li.fund > a:hover {
+  color: #e53e3e;
+}
+nav li.fund.active > a {
+  color: #e53e3e;
 }
 
 nav > ul ul {
@@ -1009,4 +1030,240 @@ pre > code {
   text-align: center;
   opacity: 0.75;
   margin-top: 2rem;
+}
+
+.text-sm {
+  font-size: 1rem;
+}
+
+.text-lg {
+  font-size: 1.25rem;
+}
+
+.text-xl {
+  font-size: 1.5rem;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.leading-relaxed {
+  line-height: 1.5;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.img-auto-size {
+  width: 100%;
+  height: auto;
+}
+
+.img-load-placeholder {
+  background-color: #607080;
+}
+
+.fund-intro-text {
+  margin-top: 3rem;
+  margin-bottom: 2rem;
+}
+
+/* Funding progress bars. */
+.fund-progress,
+.fund-progress-corporate,
+.fund-progress-individual {
+  height: 0.75rem;
+  /* Prevent whitespace from adding space between bars. */
+  font-size: 0;
+}
+
+.fund-progress-corporate,
+.fund-progress-individual {
+  display: inline-block;
+}
+
+.fund-progress {
+  /* Full bar represents the "empty" state. */
+  background-color: var(--fund-progress-background-color);
+  border-radius: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.fund-progress-corporate {
+  /* Bar is on the left side, only round the left corners. */
+  border-radius: 1rem 0 0 1rem;
+}
+
+.fund-progress-individual {
+  /* Bar is on the right side, only round the right corners. */
+  border-radius: 0 1rem 1rem 0;
+}
+
+.fund-progress-legend {
+  font-size: 0.9rem;
+  color: var(--base-color-text-title);
+  /* Prevent individual legend items from wrapping on mobile. */
+  white-space: nowrap;
+}
+
+.fund-progress-legend::before {
+  content: "";
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: var(--color);
+  margin: 0 0.5rem 0 1rem;
+  border-radius: 50%;
+}
+
+.fund-options-table {
+  display: inline-block;
+  padding: 1.5rem;
+  background-color: var(--card-background-color);
+  border-radius: 6px;
+  border-collapse: collapse;
+}
+
+@media (max-width: 40rem) {
+  .fund-intro-text {
+    margin-top: 0;
+  }
+
+  .fund-options-table {
+    margin-left: -1.5rem !important;
+    margin-right: -1.5rem !important;
+  }
+}
+
+.shadow {
+  /* Copied from Tailwind.css. */
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+}
+
+.fund-options-table thead {
+  font-weight: 700;
+}
+
+.fund-options-table thead td:nth-child(2) {
+  /* Visually align the "Perks" heading with the list items. */
+  padding-left: 2rem;
+  /* Limit the width of perks to improve readability. */
+  width: 500px;
+}
+
+@media (min-width: 40rem) {
+  .fund-options-table td:first-child {
+    padding-left: 1.5rem;
+  }
+
+  .fund-options-table td:last-child {
+    padding-right: 1.5rem;
+  }
+}
+
+.fund-options-table tbody tr {
+  border-bottom: 1px solid var(--fund-options-table-background-color);
+  transition: 0.1s filter;
+  /* Required so the filter can change the background color. */
+  background-color: var(--card-background-color);
+}
+
+.fund-options-table tbody tr:hover {
+  filter: brightness(96%);
+}
+
+.fund-options-table td:nth-child(2) li {
+  /* Decrease spacing between list items for perks. */
+  margin: 0;
+}
+
+.fund-options-table td:nth-child(3) {
+  /* Center the Choose/Contact us buttons. */
+  text-align: center;
+}
+
+.fund-options-table-level {
+  font-weight: 700;
+}
+
+.fund-options-table-price {
+  color: var(--base-color-text-subtitle);
+}
+
+.fund-options-table-popular {
+  background-color: var(--fund-options-table-popular-color) !important;
+}
+
+.sponsors .sponsor {
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  height: 70px;
+  box-sizing: border-box;
+  margin-bottom: 8px;
+  margin-left: 8px;
+}
+
+.sponsors .sponsors-platinum .sponsor {
+  height: 130px;
+}
+
+.sponsors .sponsors-gold .sponsor {
+  height: 100px;
+}
+
+.sponsors img {
+  width: inherit;
+  height: 100%;
+}
+
+.sponsors .flex {
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.figure {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.figure-caption {
+  margin-top: 1rem;
+  color: var(--base-color-text-title);
+  text-align: center;
+}
+
+.button {
+  padding: 0.625rem 1rem;
+  background-color: var(--primary-color);
+  color: hsl(0, 0%, 100%);
+  border-radius: 4px;
+  transition: 0.1s filter;
+  white-space: nowrap;
+}
+
+.button:hover {
+  color: hsl(0, 0%, 100%);
+  filter: brightness(120%);
+}
+
+.button:active {
+  filter: brightness(85%);
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
+@media (max-width: 40rem) {
+  /* Decrease font sizes on mobile to fit more easily on a single line. */
+  .fund-stats-primary {
+    font-size: 1.1rem;
+  }
+
+  .fund-stats-secondary {
+    font-size: 1rem;
+  }
 }

--- a/themes/godotengine/layouts/fund.htm
+++ b/themes/godotengine/layouts/fund.htm
@@ -1,0 +1,37 @@
+description = "Fund layout"
+==
+
+<!DOCTYPE html>
+<html lang="en">
+{% partial "head" %}
+{% partial "header" selected="fund" %}
+
+<div class="head">
+  <div class="container flex eqsize">
+    <div class="main">
+      <h1 class="intro-title">{% placeholder title %}</h1>
+    </div>
+
+    <div class="tabs">
+      <a href="/fund" class="title-font {% if this.page.id == 'fund' %} active {% endif %}">
+        Home
+      </a>
+      <a href="/fund/about" class="title-font {% if this.page.id == 'fund-about' %} active {% endif %}">
+        About
+      </a>
+      <a href="/fund/grants" class="title-font {% if this.page.id == 'fund-grants' %} active {% endif %}">
+        Grants
+      </a>
+      <a href="/fund/corporate" class="title-font {% if this.page.id == 'fund-corporate' %} active {% endif %}">
+        Corporate memberships
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="container">
+  {% page %}
+</div>
+
+{% partial "footer" %}
+</html>

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -12,8 +12,8 @@ postPage = "{{ :slug }}"
 {##}
 <!DOCTYPE html>
 <html lang="en">
-{% partial "head" %}
-{% partial "header" %}
+{% partial 'head' %}
+{% partial 'header' %}
 {% set posts = blogPosts.posts %}
 
 <style>
@@ -46,30 +46,6 @@ postPage = "{{ :slug }}"
 
   #donations h1, #donations h2, #donations h3 {
     color: var(--dark-color-text-title);
-  }
-
-  #sponsors .sponsor {
-    overflow: auto;
-    display: flex;
-    align-items: center;
-    height: 70px;
-    box-sizing: border-box;
-    margin-bottom: 8px;
-    margin-left: 8px;
-  }
-
-  #sponsors .platinum .sponsor {
-    height: 100px;
-  }
-
-  #sponsors img {
-    width: inherit;
-    height: 100%;
-  }
-
-  #sponsors .flex {
-    justify-content: center;
-    flex-wrap: wrap;
   }
 
   .feature, #highlight {
@@ -354,39 +330,19 @@ postPage = "{{ :slug }}"
       You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot&nbsp;Engine even more awesome!
     </p>
 
-    <a href="/donate" class="btn flat btn-white-text">Learn more</a>
+    <a href="/fund" class="btn flat">Learn more</a>
   </div>
 </section>
 
 <section id="sponsors">
   <div class="container sm-full padded">
     <h2 class="text-center">Sponsored by</h2>
-
-    <div class="platinum flex">
-      <a class="sponsor card base-padding" href="https://heroiclabs.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/heroiclabs.png' | theme }}" width="264" height="66" alt="Heroic Labs" loading="lazy">
-      </a>
-      <a class="sponsor card base-padding" href="https://www.gamblify.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/gamblify.png' | theme }}" width="312" height="66" alt="Gamblify" loading="lazy">
-      </a>
-      <a class="sponsor card base-padding" href="http://spiffcode.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/spiffcode.png' | theme }}" width="291" height="66" alt="Spiffcode" loading="lazy">
-      </a>
-    </div>
-    <div class="gold flex">
-      <a class="sponsor card" href="https://www.asifa-hollywood.org/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/asifa-hollywood.png' | theme }}" width="223" height="68" alt="ASIFA-Hollywood" loading="lazy">
-      </a>
-      <a class="sponsor card" href="https://www.moonwards.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/moonwards.png' | theme }}" width="200" height="68" alt="Moonwards" loading="lazy">
-      </a>
-      <a class="sponsor card" href="https://academy.zenva.com/product/godot-game-development-mini-degree/?zva_src=godotengineorg-godotmd" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/zenva-academy.png' | theme }}" width="258" height="68" alt="Zenva Academy" loading="lazy">
-      </a>
-    </div>
+    {% partial 'sponsors' page='home' %}
+    <p class="text-center" style="font-size: 110%; margin-top: 4rem">
+      <a href="/fund">Become a sponsor today!</a>
+    </p>
   </div>
 </section>
 
-{% partial "footer" %}
-
+{% partial 'footer' %}
 </html>

--- a/themes/godotengine/layouts/more.htm
+++ b/themes/godotengine/layouts/more.htm
@@ -27,9 +27,6 @@ description = "More layout"
       <a href="/license" class="title-font {% if this.page.id == 'license' %} active {% endif %}">
         License
       </a>
-      <a href="/donate" class="title-font {% if this.page.id == 'donate' %} active {% endif %}">
-        Donate
-      </a>
       <a href="/press" class="title-font {% if this.page.id == 'press' %} active {% endif %}">
         Press Kit
       </a>

--- a/themes/godotengine/pages/donate.htm
+++ b/themes/godotengine/pages/donate.htm
@@ -1,59 +1,12 @@
 title = "Donate"
 url = "/donate"
 layout = "more"
+description = "Donate page"
 is_hidden = 0
 ==
-{##}
-{% put title %} Donate {% endput %}
-
-{% put head_text %}
-  <p class="small">
-    Godot&nbsp;Engine is a not-for-profit, community-driven free and open source project.
-    It is legally represented by <a href="https://sfconservancy.org/">Software Freedom Conservancy</a>,
-    a USA-based charity that helps promote, improve, develop, and defend <abbr title="Free, Libre, and Open Source Software">FLOSS</abbr> projects.
-  </p>
-{% endput %}
-
-<h3 class="title">User and company donations</h3>
-<p>
-  The project lives of the free time of its contributors, but also of the donations from the community.
-  All our donations are processed by Conservancy.
-</p>
-
-<p>We use donations for:</p>
-<ul>
-  <li>Hiring developers so that they can work part-time or full-time on Godot&nbsp;Engine, making the project progress faster.</li>
-  <li>Hiring artists to create high quality demo artwork under a permissive license.</li>
-  <li>Purchasing hardware required to develop Godot.</li>
-  <li>Pay for hosting of some web services.</li>
-  <li>Cover travel costs to some important industry events (e.g. GDC, Gamescom).</li>
-  <li>Produce merchandising for events (T-shirts, banners, stickers, etc.).</li>
-</ul>
-
-<p>
-  You can donate monthly via <a href="https://www.patreon.com/godotengine">Patreon</a>,
-  or directly via PayPal.
-</p>
-
-<h3 class="title">Patreon</h3>
-
-<p>
-  Patreon is a platform for creators to crowdfund their work via monthly donations. Godot&nbsp;Engine launched a <a href="https://www.patreon.com/godotengine">Patreon page</a> with the aim to collect enough money each month to hire some of its developers part-time or full-time, starting with its lead developer Juan Linietsky
-</p>
-
-<a class="patronImgLink" href="https://www.patreon.com/bePatron?u=5597979" ><img alt="Become a patron!" height="37px" src="{{ 'assets/community/become_a_patron_button.png'|theme }}"> </a>
-
-<p>
-  The Patreon donations are processed by Conservancy, which then uses them to hire developers based on contracts made transparent to all supporters.
-</p>
-
-<h3 class="title">PayPal direct donation</h3>
-<p>Donations can be made to our PayPal account managed by Conservancy:</p>
-<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-  <input type="hidden" name="cmd" value="_s-xclick">
-  <input type="hidden" name="hosted_button_id" value="XS2JCYXMHV9KJ">
-  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-  <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-</form>
-
-(If you cannot see the PayPal button, disable your ad blocker temporarily.)
+<?php
+  function onStart() {
+    return Redirect::to('/fund');
+  }
+?>
+==

--- a/themes/godotengine/pages/fund.htm
+++ b/themes/godotengine/pages/fund.htm
@@ -1,0 +1,245 @@
+title = "Godot Development Fund"
+url = "/fund"
+layout = "fund"
+is_hidden = 0
+
+[Goal]
+==
+function onStart() {
+  // The number of corporate patrons (donating outside Patreon).
+  // TODO: Use a real amount.
+  $this['corporate_patron_count'] = 20;
+  // The amount of recurring donations made monthly outside Patreon in USD cents.
+  // The amount from Patreon is fetched automatically by the Patreon plugin.
+  // TODO: Use a real amount.
+  $this['corporate_amount_cents'] = 500000;
+
+  // The current goal to reach in USD cents.
+  $this['goal_cents'] = 2000000;
+
+  $this['amount_cents_total'] = $this['amount_cents'] + $this['corporate_amount_cents'];
+}
+==
+{##}
+{% put title %} Godot Development Fund {% endput %}
+
+<p class="text-xl text-center fund-intro-text">
+  Join the Development Fund and support us to work on core Godot development.
+</p>
+
+<div class="fund-progress">
+  {# Prevent the bar from overflowing by limiting the width according to the other funding type. #}
+  <div class="fund-progress-corporate" style="
+    width: {{ (corporate_amount_cents / goal_cents) * 100 }}%;
+    max-width: {{ 100 - (amount_cents / goal_cents) * 100 }}%;
+    background-color: var(--fund-corporate-color);
+  "></div>
+  <div class="fund-progress-individual" style="
+    width: {{ (amount_cents / goal_cents) * 100 }}%;
+    max-width: {{ 100 - (corporate_amount_cents / goal_cents) * 100 }}%;
+    background-color: var(--fund-individual-color);
+  "></div>
+</div>
+
+<section class="grid" style="grid-template-columns: auto auto">
+  <article>
+    <span class="fund-progress-legend" style="--color: var(--fund-corporate-color)">Corporate</span>
+    <span class="fund-progress-legend" style="--color: var(--fund-individual-color)">Individual</span>
+  </article>
+  <article class="text-right leading-relaxed" style="font-size: 1rem">
+    Goal: $&nbsp;{{ (goal_cents / 100) | number_format(0, '.', ',') }}/month<br>
+    <strong>Hire another full-time developer!</strong>
+  </article>
+</section>
+
+<section class="grid text-center leading-relaxed items-center" style="
+  color: var(--base-color-text-title);
+  grid-template-columns: auto auto auto;
+  border-top: 2px solid hsla(0, 0%, 50%, 0.15);
+  border-bottom: 2px solid hsla(0, 0%, 50%, 0.15);
+  padding: 1rem;
+  margin: 2rem 0 4rem 0;
+">
+  <article class="text-lg fund-stats-secondary">
+    {# patron_count is from the Patreon plugin. #}
+    <div class="font-bold">{{ patron_count | number_format(0, '.', ',') }}</div>
+    individual sponsors
+  </article>
+  <article class="text-xl fund-stats-primary shadow" style="
+    background-color: var(--card-background-color);
+    padding: 1rem;
+    margin: -1rem;
+    border-radius: 0.5rem;
+  ">
+    {# amount_cents is from the Patreon plugin. #}
+    <div class="font-bold">$&nbsp;{{ (amount_cents_total / 100) | number_format(2, '.', ',') }}</div>
+    monthly contribution
+  </article>
+  <article class="text-lg fund-stats-secondary">
+    <div class="font-bold">{{ corporate_patron_count | number_format(0, '.', ',') }}</div>
+    corporate sponsors
+  </article>
+</section>
+
+<div>
+  <h2 class="title text-center">Choose a membership</h3>
+
+  <div class="flex">
+    <table class="table fund-options-table shadow text-sm" style="margin: 0 auto 1rem auto">
+      <thead>
+        <tr>
+          <td>Level</td>
+          <td>Perks</td>
+          <td>{# Actions ("Choose"/"Contact us" buttons) #}</td>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">1</span><br>
+            <span class="fund-options-table-price">$&nbsp;5 / month</span>
+          </td>
+          <td>
+            <ul>
+              <li>Early development updates on <a href="https://patreon.com/godotengine">Patreon</a>.</li>
+              <li>Custom Donor role in the Godot Discord server.</li>
+            </ul>
+          </td>
+          <td><a href="https://www.patreon.com/join/godotengine/checkout?rid=1878486" class="button rounded-full font-bold">Choose</a></td>
+        </tr>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">2</span><br>
+            <span class="fund-options-table-price">$&nbsp;10 / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>Your name in the Godot editor's About box.</li>
+            </ul>
+          </td>
+          <td><a href="https://www.patreon.com/join/godotengine/checkout?rid=1878485" class="button rounded-full font-bold">Choose</a></td>
+        </tr>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">3</span><br>
+            <span class="fund-options-table-price">$&nbsp;14 / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>Your name in the Godot editor's About box (higher up in the credits).</li>
+            </ul>
+          </td>
+          <td><a href="https://www.patreon.com/join/godotengine/checkout?rid=1878512" class="button rounded-full font-bold">Choose</a></td>
+        </tr>
+        <tr class="fund-options-table-popular">
+          <td>
+            <span class="fund-options-table-level">4</span> <em class="font-bold" style="color: var(--fund-individual-color)">- Popular</em><br>
+            <span class="fund-options-table-price">$&nbsp;26 / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>
+                Submit questions for the monthy live Q&amp;A sessions hosted on
+                <a href="https://www.youtube.com/c/GodotEngineOfficial/videos">YouTube</a>.
+              </li>
+            </ul>
+          </td>
+          <td><a href="https://www.patreon.com/join/godotengine/checkout?rid=1878539" class="button rounded-full font-bold">Choose</a></td>
+        </tr>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">Mini</span><br>
+            <span class="fund-options-table-price">$&nbsp;48 / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>Your name in the Godot editor's About box Sponsor area and the website.
+            </ul>
+          </td>
+          <td><a href="https://www.patreon.com/join/godotengine/checkout?rid=1878543" class="button rounded-full font-bold">Choose</a></td>
+        </tr>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">Bronze</span><br>
+            <span class="fund-options-table-price">$&nbsp;99 / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>Your name in the Godot editor's About box Sponsor area and the website, with an optional clickable link to your website.
+              </li>
+            </ul>
+          </td>
+          <td><a href="https://www.patreon.com/join/godotengine/checkout?rid=5533838" class="button rounded-full font-bold">Choose</a></td>
+        </tr>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">Silver</span><br>
+            <span class="fund-options-table-price">$&nbsp;500 / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>
+                Your name or company logo on the Godot website front page
+                (small) and at the top of Godot's credits. Valid on releases
+                that come out during or right after you donated.
+              </li>
+            </ul>
+          </td>
+          <td><a href="https://www.patreon.com/join/godotengine/checkout?rid=5546320" class="button rounded-full font-bold">Choose</a></td>
+        </tr>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">Gold</span><br>
+            <span class="fund-options-table-price">$&nbsp;800? / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>
+                Your name or company logo on the Godot website front page
+                (medium) and at the top of Godot's credits. Valid on releases
+                that come out during or right after you donated.
+              </li>
+            </ul>
+          </td>
+          <td><a href="/fund/corporate" class="button rounded-full font-bold">Contact us</a></td>
+        </tr>
+        <tr>
+          <td>
+            <span class="fund-options-table-level">Platinum</span><br>
+            <span class="fund-options-table-price">$&nbsp;2,000? / month</span>
+          </td>
+          <td>
+            <ul>
+              <li><em>All perks above, plus:</em></li>
+              <li>
+                Your name or company logo on the Godot website front page
+                (large), at the topics of Godot's credits and on the Godot
+                editor's splash screen. Valid on releases that come out during
+                or right after you donated.
+            </li>
+              <li>One-time blog post about your company supporting Godot (optional).</li>
+            </ul>
+          </td>
+          <td><a href="/fund/corporate" class="button rounded-full font-bold">Contact us</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p class="text-sm text-center">
+    All prices are in USD. VAT may be added at checkout depending on your country of residence.<br>
+    Other pricing options are available upon request.<br>
+    <a href="/contact">Contact us</a> if you don't want your name or company to be displayed publicly.
+  </p>
+</div>
+
+<h2 class="title text-center">Credits</h3>
+{% partial 'sponsors' page='fund' %}

--- a/themes/godotengine/pages/fund/about.htm
+++ b/themes/godotengine/pages/fund/about.htm
@@ -1,0 +1,126 @@
+title = "Godot Development Fund | About"
+url = "/fund/about"
+layout = "fund"
+is_hidden = 0
+==
+{##}
+{% put title %} Development Fund - About {% endput %}
+
+<h3 class="title">
+  Let’s make our dream engine together!
+</h3>
+<p>
+  <strong>Godot is the first Free and Open Source game engine in the same league
+  as the current big, commercial ones,</strong> with many innovations in
+  workflow, features and usability.
+</p>
+<p>
+  It offers a complete editor, dedicated 2D and 3D engines, animation tools,
+  multi-platform exports, plugins, a Free asset store, and so much more! All
+  that in a lightweight (30 MB) package that runs smoothly on Windows, Mac and
+  Linux. <a href="/download">You can start using Godot now!</a>
+</p>
+
+<figure class="figure">
+  <img
+    src="https://downloads.tuxfamily.org/godotengine/patreon/patreon-2d.jpg"
+    width="1920"
+    height="1018"
+    alt="Screenshot of the Godot 2D editor"
+    class="img-auto-size img-load-placeholder">
+  <figcaption class="figure-caption">Powerful, dedicated and easy to use 2D editor</figcaption>
+</figure>
+
+<p>
+  Create games of any size and complexity using 2D, 3D, or both at the same
+  time. You can publish your creations for desktop, mobile and web platforms.
+</p>
+<p>
+  The engine's development is open, made hand in hand with the community.
+</p>
+<p>
+  <a href="/features">Learn more about Godot’s features.</a>
+</p>
+
+<figure class="figure">
+  <img
+    src="https://downloads.tuxfamily.org/godotengine/patreon/patreon-3d.jpg"
+    width="1600"
+    height="877"
+    alt="Screenshot of the Godot 3D editor"
+    class="img-auto-size img-load-placeholder"
+  >
+  <figcaption class="figure-caption">Real-time global illumination in the 3D editor</figcaption>
+</figure>
+
+<h3 class="title">Godot needs your support!</h3>
+<p>
+  Godot is mainly developed by volunteers who have other jobs and occupations.
+  To ensure the project can keep growing at a steady pace, we want to offer our
+  most proficient contributors the opportunity to work full time for the
+  project, doing what they love and benefiting everyone in the process.
+</p>
+<p>
+  In order to do this, we need to ensure them enough financial stability so they
+  can work efficiently and without worries.
+</p>
+<p>
+  For this, we need your support!
+</p>
+
+<h3 class="title">Let’s hire people who can make the difference</h3>
+<p>
+  Currently Juan Linietsky and George Marques are working thanks to an
+  <a href="https://godotengine.org/article/godot-engine-was-awarded-epic-megagrant">
+    Epic MegaGrant</a>, and the project is hiring Rémi Verschelde via Patreon. We want to
+  be able to hire more of our contributors so they can work full time, many of
+  them who have already proven to do fantastic work via previous grants.
+</p>
+<p>
+  The areas we want to cover (where trustworthy contributors would be willing to
+  dedicate their full time) are:
+  <ul>
+    <li>General editor usability and bug-fixing</li>
+    <li>Contributor for networking, HTML5 platform port</li>
+    <li>Mono / C#, GDNative</li>
+    <li>XR and mobile rendering</li>
+    <li>Junior rendering contributor</li>
+    <li>
+      More areas to come! These can evolve based on development priorities and
+      the availability of core contributors to fill those roles.
+    </li>
+  </ul>
+</p>
+<p>
+  Let's work together to make all of them a reality!
+</p>
+
+<h3 class="title">Your donations are safe with us</h3>
+<a href="https://sfconservancy.org">
+  <img
+    src="https://sfconservancy.org/img/conservancy-header.png"
+    width="893"
+    height="120"
+    alt="Software Freedom Conservancy logo"
+    class="img-auto-size img-load-placeholder"
+    style="width: 600px; max-width: 100%"
+  >
+</a>
+<p>
+  The <a href="https://sfconservancy.org/">Software Freedom Conservancy</a>,
+  a well-known non-profit and our kind partner, takes care of all donations.
+  The organization works hard to preserve the freedom of free software.
+  It supports many high-profile projects with everything related to law,
+  accounting and taxes.
+</p>
+<p>
+  They use the funds to hire developers according to instructions from the Godot
+  Project Leadership Committee. This guarantees that your funds will solely
+  benefit the engine, and nothing else.
+</p>
+<p>
+  <i>
+    Note: 10% of our donations go towards supporting Conservancy’s activity
+    (this is already included in the pledges).
+  </i>
+</p>

--- a/themes/godotengine/pages/fund/corporate.htm
+++ b/themes/godotengine/pages/fund/corporate.htm
@@ -1,0 +1,20 @@
+title = "Godot Development Fund | Corporate memberships"
+url = "/fund/corporate"
+layout = "fund"
+is_hidden = 0
+==
+{##}
+{% put title %} Development Fund - Corporate memberships {% endput %}
+
+<h3 class="title">Become a corporate sponsor</h3>
+<p>
+  The corporate membership levels are for organizations who want to further
+  support Godot development and ensure its sustainability. On top of that, your
+  company name, link and logo can be displayed prominently on the homepage or on
+  the Godot editor's splash screen.
+</p>
+
+<p>
+  <a href="/contact">Contact us</a> if you are interested in becoming a corporate
+  sponsor. Thanks for your support!
+</p>

--- a/themes/godotengine/pages/fund/grants.htm
+++ b/themes/godotengine/pages/fund/grants.htm
@@ -1,0 +1,47 @@
+title = "Godot Development Fund | Grants"
+url = "/fund/grants"
+layout = "fund"
+is_hidden = 0
+==
+{##}
+{% put title %} Development Fund - Grants {% endput %}
+
+<!-- When editing this page, list entries from most recent to oldest (including in each month). -->
+
+<h3 class="title">March 2021</h3>
+<ul>
+  <li><a href="https://godotengine.org/article/joan-fons-hired-work-godot-rendering">
+    Joan Fons was hired full-time to work on Godot's rendering engine.
+  </a></li>
+</ul>
+
+<h3 class="title">December 2020</h3>
+<ul>
+  <li><a href="https://godotengine.org/article/camille-mohr-daurat-hired-work-physics">
+    Camille Mohr-Daurat was hired full-time to work on physics engines and integrations.
+  </a></li>
+</ul>
+
+<h3 class="title">September 2020</h3>
+<ul>
+  <li><a href="https://godotengine.org/article/hugo-locurcio-hired-improve-godots-web-infrastructure">
+    Hugo Locurcio was hired full-time to work on web and infrastructure development for the Godot project.
+  </a></li>
+  <li><a href="https://godotengine.org/article/we-hired-gdquest-work-manual">
+    Nathan was hired part-time to work on the Godot documentation.
+  </a></li>
+</ul>
+
+<h3 class="title">August 2020</h3>
+<ul>
+  <li><a href="https://godotengine.org/article/announcing-new-hire-gilles-roudiere">
+    Gilles Roudière was hired full-time to work on the Godot editor and usability aspects.
+  </a></li>
+</ul>
+
+<h3 class="title">September 2019</h3>
+<ul>
+  <li><a href="https://godotengine.org/article/george-marques-will-be-working-full-time-project">
+    George Marques was hired full-time to work on GDScript.
+  </a></li>
+</ul>

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -22,7 +22,7 @@ description = "footer partial"
       <li><a href="/showcase">Showcase</a></li>
       <li><a href="https://docs.godotengine.org">Documentation</a></li>
       <li><a href="/download">Download</a></li>
-      <li><a href="/donate">Donate</a></li>
+      <li><a href="/donate">❤ Donate</a></li>
       <li><a href="/press">Press Kit</a></li>
     </ul>
     <div id="social" class="dark-desaturate">

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -1,6 +1,4 @@
 description = "header partial"
-
-[Goal]
 ==
 {##}
 
@@ -66,7 +64,7 @@ description = "header partial"
         <li {% if selected == 'download' %} class="active" {% endif %}><a href="/download">Download</a></li>
         <li><a href="https://docs.godotengine.org">Learn</a></li>
         <li><a href="https://godotengine.org/asset-library/asset">Assets</a></li>
-        {% component 'Goal' %}
+        <li class="fund {% if selected == 'fund' %} active {% endif %}"><a href="/fund">❤ Donate</a></li>
       </ul>
     </nav>
   </div>

--- a/themes/godotengine/partials/sponsor.htm
+++ b/themes/godotengine/partials/sponsor.htm
@@ -1,0 +1,30 @@
+description = "One sponsor"
+==
+{##}
+{#
+Tier codes:
+  0 = Mini
+  1 = Bronze
+  2 = Silver
+  3 = Gold
+  4 = Platinum
+#}
+
+{% if tier >= 1 %}
+<a
+  class="sponsor card {% if tier >= 3 %} base-padding {% endif %}"
+  href="{{ sponsor.url }}"
+  target="_blank"
+  rel="noopener"
+>
+{% endif %}
+
+  {% if tier >= 2 %}
+  <img src="{{ ('assets/home/sponsors/' ~ sponsor.logo) | theme }}" alt="{{ sponsor.name }}" title="{{ sponsor.name }}">
+  {% else %}
+  {{ sponsor.name }}
+  {% endif %}
+
+{% if tier >= 1 %}
+</a>
+{% endif %}

--- a/themes/godotengine/partials/sponsors.htm
+++ b/themes/godotengine/partials/sponsors.htm
@@ -1,0 +1,113 @@
+description = "List of sponsors"
+==
+function onStart() {
+  $this['sponsors'] = [
+    'platinum' => [
+      // name, logo, url
+      [
+        'name' => 'Heroic Labs',
+        'logo' =>  'heroiclabs.png',
+        'url' => 'https://heroiclabs.com/',
+      ],
+      [
+        'name' => 'Gamblify',
+        'logo' => 'gamblify.png',
+        'url' => 'https://www.gamblify.com/',
+      ],
+      [
+        'name' => 'Spiffcode',
+        'logo' => 'spiffcode.png',
+        'url' => 'http://spiffcode.com/',
+      ],
+    ],
+    'gold' => [
+      // name, logo, url
+    ],
+    'silver' => [
+      // name, logo, url
+      [
+        'name' => 'ASIFA-Hollywood',
+        'logo' => 'asifa-hollywood.png',
+        'url' => 'https://www.asifa-hollywood.org/',
+
+      ],
+      [
+        'name' => 'Moonwards',
+        'logo' => 'moonwards.png',
+        'url' => 'https://www.moonwards.com/',
+      ],
+      [
+        'name' => 'Zenva Academy',
+        'logo' => 'zenva-academy.png',
+        'url' => 'https://academy.zenva.com/product/godot-game-development-mini-degree/?zva_src=godotengineorg-godotmd',
+      ],
+    ],
+    'bronze' => [
+      // name, url
+      [
+        'name' => 'Example Sponsor',
+        'url' => 'https://example.com/',
+      ],
+    ],
+    'mini' => [
+      // name
+      ['name' => 'Example Sponsor'],
+    ],
+  ];
+}
+==
+{##}
+{#
+  On the Fund page, we want a different presentation and show all sponsor tiers.
+  On the homepage, we just want to show platinum, gold and silver sponsors without separate headings.
+#}
+<div class='sponsors'>
+  {% if sponsors.platinum %}
+  <h3 class="title text-center">Platinum Sponsors</h3>
+  <div class="sponsors-platinum flex">
+    {% for sponsor in sponsors.platinum %}
+    {% partial 'sponsor' sponsor=sponsor tier=4 %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if sponsors.gold %}
+  <h3 class="title text-center">Gold Sponsors</h3>
+  <div class="sponsors-gold flex">
+    {% for sponsor in sponsors.gold %}
+    {% partial 'sponsor' sponsor=sponsor tier=3 %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if sponsors.silver %}
+  <h3 class="title text-center">Silver Sponsors</h3>
+  <div class="sponsors-silver flex">
+    {% for sponsor in sponsors.silver %}
+    {% partial 'sponsor' sponsor=sponsor tier=2 %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if page == 'fund' %}
+
+  {% if sponsors.bronze %}
+  <h3 class="title text-center">Bronze Sponsors</h3>
+  <div class="sponsors-bronze flex">
+    {% for sponsor in sponsors.bronze %}
+    {% partial 'sponsor' sponsor=sponsor tier=1 %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if sponsors.mini %}
+  <h3 class="title text-center">Mini Sponsors</h3>
+  <div class="sponsors-mini flex">
+    {% for sponsor in sponsors.mini %}
+    {% partial 'sponsor' sponsor=sponsor tier=0 %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% endif %}
+</div>


### PR DESCRIPTION
This is a preliminary version of the Godot Development Fund page I've been working on as part of my contract.

Other changes done as part of this PR:

- Replace the Patreon bar with a simpler highlighted **Donate** button.
- Move the list of sponsors to a reusable template to avoid duplication across pages.
- Add more utility classes and move some of them to `main.css`.
- Update the Patreon plugin to return the number of patrons and the unformatted amount of money in cents. The `number_format` Twig filter is more appropriate for number formatting.

The number of corporate sponsors and amount of money donated outside Patreon should be configured here: https://github.com/Calinou/godot-website/blob/75a5380cdf81ecdfae2be199c9fa7fe78bbc7f54/themes/godotengine/pages/fund.htm#L8-L21

This closes https://github.com/godotengine/godot-website/issues/102.

## Preview

*Click to view images at full size.*

### Home

<details>
<summary>Show</summary>

![](https://i.imgur.com/VIcCDva.png)
</details>

### About

<details>
<summary>Show</summary>

![](https://i.imgur.com/euKYSHk.jpg)
</details>

### Grants

*WIP: Needs more information on ongoing and past contracts to make this page more complete.*

![](https://i.imgur.com/3P23uFK.png)

### Corporate memberships

*WIP: Needs more text.*

![](https://i.imgur.com/vqlxkcK.png)