### PR TITLE
Remove reference to non-existent locally hosted Tween.js

### DIFF
--- a/plugins/paulvonzimmerman/patreon/components/Goal.php
+++ b/plugins/paulvonzimmerman/patreon/components/Goal.php
@@ -74,7 +74,6 @@ class Goal extends ComponentBase
     public function onRun()
     {
         $this->addCss('/plugins/paulvonzimmerman/patreon/assets/css/goal.css');
-        $this->addJs('/plugins/paulvonzimmerman/patreon/bower_components/tween.js/src/Tween.js');
         $this->addJs('/plugins/paulvonzimmerman/patreon/assets/js/goal.js');
     }
     public function defineProperties()


### PR DESCRIPTION
This prevents a 404 error from being returned on every page load. Since October had to process the 404 page, it increased the server load noticeably.

We already use a CDN-hosted minified version of Tween.js, so the functionality remains identical.