### PR TITLE
Prevent the More tab navigation from taking too much space from the title

### DIFF
--- a/themes/godotengine/layouts/more.htm
+++ b/themes/godotengine/layouts/more.htm
@@ -7,7 +7,8 @@ description = "More layout"
 {% partial "header" selected="more" %}
 
 <div class="head">
-  <div class="container flex eqsize">
+  {# Prevent the secondary tab navigation from taking too much space from the title. #}
+  <div class="container flex eqsize" style="flex-direction: column">
     <div class="main">
       <h1 class="intro-title">{% placeholder title %}</h1>
       {% placeholder head_text %}


### PR DESCRIPTION
This is needed for https://github.com/godotengine/godot-website/pull/178 and the Governance page I'll submit in the future.

## Preview

### Before

![Tabs overflowing](https://user-images.githubusercontent.com/180032/102499310-4b18be80-407b-11eb-889d-ed362a7dc8a4.png)

### After

![Tabs not overflowing](https://user-images.githubusercontent.com/180032/102499239-39371b80-407b-11eb-8ce2-269eb763e790.png)
