### PR TITLE
Point license tutorial link to new directory

### DIFF
--- a/themes/godotengine/pages/license.htm
+++ b/themes/godotengine/pages/license.htm
@@ -37,7 +37,7 @@ is_hidden = 0
   acceptable way to satisfy the license terms.
 </p>
 <p>
-  See <a href="https://docs.godotengine.org/en/latest/tutorials/legal/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
+  See <a href="https://docs.godotengine.org/en/stable/tutorials/legal/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
 </p>
 
 <h3 class="title">License text</h3>

--- a/themes/godotengine/pages/license.htm
+++ b/themes/godotengine/pages/license.htm
@@ -37,7 +37,7 @@ is_hidden = 0
   acceptable way to satisfy the license terms.
 </p>
 <p>
-  See <a href="https://docs.godotengine.org/en/stable/tutorials/legal/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
+  See <a href="https://docs.godotengine.org/en/latest/about/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
 </p>
 
 <h3 class="title">License text</h3>


### PR DESCRIPTION
This corrects an issue #205 where the tutorial page 404s