### PR TITLE
Add comment blocks for syntax highlighting support in Visual Studio Code

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -4,7 +4,7 @@ description = "Article layout"
 slug = "{{ :slug }}"
 categoryPage = "article"
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/layouts/default.htm
+++ b/themes/godotengine/layouts/default.htm
@@ -1,6 +1,6 @@
 description = "Default page"
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -6,7 +6,7 @@ description = "Download layout"
   }
 ?>
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/layouts/events.htm
+++ b/themes/godotengine/layouts/events.htm
@@ -1,6 +1,6 @@
 description = "Events layout"
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/layouts/features.htm
+++ b/themes/godotengine/layouts/features.htm
@@ -1,6 +1,6 @@
 description = "Features layout"
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -9,7 +9,7 @@ sortOrder = "published_at desc"
 categoryPage = "home"
 postPage = "{{ :slug }}"
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/layouts/more.htm
+++ b/themes/godotengine/layouts/more.htm
@@ -1,6 +1,6 @@
 description = "More layout"
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -1,6 +1,6 @@
 description = "News layout"
 ==
-
+{##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}

--- a/themes/godotengine/pages/404.htm
+++ b/themes/godotengine/pages/404.htm
@@ -4,7 +4,7 @@ layout = "default"
 description = "404 error page"
 is_hidden = 0
 ==
-
+{##}
 <style>
     .error {
       display: flex;

--- a/themes/godotengine/pages/code-of-conduct.htm
+++ b/themes/godotengine/pages/code-of-conduct.htm
@@ -4,7 +4,7 @@ layout = "more"
 description = "Godot community's Code of Conduct"
 is_hidden = 0
 ==
-
+{##}
 {% put title %} Code of Conduct {% endput %}
 
 <p>

--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -4,7 +4,7 @@ layout = "default"
 description = "Community page"
 is_hidden = 0
 ==
-
+{##}
 {% put head_text %}
   <p class="small">
     Godot has a very active community across multiple channels.<br />

--- a/themes/godotengine/pages/contact.htm
+++ b/themes/godotengine/pages/contact.htm
@@ -4,7 +4,7 @@ layout = "more"
 description = "Contact page"
 is_hidden = 0
 ==
-
+{##}
 {% put title %} Contact us {% endput %}
 
 <div class="container">

--- a/themes/godotengine/pages/donate.htm
+++ b/themes/godotengine/pages/donate.htm
@@ -3,7 +3,7 @@ url = "/donate"
 layout = "more"
 is_hidden = 0
 ==
-
+{##}
 {% put title %} Donate {% endput %}
 
 {% put head_text %}

--- a/themes/godotengine/pages/download/linux.htm
+++ b/themes/godotengine/pages/download/linux.htm
@@ -8,7 +8,7 @@ is_hidden = 0
   function onStart() {$this["platform"] = 'linux'; }
 ?>
 ==
-
+{##}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_x11.64.zip">

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -8,7 +8,7 @@ is_hidden = 0
   function onStart() {$this["platform"] = 'osx'; }
 ?>
 ==
-
+{##}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_osx.64.zip">

--- a/themes/godotengine/pages/download/server.htm
+++ b/themes/godotengine/pages/download/server.htm
@@ -8,7 +8,7 @@ is_hidden = 0
   function onStart() {$this["platform"] = 'server'; }
 ?>
 ==
-
+{##}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_linux_headless.64.zip">

--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -8,7 +8,7 @@ is_hidden = 0
   function onStart() {$this["platform"] = 'windows'; }
 ?>
 ==
-
+{##}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_win64.exe.zip">

--- a/themes/godotengine/pages/error.htm
+++ b/themes/godotengine/pages/error.htm
@@ -4,7 +4,7 @@ layout = "default"
 description = "Server error page"
 is_hidden = 0
 ==
-
+{##}
 <style>
     .error {
       display: flex;

--- a/themes/godotengine/pages/events.htm
+++ b/themes/godotengine/pages/events.htm
@@ -3,6 +3,7 @@ url = "/events"
 layout = "events"
 is_hidden = 0
 ==
+{##}
 <section id="upcoming" class="events">
 
   <h2>2020</h2>

--- a/themes/godotengine/pages/events/past.htm
+++ b/themes/godotengine/pages/events/past.htm
@@ -3,7 +3,7 @@ url = "/events/past"
 layout = "events"
 is_hidden = 0
 ==
-
+{##}
 <section id="2017" class="events">
 
   <h2>2020</h2>

--- a/themes/godotengine/pages/home.htm
+++ b/themes/godotengine/pages/home.htm
@@ -4,7 +4,7 @@ layout = "home"
 description = "The first page"
 is_hidden = 0
 ==
-
+{##}
 <p>
   Godot provides a huge set of common tools, so you can just focus on making
   your game without reinventing the wheel.

--- a/themes/godotengine/pages/license.htm
+++ b/themes/godotengine/pages/license.htm
@@ -4,7 +4,7 @@ layout = "more"
 description = "Licensing details"
 is_hidden = 0
 ==
-
+{##}
 {% put title %} License {% endput %}
 
 <h3 class="title">The engine</h3>

--- a/themes/godotengine/pages/privacy-policy.htm
+++ b/themes/godotengine/pages/privacy-policy.htm
@@ -4,7 +4,7 @@ layout = "more"
 description = "Privacy statement for Godot Engine"
 is_hidden = 0
 ==
-
+{##}
 {% put title %} Privacy policy {% endput %}
 
 <div class="container">

--- a/themes/godotengine/pages/user-groups.htm
+++ b/themes/godotengine/pages/user-groups.htm
@@ -4,7 +4,7 @@ layout = "default"
 description = "Find local Godot user groups run by community members."
 is_hidden = 0
 ==
-
+{##}
 {% put head_text %}
   <p class="small">
     Some community members manage local Godot user groups.

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -1,6 +1,6 @@
 description = "footer partial"
 ==
-
+{##}
 <footer>
   <div class="container flex">
     <div id="copyright">

--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -4,7 +4,7 @@ description = "head partial"
 slug = "{{ :slug }}"
 categoryPage = "blog/category"
 ==
-
+{##}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -2,7 +2,7 @@ description = "header partial"
 
 [Goal]
 ==
-
+{##}
 {% styles %}
 
 <header>


### PR DESCRIPTION
Using the OctoberCMS Template Language add-on, it's possible to have proper syntax highlighting for October templates in Visual Studio Code. However, due to a limitation of this add-on, we need to add empty comment blocks at the top of every template.

See https://marketplace.visualstudio.com/items?itemName=dqsully.octobercms-template-language.