### PR TITLE
Add CSS gradient placeholders for all showcase images

### DIFF
--- a/themes/godotengine/layouts/showcase-item.htm
+++ b/themes/godotengine/layouts/showcase-item.htm
@@ -172,7 +172,7 @@ description = "Showcase item layout"
           height="9"
           src="{{ ('assets/showcase/' ~ (placeholder('image') | replace({' ': ''}))) | theme }}"
           alt="Screenshot of {{ placeholder('title') }}"
-          style="width: 100%; height: auto; margin-top: 1rem; background-color: #607080"
+          style="width: 100%; height: auto; margin-top: 1rem; background: {{ placeholder('placeholder') }}"
         >
       </a>
     </article>

--- a/themes/godotengine/pages/showcase.htm
+++ b/themes/godotengine/pages/showcase.htm
@@ -63,6 +63,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="kingdoms-of-the-dump"
     image="kingdoms-of-the-dump.png"
+    placeholder="linear-gradient(90deg, #b5c1d8 2%, #a8b5d5 9%, #707473 47%, #666a6a 57%)"
   %}
   {%
     partial "showcase/list-item"
@@ -71,6 +72,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="haiki"
     image="haiki.png"
+    placeholder="linear-gradient(90deg, #2d353f 4%, #749bbf 36%, #24232a 87%, #393139 94%)"
   %}
   {%
     partial "showcase/list-item"
@@ -79,6 +81,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="the-garden-path"
     image="the-garden-path.jpg"
+    placeholder="linear-gradient(90deg, #61242a 21%, #70323a 37%, #692b33 78%, #692b32 84%)"
   %}
   {%
     partial "showcase/list-item"
@@ -87,6 +90,7 @@ is_hidden = 0
     platforms="windows, linux"
     slug="rogue-state-revolution"
     image="rogue-state-revolution.jpg"
+    placeholder="linear-gradient(90deg, #896541 32%, #8d6943 42%, #8d6943 53%, #8d6943 64%)"
   %}
   {%
     partial "showcase/list-item"
@@ -95,6 +99,7 @@ is_hidden = 0
     platforms="windows, macos, linux, switch"
     slug="ex-zodiac"
     image="ex-zodiac.png"
+    placeholder="linear-gradient(90deg, #659abb 3%, #649abb 14%, #71a3b8 24%, #6399bb 79%)"
   %}
   {%
     partial "showcase/list-item"
@@ -103,6 +108,7 @@ is_hidden = 0
     platforms="windows, macos, linux, switch"
     slug="until-then"
     image="until-then.png"
+    placeholder="linear-gradient(90deg, #947451 12%, #a8885f 29%, #8c8977 65%, #d2ba9f 98%)"
   %}
   {%
     partial "showcase/list-item"
@@ -111,6 +117,7 @@ is_hidden = 0
     platforms="windows, linux"
     slug="gravity-ace"
     image="gravity-ace.png"
+    placeholder="linear-gradient(90deg, #a52a37 20%, #0f0e24 60%, #c53f4e 88%, #b53442 93%)"
   %}
   {%
     partial "showcase/list-item"
@@ -119,6 +126,7 @@ is_hidden = 0
     platforms="windows, linux"
     slug="human-diaspora"
     image="human-diaspora.jpg"
+    placeholder="linear-gradient(90deg, #2e6d8f 11%, #32769d 47%, #295e8a 67%, #295e8a 73%)"
   %}
   {%
     partial "showcase/list-item"
@@ -127,6 +135,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="primal-light"
     image="primal-light.png"
+    placeholder="linear-gradient(90deg, #24190a 5%, #24190a 15%, #25190a 28%, #25190a 83%)"
   %}
   {%
     partial "showcase/list-item"
@@ -135,6 +144,7 @@ is_hidden = 0
     platforms="windows, macos, linux, switch"
     slug="resolutiion"
     image="resolutiion.png"
+    placeholder="linear-gradient(90deg, #5b0e73 2%, #412f82 24%, #41247e 86%, #5b0e73 97%)"
   %}
   {%
     partial "showcase/list-item"
@@ -143,6 +153,7 @@ is_hidden = 0
     platforms="windows, macos"
     slug="dungeondraft"
     image="dungeondraft.jpg"
+    placeholder="linear-gradient(90deg, #5b412f 4%, #5c4330 57%, #5d4a36 70%, #593c2b 98%)"
   %}
   {%
     partial "showcase/list-item"
@@ -151,6 +162,7 @@ is_hidden = 0
     platforms="windows, linux"
     slug="material-maker"
     image="material-maker.png"
+    placeholder="linear-gradient(90deg, #353943 9%, #353943 29%, #353943 41%, #353943 61%)"
   %}
   {%
     partial "showcase/list-item"
@@ -159,6 +171,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="rpg-in-a-box"
     image="rpg-in-a-box.png"
+    placeholder="linear-gradient(90deg, #2d343c 1%, #2d343c 10%, #174d3a 24%, #161e23 80%)"
   %}
   {%
     partial "showcase/list-item"
@@ -167,6 +180,7 @@ is_hidden = 0
     platforms="windows, macos, linux, html5"
     slug="pixelorama"
     image="pixelorama.png"
+    placeholder="linear-gradient(90deg, #1b1c1c 10%, #776b7e 31%, #98797c 55%, #1b1c1c 77%)"
   %}
   {%
     partial "showcase/list-item"
@@ -175,6 +189,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="city-game-studio"
     image="city-game-studio.png"
+    placeholder="linear-gradient(90deg, #d7dac1 14%, #d7dac1 27%, #7c7171 70%, #a69483 87%)"
   %}
   {%
     partial "showcase/list-item"
@@ -183,6 +198,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="hive-time"
     image="hive-time.png"
+    placeholder="linear-gradient(90deg, #2f702e 1%, #849067 34%, #91975a 43%, #909759 47%)"
   %}
   {%
     partial "showcase/list-item"
@@ -191,6 +207,7 @@ is_hidden = 0
     platforms="windows, macos, linux"
     slug="delta-v-rings-of-saturn"
     image="delta-v-rings-of-saturn.jpg"
+    placeholder="linear-gradient(90deg, #060606 8%, #060607 27%, #0e0e0f 90%, #060606 97%)"
   %}
   {%
     partial "showcase/list-item"
@@ -199,5 +216,6 @@ is_hidden = 0
     platforms="windows, linux"
     slug="precipice"
     image="precipice.png"
+    placeholder="linear-gradient(90deg, #343782 18%, #414145 47%, #522629 66%, #522629 81%)"
   %}
   </section>

--- a/themes/godotengine/pages/showcase/city-game-studio.htm
+++ b/themes/godotengine/pages/showcase/city-game-studio.htm
@@ -68,6 +68,7 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} city-game-studio.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #d7dac1 14%, #d7dac1 27%, #7c7171 70%, #a69483 87%) {% endput %}
 {% put youtube_embed_code %} TODO {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/726840/City_Game_Studio_a_tycoon_about_game_dev/ {% endput %}
 {% put link_itch %} https://binogure.itch.io/city-game-studio {% endput %}

--- a/themes/godotengine/pages/showcase/delta-v-rings-of-saturn.htm
+++ b/themes/godotengine/pages/showcase/delta-v-rings-of-saturn.htm
@@ -49,6 +49,7 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} delta-v-rings-of-saturn.jpg {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #060606 8%, #060607 27%, #0e0e0f 90%, #060606 97%) {% endput %}
 {% put youtube_embed_code %} 7rE4ZTYLkVA {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/846030/V_Rings_of_Saturn/ {% endput %}
 {% put link_itch %} https://koder.itch.io/dv-rings-of-saturn/ {% endput %}

--- a/themes/godotengine/pages/showcase/dungeondraft.htm
+++ b/themes/godotengine/pages/showcase/dungeondraft.htm
@@ -29,5 +29,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} dungeondraft.jpg {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #5b412f 4%, #5c4330 57%, #5d4a36 70%, #593c2b 98%) {% endput %}
 {% put youtube_embed_code %} LYTHVRpihKg {% endput %}
 {% put link_custom %} https://dungeondraft.net/ {% endput %}

--- a/themes/godotengine/pages/showcase/ex-zodiac.htm
+++ b/themes/godotengine/pages/showcase/ex-zodiac.htm
@@ -29,5 +29,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} ex-zodiac.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #659abb 3%, #649abb 14%, #71a3b8 24%, #6399bb 79%) {% endput %}
 {% put youtube_embed_code %} 7sJJW_x6Xg4 {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/1249480/ExZodiac/ {% endput %}

--- a/themes/godotengine/pages/showcase/gravity-ace.htm
+++ b/themes/godotengine/pages/showcase/gravity-ace.htm
@@ -22,6 +22,7 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} gravity-ace.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #a52a37 20%, #0f0e24 60%, #c53f4e 88%, #b53442 93%) {% endput %}
 {% put youtube_embed_code %} wb0r83K3YBk {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/1003860/Gravity_Ace/ {% endput %}
 {% put link_itch %} https://jotson.itch.io/gravity {% endput %}

--- a/themes/godotengine/pages/showcase/haiki.htm
+++ b/themes/godotengine/pages/showcase/haiki.htm
@@ -54,5 +54,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} haiki.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #2d353f 4%, #749bbf 36%, #24232a 87%, #393139 94%) {% endput %}
 {% put youtube_embed_code %} oJG80se4D_I {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/1395270/Haiki/ {% endput %}

--- a/themes/godotengine/pages/showcase/hive-time.htm
+++ b/themes/godotengine/pages/showcase/hive-time.htm
@@ -25,5 +25,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} hive-time.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #2f702e 1%, #849067 34%, #91975a 43%, #909759 47%) {% endput %}
 {% put youtube_embed_code %} w4M6-zkLN6Y {% endput %}
 {% put link_itch %} https://cheeseness.itch.io/hive-time {% endput %}

--- a/themes/godotengine/pages/showcase/human-diaspora.htm
+++ b/themes/godotengine/pages/showcase/human-diaspora.htm
@@ -29,5 +29,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} human-diaspora.jpg {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #2e6d8f 11%, #32769d 47%, #295e8a 67%, #295e8a 73%) {% endput %}
 {% put youtube_embed_code %} NhPjTSAhFYM {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/1395420/Human_Diaspora/ {% endput %}

--- a/themes/godotengine/pages/showcase/kingdoms-of-the-dump.htm
+++ b/themes/godotengine/pages/showcase/kingdoms-of-the-dump.htm
@@ -28,4 +28,5 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} kingdoms-of-the-dump.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #b5c1d8 2%, #a8b5d5 9%, #707473 47%, #666a6a 57%) {% endput %}
 {% put youtube_embed_code %} swcFuuwHKFE {% endput %}

--- a/themes/godotengine/pages/showcase/material-maker.htm
+++ b/themes/godotengine/pages/showcase/material-maker.htm
@@ -28,6 +28,7 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} material-maker.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #353943 9%, #353943 29%, #353943 41%, #353943 61%) {% endput %}
 {% put youtube_embed_code %} PY-fCt1j2Ag {% endput %}
 {% put link_itch %} https://rodzilla.itch.io/material-maker {% endput %}
 {% put link_github %} https://github.com/RodZill4/material-maker {% endput %}

--- a/themes/godotengine/pages/showcase/pixelorama.htm
+++ b/themes/godotengine/pages/showcase/pixelorama.htm
@@ -47,6 +47,7 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} pixelorama.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #1b1c1c 10%, #776b7e 31%, #98797c 55%, #1b1c1c 77%) {% endput %}
 {% put youtube_embed_code %} NLb0TNxZ27E {% endput %}
 {% put link_itch %} https://orama-interactive.itch.io/pixelorama/ {% endput %}
 {% put link_github %} https://github.com/Orama-Interactive/Pixelorama {% endput %}

--- a/themes/godotengine/pages/showcase/precipice.htm
+++ b/themes/godotengine/pages/showcase/precipice.htm
@@ -48,5 +48,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} precipice.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #343782 18%, #414145 47%, #522629 66%, #522629 81%) {% endput %}
 {% put youtube_embed_code %} Ri0Pc5xvJkM {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/951670/Precipice/ {% endput %}

--- a/themes/godotengine/pages/showcase/primal-light.htm
+++ b/themes/godotengine/pages/showcase/primal-light.htm
@@ -30,5 +30,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} primal-light.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #24190a 5%, #24190a 15%, #25190a 28%, #25190a 83%) {% endput %}
 {% put youtube_embed_code %} Kf4lVuTYdeM {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/771420/Primal_Light/ {% endput %}

--- a/themes/godotengine/pages/showcase/resolutiion.htm
+++ b/themes/godotengine/pages/showcase/resolutiion.htm
@@ -47,6 +47,7 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} resolutiion.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #5b0e73 2%, #412f82 24%, #41247e 86%, #5b0e73 97%) {% endput %}
 {% put youtube_embed_code %} wk9v5w7ZEx0 {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/975150/Resolutiion/ {% endput %}
 {% put link_gog %} https://www.gog.com/game/resolutiion/ {% endput %}

--- a/themes/godotengine/pages/showcase/rogue-state-revolution.htm
+++ b/themes/godotengine/pages/showcase/rogue-state-revolution.htm
@@ -34,5 +34,6 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} rogue-state-revolution.jpg {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #896541 32%, #8d6943 42%, #8d6943 53%, #8d6943 64%) {% endput %}
 {% put youtube_embed_code %} Vfz66iLuwzQ {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/1145340/Rogue_State_Revolution/ {% endput %}

--- a/themes/godotengine/pages/showcase/rpg-in-a-box.htm
+++ b/themes/godotengine/pages/showcase/rpg-in-a-box.htm
@@ -46,6 +46,7 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} rpg-in-a-box.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #2d343c 1%, #2d343c 10%, #174d3a 24%, #161e23 80%) {% endput %}
 {% put youtube_embed_code %} M4OWahrBlsQ {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/498310 {% endput %}
 {% put link_itch %} https://zeromatrix.itch.io/rpginabox {% endput %}

--- a/themes/godotengine/pages/showcase/the-garden-path.htm
+++ b/themes/godotengine/pages/showcase/the-garden-path.htm
@@ -31,4 +31,5 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} the-garden-path.jpg {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #61242a 21%, #70323a 37%, #692b33 78%, #692b32 84%) {% endput %}
 {% put youtube_embed_code %} E9SnpPXg8hw {% endput %}

--- a/themes/godotengine/pages/showcase/until-then.htm
+++ b/themes/godotengine/pages/showcase/until-then.htm
@@ -29,4 +29,5 @@ is_hidden = 0
 {% endput %}
 
 {% put image %} until-then.png {% endput image %}
+{% put placeholder %} linear-gradient(90deg, #947451 12%, #a8885f 29%, #8c8977 65%, #d2ba9f 98%) {% endput %}
 {% put youtube_embed_code %} YeMs2y37yxA {% endput %}

--- a/themes/godotengine/partials/showcase/list-item.htm
+++ b/themes/godotengine/partials/showcase/list-item.htm
@@ -4,7 +4,12 @@ description = "Showcase list item"
   {# Add a gradient to ensure the text is readable regardless of the background color. #}
   <article
     class="card showcase-card"
-    style="background-image: linear-gradient(to bottom, transparent, hsla(0, 0%, 0%, 0.8)), url({{ ('assets/showcase/' ~ (image | replace({' ': ''}))) | theme }})"
+    style="
+      background-image:
+        linear-gradient(to bottom, transparent, hsla(0, 0%, 0%, 0.8)),
+        url({{ ('assets/showcase/' ~ (image | replace({' ': ''}))) | theme }}),
+        {{ placeholder }}
+    "
   >
     <div>
       <div class="showcase-card-title">{{ title }}</div>


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-website/pull/223.

This improves perceived preformance by displaying an approximation of the image before it's loaded.

The gradient code was generated using https://www.npmjs.com/package/resemble-image-cli.

## Preview

### Loading

![Showcase Placeholder Loading](https://user-images.githubusercontent.com/180032/103572035-38e8ae00-4ecc-11eb-8648-f9042647717d.png)

### Finished

![Showcase Placeholder Finished](https://user-images.githubusercontent.com/180032/103572032-37b78100-4ecc-11eb-9089-511d018362fc.png)