### PR TITLE
Add a link to third-party tutorials on the Community page

### DIFF
--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -73,6 +73,10 @@ is_hidden = 0
       <h3>Events</h3>
       <p>Upcoming community events.</p>
     </a>
+    <a href="https://docs.godotengine.org/en/stable/community/tutorials.html" class="card base-padding">
+      <h3>Tutorials</h3>
+      <p>Find tutorials and guides written by the community.</p>
+    </a>
   </div>
 
   <div>


### PR DESCRIPTION
This helps new users discover third-party tutorials more easily.

## Preview

### Before

<details>

![Screenshot_2020-11-11 Community](https://user-images.githubusercontent.com/180032/98841398-58250b00-2448-11eb-84f7-d73defc57c6d.png)
</details>

### After

<details>

![Screenshot_2020-11-11 Community(1)](https://user-images.githubusercontent.com/180032/98841394-56f3de00-2448-11eb-8faf-d091d727f739.png)
</details>