### PR TITLE
Decrease the height of the homepage hero image on narrower displays

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -422,6 +422,7 @@ article .content img {
   background-size: cover;
   background-blend-mode: darken;
   height: 600px;
+  max-height: 50vh;
 }
 
 svg.icon {


### PR DESCRIPTION
This makes the page text more visible on narrow displays such as 1366×768 up to 1920×1080.

Mobile and very large displays (such as 2560×1440 at 100% scaling) aren't affected by this change.