### PR TITLE
Decrease the font weight for inline code

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -23,7 +23,6 @@ categoryPage = "article"
   :not(pre) > code {
     background: var(--code-background-color);
     padding: 1px 4px;
-    font-weight: 600;
     font-size: 0.95em;
     border-radius: 3px;
   }


### PR DESCRIPTION
The inherited font weight (400) will now be used instead of 600.

## Preview

### Before

![Font weight 600](https://user-images.githubusercontent.com/180032/103921923-5c516a00-5113-11eb-8903-3e822d1142b5.png)

### After

![Font weight 400](https://user-images.githubusercontent.com/180032/103921925-5cea0080-5113-11eb-945f-09a651219f13.png)