### PR TITLE
Fix and improve showcase card styles

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -800,7 +800,7 @@ pre > code {
 
 .showcase-card {
   /* Display a placeholder color while the card's background image is loading. */
-  background-color: hsl(0, 0%, 50%) !important;
+  background-color: #607080 !important;
   background-size: cover;
   background-position: center;
   border: none;
@@ -810,6 +810,10 @@ pre > code {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.showcase-cards a {
+  text-decoration: none;
 }
 
 .showcase-card:hover {

--- a/themes/godotengine/layouts/showcase-item.htm
+++ b/themes/godotengine/layouts/showcase-item.htm
@@ -168,10 +168,11 @@ description = "Showcase item layout"
         rel="noopener noreferrer"
       >
         <img
-          width="100%"
+          width="16"
+          height="9"
           src="{{ ('assets/showcase/' ~ (placeholder('image') | replace({' ': ''}))) | theme }}"
           alt="Screenshot of {{ placeholder('title') }}"
-          style="margin-top: 1rem; background-color: #607080"
+          style="width: 100%; height: auto; margin-top: 1rem; background-color: #607080"
         >
       </a>
     </article>

--- a/themes/godotengine/pages/showcase.htm
+++ b/themes/godotengine/pages/showcase.htm
@@ -55,7 +55,7 @@ is_hidden = 0
 
 {# 3 columns at most (instead of 4). #}
 {# Projects are sorted from most recent to least recent release date. #}
-<section class="flex grid" style="grid-template-columns: repeat(auto-fill, minmax(300px, 1fr))">
+<section class="flex grid showcase-cards" style="grid-template-columns: repeat(auto-fill, minmax(300px, 1fr))">
   {%
     partial "showcase/list-item"
     title="Kingdoms of the Dump"

--- a/themes/godotengine/partials/showcase/list-item.htm
+++ b/themes/godotengine/partials/showcase/list-item.htm
@@ -4,7 +4,7 @@ description = "Showcase list item"
   {# Add a gradient to ensure the text is readable regardless of the background color. #}
   <article
     class="card showcase-card"
-    style="background: linear-gradient(to bottom, transparent, hsla(0, 0%, 0%, 0.8)), url({{ ('assets/showcase/' ~ (image | replace({' ': ''}))) | theme }})"
+    style="background-image: linear-gradient(to bottom, transparent, hsla(0, 0%, 0%, 0.8)), url({{ ('assets/showcase/' ~ (image | replace({' ': ''}))) | theme }})"
   >
     <div>
       <div class="showcase-card-title">{{ title }}</div>


### PR DESCRIPTION
- Disable the text underline for showcase links.
- Tweak the load placeholder color to match other placeholders on the website.
- Fix background not having the correct size due to using `background` instead of `background-image` (regression from 538e6a5908f356f73fc43bb0198915ddc7de6d14).
- Reserve the space for the screenshot on the showcase detail page to avoid a reflow while the page is loading.