### PR TITLE
Add a temporary Showcase page with showreel videos

### DIFF
--- a/themes/godotengine/pages/showcase.htm
+++ b/themes/godotengine/pages/showcase.htm
@@ -1,0 +1,44 @@
+title = "Showcase"
+url = "/showcase"
+layout = "default"
+description = "Showcase page"
+is_hidden = 0
+==
+{##}
+{% put title %} Showcase {% endput %}
+
+<div class="container">
+
+  <p>
+    This page is a placeholder until we set up an up-to-date game showcase.<br>
+    Stay tuned for an upcoming showcase page featuring high-quality published games!
+  </p>
+  <h3 class="title">Desktop games</h3>
+  <iframe
+    width="854"
+    height="480"
+    src="https://www.youtube-nocookie.com/embed/UEDEIksGEjQ"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    style="max-width: 100%">
+  </iframe>
+
+  <h3 class="title">Mobile games</h3>
+  <iframe
+    width="854"
+    height="480"
+    src="https://www.youtube-nocookie.com/embed/AIapugketbs"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    style="max-width: 100%"
+  ></iframe>
+
+  <p>
+    Previous showreel videos:
+    <a href="https://www.youtube.com/watch?v=NlKEO1N8wMM">2019 Desktop Games</a>,
+    <a href="https://www.youtube.com/watch?v=ODn4oOqWGik">2019 Mobile Games</a>,
+    <a href="https://www.youtube.com/watch?v=UTAeDoRIHaA">2018 Games</a>
+  </p>
+</div>


### PR DESCRIPTION
This prevents visitors from getting 404 errors if clicking on a link that points to the website's `/showcase` page.

This closes #187.

## Preview

![Showcase page](https://user-images.githubusercontent.com/180032/95469287-c83efd80-097f-11eb-8d6a-41ac332f3ca6.png)
