### PR TITLE
Display a caption for the header image in blog posts

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -32,6 +32,7 @@ categoryPage = "article"
     background: var(--codeblock-background-color);
     color: var(--codeblock-color);
   }
+
   pre code {
     display: block;
     overflow-x: auto;
@@ -55,6 +56,7 @@ categoryPage = "article"
     margin-top: 16px;
     margin-bottom: 16px;
   }
+
   article img:first-child, article video:first-child {
     max-width: 85%;
   }
@@ -107,12 +109,19 @@ categoryPage = "article"
 <div class="container">
   <article class="flex padded">
     <div class="content">
-      <img
-        data-src="{{ post.featured_images[0].filename }}"
-        src="{{ post.featured_images[0].path }}"
-        alt="{{ post.featured_images[0].description }}"
-        style="width: 100%;"
-      />
+      <figure style="text-align: center">
+        <img
+          data-src="{{ post.featured_images[0].filename }}"
+          src="{{ post.featured_images[0].path }}"
+          title="{{ post.featured_images[0].title }}"
+          alt="{{ post.featured_images[0].title }} {{ post.featured_images[0].description }}"
+          style="width: 100%"
+        />
+        <figcaption style="opacity: 0.8; line-height: 1.5">
+          <strong>{{ post.featured_images[0].title }}</strong>
+          <span style="margin-left: 0.75rem; font-size: 90%">{{ post.featured_images[0].description }}</span>
+        </figcaption>
+      </figure>
 
       <div class="info">
         <h1>{{ post.title }}</h1>


### PR DESCRIPTION
This can be used for attribution and other purposes.

The metadata can be edited by clicking on a featured image in the Manage tab of a blog post in the backend:

![image](https://user-images.githubusercontent.com/180032/98281716-63d28680-1f9d-11eb-9f30-04e55ead9992.png)

The title should describe the image itself. The description should mention licensing information or other secondary information. Both the title and description are optional.

This partially addresses https://github.com/godotengine/godot-website/issues/35.

## Preview

![Screenshot_2020-11-05 First blog post](https://user-images.githubusercontent.com/180032/98281774-79e04700-1f9d-11eb-855e-ca53d9774326.png)