### PR TITLE
Try to fix Barba.js reloading the same page instead of loading the link

### DIFF
--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -55,6 +55,9 @@ description = "footer partial"
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     barba.init({
+      // Increase timeout from the default value (2000) as our server is relatively slow to respond.
+      // Otherwise, the current page will be reloaded instead of loading the new page.
+      timeout: 10000,
       transitions: [
         {
           name: 'default',


### PR DESCRIPTION
This PR attempts to fix a regression from https://github.com/godotengine/godot-website/pull/222.

This seems to be caused by the timeout value being too low.

Since our production server is slow to respond, this happens relatively frequently, even on a good connection.