### PR TITLE
Increase the number of blog posts per page to 25

### DIFF
--- a/themes/godotengine/pages/devblog.htm
+++ b/themes/godotengine/pages/devblog.htm
@@ -6,7 +6,7 @@ is_hidden = 0
 [blogPosts]
 pageNumber = "{{ :page }}"
 categoryFilter = "devblog"
-postsPerPage = "{{ 8 }}"
+postsPerPage = 25
 noPostsMessage = "No posts found"
 sortOrder = "published_at desc"
 categoryPage = "article"

--- a/themes/godotengine/pages/news.htm
+++ b/themes/godotengine/pages/news.htm
@@ -7,7 +7,7 @@ is_hidden = 0
 [blogPosts]
 pageNumber = "{{ :page }}"
 categoryFilter = ""
-postsPerPage = "{{ 8 }}"
+postsPerPage = 25
 noPostsMessage = "No posts found"
 sortOrder = "published_at desc"
 categoryPage = "article"


### PR DESCRIPTION
This makes it easier to browse through the blog archives while requiring less page loads. I tested this change locally by creating 16 blog posts; they now all appear on the same page.

The previous number of posts per page was 15.