### PR TITLE
Fix the link underline color on dark theme

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -70,7 +70,7 @@
     --accent-color: #f57389;
 
     --link-color: hsl(200, 60%, 70%);
-    --link-underline-color: hsla(200, 60%, 60%, 0.3);
+    --link-underline-color: hsla(200, 60%, 70%, 0.3);
     --navbar-link-color: hsla(0, 0%, 100%, 0.9);
     --navbar-link-current-color: hsl(200, 100%, 80%);
     --footer-link-color: hsla(0, 0%, 100%, 0.85);


### PR DESCRIPTION
It should be a less opaque version of the link color. The difference is barely visible, but it now matches what's done with the light theme :slightly_smiling_face: 

## Preview

### Before

![Link underline](https://user-images.githubusercontent.com/180032/103984631-c146a780-5187-11eb-8e37-19f6ec8d2e46.png)

### After

![Lighter link underline](https://user-images.githubusercontent.com/180032/103984634-c1df3e00-5187-11eb-93bb-a42c498ae789.png)