### PR TITLE
Use lazy loading for images on Home, Features and Community

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -118,7 +118,7 @@ description = "Download layout"
 
   <div class="flex responsive eqsize">
     <div class="version-overview">
-      <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" width="200" height="200">
+      <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" width="200" height="200" alt="">
       <h2>Godot <em>{{stable_version}}</em></h2>
       <i class="date">released September 17, 2020</i>
       <p></p>
@@ -165,11 +165,11 @@ description = "Download layout"
       </div>
 
       <a class="steam-download base-padding card" href="https://godotengine.itch.io/godot" title="Godot Engine on itch.io">
-        <img src="{{ 'assets/download/itch_logo.svg' | theme }}" width="42" height="42">
+        <img src="{{ 'assets/download/itch_logo.svg' | theme }}" width="42" height="42" alt="">
         Available on <strong>itch.io</strong>.
       </a>
       <a class="steam-download base-padding card" href="https://store.steampowered.com/app/404790" title="Godot Engine on Steam">
-        <img src="{{ 'assets/download/steam_logo.svg' | theme }}" width="42" height="42">
+        <img src="{{ 'assets/download/steam_logo.svg' | theme }}" width="42" height="42" alt="">
         Available on <strong>Steam</strong>.
       </a>
     </div>
@@ -259,7 +259,7 @@ description = "Download layout"
     </div>
 
     <div class="text-center base-padding">
-      <img class="flex-center dark-invert" src="{{ 'assets/download/dl_icon_github.png' | theme }}" width="200" height="200">
+      <img class="flex-center dark-invert" src="{{ 'assets/download/dl_icon_github.png' | theme }}" width="200" height="200" alt="">
       <p>
         Godot's development is <strong>open</strong>. This means that you can
         fix or improve any part of the engine yourself and choose

--- a/themes/godotengine/layouts/features.htm
+++ b/themes/godotengine/layouts/features.htm
@@ -73,6 +73,7 @@ description = "Features layout"
       height="893"
       alt="Screenshot of Infinistate by fracteed"
       style="background: linear-gradient(90deg, #8e3019 23%, #381d15 68%, #150f0e 80%, #150f0e 94%)"
+      loading="lazy"
     >
   </a>
   <div class="title-padded base-padding">
@@ -104,6 +105,7 @@ description = "Features layout"
       height="696"
       alt="Screenshot of Slyway by Guaranapps"
       style="background: linear-gradient(90deg, #4b5a6b 36%, #54687e 54%, #54677c 90%, #3f649e 95%)"
+      loading="lazy"
     >
   </a>
   <div class="title-padded base-padding">
@@ -133,6 +135,7 @@ description = "Features layout"
         height="420"
         alt="Screenshot of Godot's animation editor by ndee85"
         style="background: linear-gradient(90deg, #423f4b 33%, #47444f 40%, #47444f 71%, #3c3a46 81%)"
+        loading="lazy"
       >
     </a>
   </div>
@@ -250,6 +253,7 @@ description = "Features layout"
         height="420"
         alt="Screenshot of XR support by Mux213"
         style="background: linear-gradient(90deg, #50594d 6%, #2b221b 43%, #7d7a77 82%, #84817e 92%)"
+        loading="lazy"
       >
     </a>
   </div>

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -200,6 +200,7 @@ postPage = "{{ :slug }}"
         width="1"
         height="1"
         style="background: linear-gradient(90deg, #333747 11%, #2d3342 50%, #2d3342 68%, #272d3c 87%)"
+        loading="lazy"
       >
       <div class="dark base-padding">
         <h4>Innovative design</h4>
@@ -213,6 +214,7 @@ postPage = "{{ :slug }}"
         width="1"
         height="1"
         style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)"
+        loading="lazy"
       >
       <div class="dark base-padding">
         <h4>Gorgeous 3D</h4>
@@ -229,6 +231,7 @@ postPage = "{{ :slug }}"
         width="1"
         height="1"
         style="background: linear-gradient(90deg, #252928 4%, #2c312f 13%, #252928 21%, #141213 33%)"
+        loading="lazy"
       >
       <div class="dark base-padding">
         <h4>Beautiful 2D</h4>
@@ -242,6 +245,7 @@ postPage = "{{ :slug }}"
         width="1"
         height="1"
         style="background: linear-gradient(90deg, #252a35 46%, #252a35 53%, #202630 76%, #202630 89%)"
+        loading="lazy"
       >
       <div class="dark base-padding">
         <h4>Easy to program</h4>
@@ -258,6 +262,7 @@ postPage = "{{ :slug }}"
         width="1"
         height="1"
         style="background-color: #335767"
+        loading="lazy"
       >
       <div class="dark base-padding">
         <h4>Team-friendly</h4>
@@ -271,6 +276,7 @@ postPage = "{{ :slug }}"
         width="1"
         height="1"
         style="background-color: #333667"
+        loading="lazy"
       >
       <div class="dark base-padding">
         <h4>Open Source</h4>
@@ -289,7 +295,7 @@ postPage = "{{ :slug }}"
   <div class="flex eqsize responsive">
 
     <div class="text-center base-padding">
-      <img src="{{ 'assets/home/code.svg' | theme }}" alt="" width="250" height="250">
+      <img src="{{ 'assets/home/code.svg' | theme }}" alt="" width="250" height="250" loading="lazy">
       <h4>Code</h4>
       <p>
         If you know how to code, and enjoy fun and challenging problems, you can help by fixing bugs or creating cool new features.
@@ -298,7 +304,7 @@ postPage = "{{ :slug }}"
     </div>
 
     <div class="text-center base-padding">
-      <img src="{{ 'assets/home/document.svg' | theme }}" alt="" width="250" height="250">
+      <img src="{{ 'assets/home/document.svg' | theme }}" alt="" width="250" height="250" loading="lazy">
       <h4>Document</h4>
       <p>
         Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections.
@@ -307,7 +313,7 @@ postPage = "{{ :slug }}"
     </div>
 
     <div class="text-center base-padding">
-      <img src="{{ 'assets/home/report.svg' | theme }}" alt="" width="250" height="250">
+      <img src="{{ 'assets/home/report.svg' | theme }}" alt="" width="250" height="250" loading="lazy">
       <h4>Report</h4>
       <p>
         Found a problem with the engine? Don't forget to report it so that developers can track it down.
@@ -320,7 +326,7 @@ postPage = "{{ :slug }}"
 
 <section id="donations" class="padded">
   <div class="container sm-full">
-    <img id="sfc_graphic" src=" {{ 'assets/home/sfc.svg' | theme }} " alt="Software Freedom Conservancy" width="1" height="1" class="img-auto-size">
+    <img id="sfc_graphic" src="{{ 'assets/home/sfc.svg' | theme }}" alt="Software Freedom Conservancy logo" width="1" height="1" class="img-auto-size"  loading="lazy">
     <h3 class="text-center">Donate</h3>
     <p class="small auto-margin">
       You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot Engine even more awesome!
@@ -336,24 +342,24 @@ postPage = "{{ :slug }}"
 
     <div class="platinum flex">
       <a class="sponsor card base-padding" href="https://heroiclabs.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/heroiclabs.png' | theme }}" alt="Heroic Labs">
+        <img src="{{ 'assets/home/sponsors/heroiclabs.png' | theme }}" alt="Heroic Labs" loading="lazy">
       </a>
       <a class="sponsor card base-padding" href="https://www.gamblify.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/gamblify.png' | theme }}" alt="Gamblify">
+        <img src="{{ 'assets/home/sponsors/gamblify.png' | theme }}" alt="Gamblify" loading="lazy">
       </a>
       <a class="sponsor card base-padding" href="http://spiffcode.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/spiffcode.png' | theme }}" alt="Spiffcode">
+        <img src="{{ 'assets/home/sponsors/spiffcode.png' | theme }}" alt="Spiffcode" loading="lazy">
       </a>
     </div>
     <div class="gold flex">
       <a class="sponsor card" href="https://www.asifa-hollywood.org/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/asifa-hollywood.png' | theme }}" alt="ASIFA-Hollywood">
+        <img src="{{ 'assets/home/sponsors/asifa-hollywood.png' | theme }}" alt="ASIFA-Hollywood" loading="lazy">
       </a>
       <a class="sponsor card" href="https://www.moonwards.com/" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/moonwards.png' | theme }}" alt="Moonwards">
+        <img src="{{ 'assets/home/sponsors/moonwards.png' | theme }}" alt="Moonwards" loading="lazy">
       </a>
       <a class="sponsor card" href="https://academy.zenva.com/product/godot-game-development-mini-degree/?zva_src=godotengineorg-godotmd" target="_blank" rel="noopener">
-        <img src="{{ 'assets/home/sponsors/zenva-academy.png' | theme }}" alt="Moonwards">
+        <img src="{{ 'assets/home/sponsors/zenva-academy.png' | theme }}" alt="Moonwards" loading="lazy">
       </a>
     </div>
   </div>

--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -90,6 +90,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #fbfbfb 30%, #fdfcfd 46%, #e7ebed 83%, #fefdfe 98%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -108,6 +109,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #323541 16%, #42454e 33%, #383b42 82%, #35373e 96%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -126,6 +128,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #29312c 6%, #fafafa 41%, #fcfbfb 70%, #f4f3f0 90%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -145,6 +148,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #323333 10%, #323333 18%, #323333 57%, #323333 94%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -162,7 +166,9 @@ is_hidden = 0
           width="350"
           height="215"
           alt=""
-          style="background: linear-gradient(90deg, #2f3c63 5%, #2f3c63 25%, #2f3c63 65%, #2f3c63 82%)">
+          style="background: linear-gradient(90deg, #2f3c63 5%, #2f3c63 25%, #2f3c63 65%, #2f3c63 82%)"
+          loading="lazy"
+        >
       </a>
       <div class="base-padding">
         <h3><a href="https://www.facebook.com/groups/godotengine/">Facebook</a></h3>
@@ -179,7 +185,9 @@ is_hidden = 0
           width="350"
           height="215"
           alt=""
-          style="background-color: #4492e6">
+          style="background-color: #4492e6"
+          loading="lazy"
+        >
       </a>
       <div class="base-padding">
         <h3><a href="https://www.reddit.com/r/godot">Reddit</a></h3>
@@ -197,6 +205,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #e2e2e3 30%, #e2e2e3 45%, #e3e4e4 80%, #d5d7d7 91%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -215,6 +224,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #fbfbfc 2%, #fbfbfc 9%, #edf1ef 92%, #fbfbfc 99%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -233,6 +243,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #e3eaf1 2%, #e3eaf1 28%, #e3eaf1 57%, #e3eaf1 90%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -251,6 +262,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #1b232d 2%, #1b232d 52%, #131920 78%, #1b232d 98%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">
@@ -269,6 +281,7 @@ is_hidden = 0
           height="215"
           alt=""
           style="background: linear-gradient(90deg, #cdbcc5 24%, #cdbcc5 57%, #cdbcc5 66%, #cab8c1 92%)"
+          loading="lazy"
         >
       </a>
       <div class="base-padding">


### PR DESCRIPTION
This improves page loading performance by deferring non-critical image loading.

This also adds missing `alt` attributes.