### PR TITLE
Link to Blender ESCN exporter in the Download page

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -227,10 +227,22 @@ description = "Download layout"
         </div>
       </a>
 
+      <a href="https://github.com/godotengine/godot-blender-exporter" class="base-padding card">
+        <div>
+          <h3>Blender ESCN exporter</h3>
+          <p>
+            Blender add-on to export scenes to Godot's scene format directly.
+          </p>
+        </div>
+      </a>
+
       <a href="https://downloads.tuxfamily.org/godotengine/collada-exporter/BetterColladaExporter-latest.zip" class="base-padding card">
         <div>
           <h3>Better Collada exporter</h3>
-          <p>An improved Collada exporter for Blender.</p>
+          <p>
+            An improved Collada exporter for Blender 2.7x.<br>
+            <strong>Not compatible with Blender 2.80 or later.</strong>
+          </p>
         </div>
       </a>
 


### PR DESCRIPTION
- Mark Collada exporter as incompatible with Blender 2.80 or later.

See https://github.com/godotengine/collada-exporter/issues/125.