### PR TITLE
Use a single code block for Docker commands in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ October instance.
 
 ### Restoring a database
 
-- `mv /your/dump/backup-file.sql ./docker/mariadb/init`
-- `./docker/mariadb/bash.sh`
-- `cd /docker-entrypoint-initdb.d/`
-- `mysql < 000-setup.sql`
-- `mysql < backup-file.sql`
+```sh
+mv /your/dump/backup-file.sql docker/mariadb/init
+docker/mariadb/bash.sh
+cd /docker-entrypoint-initdb.d/
+mysql < 000-setup.sql
+mysql < backup-file.sql
+```
 
 ### Interfacing with the Docker containers
 


### PR DESCRIPTION
This makes it easier to copy all the lines at once for later editing.