### PR TITLE
Fix the focus outline being displayed below Download/More tabs

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -123,6 +123,9 @@
 *:focus {
   /* More visible outline for better keyboard navigation. */
   outline: 0.125rem solid hsl(220, 100%, 62.5%);
+  /* Make the outline always appear above other elements.
+  /* Otherwise, one of its sides can be hidden by tabs in the Download and More layouts. */
+  position: relative;
 }
 
 body {


### PR DESCRIPTION
## Preview

### Before

![2021-01-04_18 20 24](https://user-images.githubusercontent.com/180032/103561374-b0611200-4eb9-11eb-8338-0a79d7d08164.png)

### After


![2021-01-04_18 20 36](https://user-images.githubusercontent.com/180032/103561376-b0f9a880-4eb9-11eb-92ce-30d5d8fe1c06.png)