### PR TITLE
Add spacing between Events and Community blocks on Community page

### DIFF
--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -43,6 +43,10 @@ is_hidden = 0
     color: var(--dark-color-text-title);
     margin-bottom: 0;
   }
+  
+  #events {
+    margin-bottom: 16px;
+  }
 
   #extras {
     grid-column-end: span 2;


### PR DESCRIPTION
It seems weird that Events and Tutorials would be grouped together, so I added space between them to match the space between User groups and Events.  Apologies if this isn't desired, or I'm doing this wrong.