### PR TITLE
Add platform icons to the showcase list for easier recognition

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -732,7 +732,16 @@ pre > code {
 .showcase-card-title {
   font-size: 180%;
   font-weight: 700;
+  /* Compensate for the platform icon margins. */
+  margin-top: 2rem;
   margin-bottom: 0.5rem;
   text-align: center;
   text-shadow: 0.125rem 0.125rem 0.125rem hsl(0, 0%, 0%);
+}
+
+.showcase-card-icons {
+  filter: invert(100%);
+  text-align: center;
+  opacity: 0.75;
+  margin-top: 2rem;
 }

--- a/themes/godotengine/pages/showcase.htm
+++ b/themes/godotengine/pages/showcase.htm
@@ -60,6 +60,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Kingdoms of the Dump"
     author="Roach Games"
+    platforms="windows, macos, linux"
     slug="kingdoms-of-the-dump"
     image="kingdoms-of-the-dump.png"
   %}
@@ -67,6 +68,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Rogue State Revolution"
     author="Little Red Dog Games"
+    platforms="windows, linux"
     slug="rogue-state-revolution"
     image="rogue-state-revolution.jpg"
   %}
@@ -74,6 +76,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Ex Zodiac"
     author="Ben Hickling"
+    platforms="windows, macos, linux, switch"
     slug="ex-zodiac"
     image="ex-zodiac.png"
   %}
@@ -81,6 +84,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Until Then"
     author="Polychroma Games"
+    platforms="windows, macos, linux, switch"
     slug="until-then"
     image="until-then.png"
   %}
@@ -88,6 +92,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Gravity Ace"
     author="John Watson"
+    platforms="windows, linux"
     slug="gravity-ace"
     image="gravity-ace.png"
   %}
@@ -95,6 +100,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Human Diaspora"
     author="Leocesar3D"
+    platforms="windows, linux"
     slug="human-diaspora"
     image="human-diaspora.jpg"
   %}
@@ -102,6 +108,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Primal Light"
     author="Fat Gem"
+    platforms="windows, macos, linux"
     slug="primal-light"
     image="primal-light.png"
   %}
@@ -109,6 +116,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Resolutiion"
     author="Monolith of Minds"
+    platforms="windows, macos, linux, switch"
     slug="resolutiion"
     image="resolutiion.png"
   %}
@@ -116,6 +124,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Dungeondraft"
     author="Megasploot"
+    platforms="windows, macos"
     slug="dungeondraft"
     image="dungeondraft.jpg"
   %}
@@ -123,6 +132,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Material Maker"
     author="R0dZill4"
+    platforms="windows, linux"
     slug="material-maker"
     image="material-maker.png"
   %}
@@ -130,6 +140,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="RPG in a Box"
     author="Justin Arnold"
+    platforms="windows, macos, linux"
     slug="rpg-in-a-box"
     image="rpg-in-a-box.png"
   %}
@@ -137,6 +148,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Pixelorama"
     author="Orama Interactive"
+    platforms="windows, macos, linux, html5"
     slug="pixelorama"
     image="pixelorama.png"
   %}
@@ -144,6 +156,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="City Game Studio"
     author="Binogure Studio"
+    platforms="windows, macos, linux"
     slug="city-game-studio"
     image="city-game-studio.png"
   %}
@@ -151,6 +164,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Hive Time"
     author="Cheeseness"
+    platforms="windows, macos, linux"
     slug="hive-time"
     image="hive-time.png"
   %}
@@ -158,6 +172,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="ΔV: Rings of Saturn"
     author="Kodera Software"
+    platforms="windows, macos, linux"
     slug="delta-v-rings-of-saturn"
     image="delta-v-rings-of-saturn.jpg"
   %}
@@ -165,6 +180,7 @@ is_hidden = 0
     partial "showcase/list-item"
     title="Precipice"
     author="Little Red Dog Games"
+    platforms="windows, linux"
     slug="precipice"
     image="precipice.png"
   %}

--- a/themes/godotengine/partials/showcase/list-item.htm
+++ b/themes/godotengine/partials/showcase/list-item.htm
@@ -9,6 +9,29 @@ description = "Showcase list item"
     <div>
       <div class="showcase-card-title">{{ title }}</div>
       <div class="text-center">{{ author }}</div>
+      <div class="showcase-card-icons">
+        {% for platform in platforms | replace({' ': ''}) | split(',') %}
+
+        {% if platform is same as('windows') %} {% set platformName = 'Windows' %} {% endif %}
+        {% if platform is same as('macos') %} {% set platformName = 'macOS' %} {% endif %}
+        {% if platform is same as('linux') %} {% set platformName = 'Linux' %} {% endif %}
+        {% if platform is same as('android') %} {% set platformName = 'Android' %} {% endif %}
+        {% if platform is same as('ios') %}  {% set platformName = 'iOS' %} {% endif %}
+        {% if platform is same as('html5') %} {% set platformName = 'HTML5' %} {% endif %}
+        {% if platform is same as('switch') %} {% set platformName = 'Nintendo Switch' %} {% endif %}
+        {% if platform is same as('playstation') %} {% set platformName = 'PlayStation' %} {% endif %}
+        {% if platform is same as('xbox') %} {% set platformName = 'Xbox' %} {% endif %}
+
+        <img
+          width="24"
+          height="24"
+          src="{{ ('assets/icons/' ~ platform ~ '.svg') | theme }}"
+          alt="{{ platformName }}"
+          title="{{ platformName }}"
+          style="margin: 0 0.125rem"
+        >
+        {% endfor %}
+      </div>
     </div>
   </article>
 </a>


### PR DESCRIPTION
Games that are supported on highly sought-after platforms (like consoles) can now be seen immediately on the list.

## Preview

![Screenshot_2020-12-08 Showcase](https://user-images.githubusercontent.com/180032/101498325-42820300-396c-11eb-85d9-d7405da235d2.jpg)