### PR TITLE
Mention that the Server download is only for Linux

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -109,7 +109,7 @@ description = "Download layout"
       <a href="/download/linux" class="title-font {% if platform == 'linux' %} active {% endif %}">Linux</a>
       <a href="/download/osx" class="title-font {% if platform == 'osx' %} active {% endif %}">macOS</a>
       <a href="/download/windows" class="title-font {% if platform == 'windows' %} active {% endif %}">Windows</a>
-      <a href="/download/server" class="title-font {% if platform == 'server' %} active {% endif %}">Server</a>
+      <a href="/download/server" class="title-font {% if platform == 'server' %} active {% endif %}">Linux Server</a>
     </div>
   </div>
 </div>

--- a/themes/godotengine/pages/download/server.htm
+++ b/themes/godotengine/pages/download/server.htm
@@ -1,4 +1,4 @@
-title = "Download | Server"
+title = "Download | Linux Server"
 url = "/download/server"
 layout = "download"
 description = "Download Godot for Linux servers on this page (headless binaries)."

--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -33,7 +33,7 @@ is_hidden = 0
       32-bit
     </a>
   </div>
-  <p>Note: The 32-bit Mono binaries do not run on 64-bit Windows systems at the time being. Make sure to export 64-bit Mono binaries for your 64-bit target platforms.</p>
+  <p><strong>Note:</strong> The 32-bit Mono binaries do not run on 64-bit Windows systems at the time being. Make sure to export 64-bit Mono binaries for your 64-bit target platforms.</p>
 {% endput %}
 
 {% put instructions %}


### PR DESCRIPTION
As of Godot 3.2, the `server` platform can be compiled for Linux and macOS but only official Linux binaries are provided.