### PR TITLE
Add CSS gradient placeholders to all static images

### DIFF
--- a/themes/godotengine/layouts/features.htm
+++ b/themes/godotengine/layouts/features.htm
@@ -16,10 +16,6 @@ description = "Features layout"
     height: auto;
   }
 
-  .load-placeholder {
-  	background-color: #607080;
-  }
-
   h2 {
     width: 70%;
   }
@@ -70,8 +66,13 @@ description = "Features layout"
 </section>
 
 <section id="features_3d" class="container sm-full">
-  <img src="{{ 'assets/features/3dgames.jpg' | theme }}" width="1587" height="893" alt="3D game screenshot" class="load-placeholder">
-
+  <img
+    src="{{ 'assets/features/3dgames.jpg' | theme }}"
+    width="1587"
+    height="893"
+    alt="3D game screenshot"
+    style="background: linear-gradient(90deg, #8e3019 23%, #381d15 68%, #150f0e 80%, #150f0e 94%)"
+  >
   <div class="title-padded base-padding">
     <h2>Gorgeous 3D graphics</h2>
     <em>
@@ -94,8 +95,13 @@ description = "Features layout"
 </section>
 
 <section id="features_2d" class="container sm-full">
-  <img src="{{ 'assets/features/2dgames.jpg' | theme }}" width="1186" height="696" alt="2D game screenshot" class="load-placeholder">
-
+  <img
+    src="{{ 'assets/features/2dgames.jpg' | theme }}"
+    width="1186"
+    height="696"
+    alt="2D game screenshot"
+    style="background: linear-gradient(90deg, #4b5a6b 36%, #54687e 54%, #54677c 90%, #3f649e 95%)"
+  >
   <div class="title-padded base-padding">
     <h2>Create 2D games with ease</h2>
     <em>Godot comes with a fully-dedicated 2D engine packed with features.</em>
@@ -116,7 +122,13 @@ description = "Features layout"
 
 <section id="animation" class="container flex eqsize responsive">
   <div style="overflow: hidden;">
-    <img src="{{ 'assets/features/animate.jpg'|theme }}" width="780" height="420" alt="Animation editor in Godot" class="load-placeholder">
+    <img
+      src="{{ 'assets/features/animate.jpg'|theme }}"
+      width="780"
+      height="420"
+      alt="Animation editor in Godot"
+      style="background: linear-gradient(90deg, #423f4b 33%, #47444f 40%, #47444f 71%, #3c3a46 81%)"
+    >
   </div>
   <div class="base-padding" style="padding-top: 0;">
     <h2>Animate everything</h2>
@@ -225,7 +237,13 @@ description = "Features layout"
     </ul>
   </div>
   <div style="overflow: hidden;">
-    <img src="{{ 'assets/features/xrsupport.jpg'|theme }}" width="716" height="420" alt="XR support screenshot" class="load-placeholder">
+    <img
+      src="{{ 'assets/features/xrsupport.jpg'|theme }}"
+      width="716"
+      height="420"
+      alt="XR support screenshot"
+      style="background: linear-gradient(90deg, #50594d 6%, #2b221b 43%, #7d7a77 82%, #84817e 92%)"
+    >
   </div>
 </section>
 

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -126,7 +126,13 @@ postPage = "{{ :slug }}"
   }
 </style>
 
-<div id="main_image"></div>
+{#
+  Use placeholder background to show while the image is loading. This improves perceived performance.
+  Make sure to update this gradient when the home background image is changed.
+#}
+<div style="background: linear-gradient(90deg, #6a515c 2%, #4d253c 14%, #5d4753 31%, #6c4448 53%, #3b2847 86%, #3c2848 93%)">
+  <div id="main_image"></div>
+</div>
 
 <section id="main_message" class="dark">
   <div class="container flex eqsize responsive">
@@ -188,14 +194,26 @@ postPage = "{{ :slug }}"
 
   <div class="flex eqsize responsive features-row">
     <div class="feature">
-      <img src="{{ 'assets/home/features/innovative.png' | theme }}" alt="" width="1" height="1">
+      <img
+        src="{{ 'assets/home/features/innovative.png' | theme }}"
+        alt=""
+        width="1"
+        height="1"
+        style="background: linear-gradient(90deg, #333747 11%, #2d3342 50%, #2d3342 68%, #272d3c 87%)"
+      >
       <div class="dark base-padding">
         <h4>Innovative design</h4>
         <p>Big or small ideas adapt seamlessly to Godot's node-based architecture, making your life easier.</p>
       </div>
     </div>
     <div class="feature">
-      <img src="{{ 'assets/home/features/3d.jpg' | theme }}" alt="" width="1" height="1">
+      <img
+        src="{{ 'assets/home/features/3d.jpg' | theme }}"
+        alt=""
+        width="1"
+        height="1"
+        style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)"
+      >
       <div class="dark base-padding">
         <h4>Gorgeous 3D</h4>
         <p>Innovative 3D renderer design, which makes your art look great with minimal effort.</p>
@@ -205,14 +223,26 @@ postPage = "{{ :slug }}"
 
   <div class="flex eqsize responsive features-row">
     <div class="feature">
-      <img src="{{ 'assets/home/features/2d.jpg' | theme }}" alt="" width="1" height="1">
+      <img
+        src="{{ 'assets/home/features/2d.jpg' | theme }}"
+        alt=""
+        width="1"
+        height="1"
+        style="background: linear-gradient(90deg, #252928 4%, #2c312f 13%, #252928 21%, #141213 33%)"
+      >
       <div class="dark base-padding">
         <h4>Beautiful 2D</h4>
         <p>Dedicated 2D engine that works in pixel coordinates, with plenty of built-in tools.</p>
       </div>
     </div>
     <div class="feature">
-      <img src="{{ 'assets/home/features/easy_code.png' | theme }}" alt="" width="1" height="1">
+      <img
+        src="{{ 'assets/home/features/easy_code.png' | theme }}"
+        alt=""
+        width="1"
+        height="1"
+        style="background: linear-gradient(90deg, #252a35 46%, #252a35 53%, #202630 76%, #202630 89%)"
+      >
       <div class="dark base-padding">
         <h4>Easy to program</h4>
         <p>Object-oriented API with language options such as GDScript, C#, C++ and visual scripting.</p>
@@ -222,14 +252,26 @@ postPage = "{{ :slug }}"
 
   <div class="flex eqsize responsive features-row">
     <div class="feature">
-      <img src="{{ 'assets/home/features/team_friendly.svg' | theme }}" alt="" width="1" height="1">
+      <img
+        src="{{ 'assets/home/features/team_friendly.svg' | theme }}"
+        alt=""
+        width="1"
+        height="1"
+        style="background-color: #335767"
+      >
       <div class="dark base-padding">
         <h4>Team-friendly</h4>
         <p>From architecture and tools to VCS integration, Godot is designed for everyone in your team.</p>
       </div>
     </div>
     <div class="feature">
-      <img src="{{ 'assets/home/features/oss.svg' | theme }}" alt="" width="1" height="1">
+      <img
+        src="{{ 'assets/home/features/oss.svg' | theme }}"
+        alt=""
+        width="1"
+        height="1"
+        style="background-color: #333667"
+      >
       <div class="dark base-padding">
         <h4>Open Source</h4>
         <p>Truly open development: anyone who contributes to Godot benefits equally from others’ contributions.</p>

--- a/themes/godotengine/layouts/showcase-item.htm
+++ b/themes/godotengine/layouts/showcase-item.htm
@@ -158,7 +158,7 @@ description = "Showcase item layout"
           frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen
-          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0"
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; background-color: #000"
         >
         </iframe>
       </div>
@@ -171,7 +171,7 @@ description = "Showcase item layout"
           width="100%"
           src="{{ ('assets/showcase/' ~ (placeholder('image') | replace({' ': ''}))) | theme }}"
           alt="Screenshot of {{ placeholder('title') }}"
-          style="margin-top: 1rem"
+          style="margin-top: 1rem; background-color: #607080"
         >
       </a>
     </article>

--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -23,8 +23,6 @@ is_hidden = 0
   }
 
   .card img {
-    /* Use a visible background color while the image is loading. */
-    background-color: #607080;
     width: 100%;
     height: auto;
   }
@@ -85,7 +83,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://godotengine.org/qa" data-barba-prevent><img src="{{ 'assets/community/icon_qa.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://godotengine.org/qa" data-barba-prevent>
+        <img
+          src="{{ 'assets/community/icon_qa.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #fbfbfb 30%, #fdfcfd 46%, #e7ebed 83%, #fefdfe 98%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://godotengine.org/qa" data-barba-prevent>Questions &amp; Answers</a></h3>
         <p>Place to ask questions and search for answers from the community.</p>
@@ -95,7 +101,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://discord.gg/4JBkykG"><img src="{{ 'assets/community/icon_discord.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://discord.gg/4JBkykG">
+        <img
+          src="{{ 'assets/community/icon_discord.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #323541 16%, #42454e 33%, #383b42 82%, #35373e 96%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://discord.gg/4JBkykG">Discord</a></h3>
         <p>A vibrant community for discussion, user support, showcases... and custom emoji!</p>
@@ -105,7 +119,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://webchat.freenode.net/?channels=#godotengine"><img src="{{ 'assets/community/icon_irc.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://webchat.freenode.net/?channels=#godotengine">
+        <img
+          src="{{ 'assets/community/icon_irc.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #29312c 6%, #fafafa 41%, #fcfbfb 70%, #f4f3f0 90%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://webchat.freenode.net/?channels=#godotengine">IRC</a></h3>
         <p>Old-fashioned but reliable, the main discussion platform of core developers.</p>
@@ -116,7 +138,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://matrix.to/#/#godotengine:matrix.org"><img src="{{ 'assets/community/icon_matrix.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://matrix.to/#/#godotengine:matrix.org">
+        <img
+          src="{{ 'assets/community/icon_matrix.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #323333 10%, #323333 18%, #323333 57%, #323333 94%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://matrix.to/#/#godotengine:matrix.org">Matrix</a></h3>
         <p>Libre decentralized chat with advanced features, compatible with IRC.</p>
@@ -126,7 +156,14 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://www.facebook.com/groups/godotengine/"><img src="{{ 'assets/community/icon_facebook.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://www.facebook.com/groups/godotengine/">
+        <img
+          src="{{ 'assets/community/icon_facebook.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #2f3c63 5%, #2f3c63 25%, #2f3c63 65%, #2f3c63 82%)">
+      </a>
       <div class="base-padding">
         <h3><a href="https://www.facebook.com/groups/godotengine/">Facebook</a></h3>
         <p>Large community for discussions around Godot.</p>
@@ -136,7 +173,14 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://www.reddit.com/r/godot"><img src="{{ 'assets/community/icon_reddit.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://www.reddit.com/r/godot">
+        <img
+          src="{{ 'assets/community/icon_reddit.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background-color: #4492e6">
+      </a>
       <div class="base-padding">
         <h3><a href="https://www.reddit.com/r/godot">Reddit</a></h3>
         <p>For the anti-imperialist resistance to Facebook.</p>
@@ -146,7 +190,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://github.com/godotengine/godot"><img src="{{ 'assets/community/icon_github.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://github.com/godotengine/godot">
+        <img
+          src="{{ 'assets/community/icon_github.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #e2e2e3 30%, #e2e2e3 45%, #e3e4e4 80%, #d5d7d7 91%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://github.com/godotengine/godot">GitHub</a></h3>
         <p>Send bug reports here. To request features, use the <a href="https://github.com/godotengine/godot-proposals">Godot proposals</a> repository instead.</p>
@@ -156,7 +208,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://twitter.com/godotengine"><img src="{{ 'assets/community/icon_twitter.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://twitter.com/godotengine">
+        <img
+          src="{{ 'assets/community/icon_twitter.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #fbfbfc 2%, #fbfbfc 9%, #edf1ef 92%, #fbfbfc 99%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://twitter.com/godotengine">Twitter</a></h3>
         <p>Get small bits of development news.</p>
@@ -166,7 +226,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://godotforums.org"><img src="{{ 'assets/community/icon_forum.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://godotforums.org">
+        <img
+          src="{{ 'assets/community/icon_forum.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #e3eaf1 2%, #e3eaf1 28%, #e3eaf1 57%, #e3eaf1 90%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://godotforums.org">Forum</a></h3>
         <p>Community forum for all Godot developers.</p>
@@ -176,7 +244,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://steamcommunity.com/app/404790"><img src="{{ 'assets/community/icon_steam.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://steamcommunity.com/app/404790">
+        <img
+          src="{{ 'assets/community/icon_steam.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #1b232d 2%, #1b232d 52%, #131920 78%, #1b232d 98%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://steamcommunity.com/app/404790">Steam Community</a></h3>
         <p>Discuss and share tips with other developers on Steam.</p>
@@ -186,7 +262,15 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://www.youtube.com/c/GodotEngineOfficial"><img src="{{ 'assets/community/icon_youtube.png'|theme }}" width="350" height="215" alt=""></a>
+      <a href="https://www.youtube.com/c/GodotEngineOfficial">
+        <img
+          src="{{ 'assets/community/icon_youtube.png'|theme }}"
+          width="350"
+          height="215"
+          alt=""
+          style="background: linear-gradient(90deg, #cdbcc5 24%, #cdbcc5 57%, #cdbcc5 66%, #cab8c1 92%)"
+        >
+      </a>
       <div class="base-padding">
         <h3><a href="https://www.youtube.com/c/GodotEngineOfficial">YouTube</a></h3>
         <p>Channel for official Godot videos.</p>

--- a/themes/godotengine/partials/showcase/list-item.htm
+++ b/themes/godotengine/partials/showcase/list-item.htm
@@ -4,7 +4,7 @@ description = "Showcase list item"
   {# Add a gradient to ensure the text is readable regardless of the background color. #}
   <article
     class="card showcase-card"
-    style="background-image: linear-gradient(to bottom, transparent, hsla(0, 0%, 0%, 0.8)), url({{ ('assets/showcase/' ~ (image | replace({' ': ''}))) | theme }})"
+    style="background: linear-gradient(to bottom, transparent, hsla(0, 0%, 0%, 0.8)), url({{ ('assets/showcase/' ~ (image | replace({' ': ''}))) | theme }})"
   >
     <div>
       <div class="showcase-card-title">{{ title }}</div>


### PR DESCRIPTION
Showcase images still use generic background colors, but this could be improved later.

The homepage background uses a 6-stop gradient (since the image spans the whole page width), other images use 4-stop gradients.

This also adds a black background to showcase video iframes to match the YouTube loading color (as is done on the showcase list already).