### PR TITLE
Preload fonts to improve loading performance

### DIFF
--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -39,4 +39,6 @@ description = "head partial"
   <link rel="icon" href="{{ 'assets/favicon.png'|theme }}">
   <link rel="stylesheet" href="{{ 'assets/css/main.css' | theme }}">
   <link rel="stylesheet" href="{{ 'assets/css/tobii.min.css' | theme }}">
+  <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-Bold.woff2' | theme }}" crossorigin>
+  <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-ExtraBold.woff2' | theme }}" crossorigin>
 </head>


### PR DESCRIPTION
The browser no longer has to parse the CSS to discover the font resources. Since this feature is only available in modern browsers, there's no need to preload the legacy `.woff` format.

[Preloading isn't supported on Firefox yet.](https://caniuse.com/link-rel-preload)