### PR TITLE
Add October CacheRoute plugin to speed up page loading

### DIFF
--- a/plugins/serenitynow/cacheroute/Plugin.php
+++ b/plugins/serenitynow/cacheroute/Plugin.php
@@ -1,0 +1,14 @@
+<?php namespace SerenityNow\Cacheroute;
+
+use System\Classes\PluginBase;
+
+class Plugin extends PluginBase
+{
+    public function boot()
+    {
+        //add RouteCacheMiddleware as a global middleware to intercept all routes
+        $this->app['Illuminate\Contracts\Http\Kernel']
+             ->pushMiddleware('SerenityNow\CacheRoute\Classes\RouteCacheMiddleware');
+    }
+    
+}

--- a/plugins/serenitynow/cacheroute/README.md
+++ b/plugins/serenitynow/cacheroute/README.md
@@ -1,0 +1,45 @@
+##CacheRoute plugin
+
+As we are well aware, the best way to speed up a web application is to serve cached content. This is especially true for 
+an interpreted language like PHP.The logic is simple - if there is no server-side processing to render a page, response is almost immediate.
+The CacheRoute plugin for OctoberCMS is designed to provide a speedup to relatively static pages by caching entire routes. 
+
+So, Let's say you indicate in the backend that you want to have "`blog/*`" cached. The first time you invoke a url matching this pattern,
+ (i.e. cache miss) it goes through all the motions of querying the database, rendering the template and displaying the output.
+This entire page content is then cached (in whatever store you specify in your `config->cache` file).
+
+The next time the same url is requested (while the number of minutes specified in the TTL does not elapse), 
+the cached content is served. So, no database calls, no php rendering overhead, no twig rendering overhead etc. 
+This results in substantial page speedup.
+
+###How it works
+Routes (or route patterns) that you want cached are entered in the backend section (CacheRoutes).
+On boot, the CacheRoute plugin registers a global middleware that intercepts all requests. This middleware then 
+uses "before" and "after" criteria to cache entire pages that match pattern(s) specified in the table. 
+
+###Main features
+* The contents of the backend cacheroute table are cached to avoid the overhead of a database query on every route - The ttl for
+    this cache is extracted from `config->cms->urlCacheTtl` (i.e. `Config::get(cms.urlCacheTtl)`)
+* You can specify different TTL (time to live) values for different routes
+* The plugin uses a simple `Request::is('pattern')` to check for a match (and cache the corresponding route)
+
+###Installation
+1. Go to __Settings > "Updates & Plugins"__ page in the Backend.
+2. Click on the __"Install plugins"__ option.
+3. Type __CacheRoute__ text in the search field, and pick the appropriate plugin.
+4. On your backend, under the "CacheRoute" menu, enter your route pattern(s) and corresponding cache ttl and sort order.
+5. Example:
+
+| Route Pattern   |      TTL      |  Sort Order |
+|-----------------|---------------|-------------|
+| resume 		  |  100		  | 1		    |
+| blog			  |  10			  | 2			|
+| blog/*		  |  10			  | 3			|
+
+###Usage Notes and other information
+* Be mindful of what you are caching! This approach works best for relatively static global content.
+* Note that __it is required to clear ALL cached content every time you add a new route pattern for the plugin to work with it__. To do this, you can use the provided button in the plugin backend panel (or "`php artisan cache:clear`" on terminal). This will clear __ALL__ the cached content, both by the plugin and the backend, if any.
+* You can verify functionality by appending "`?cache-info`" (or "`?debug`" as in previous versions of this plugin) to a cached url, e.g.: `http://mysite.com/mypage?cache-info`.
+    This would show a modal window (centered in the lower part of the screen) over your page content reflecting this specific cache related information, as well as a button to clear (__only__) this specific content cache.
+* You can also clear any specific page cached content directly appending "`?cache-clear`" to its url, e.g.: `http://mysite.com/mypage?cache-clear`
+* FYI: the cache key is a slug of the request url (without any get params) i.e. str_slug($request->url())

--- a/plugins/serenitynow/cacheroute/classes/RouteCacheMiddleware.php
+++ b/plugins/serenitynow/cacheroute/classes/RouteCacheMiddleware.php
@@ -1,0 +1,112 @@
+<?php
+namespace SerenityNow\Cacheroute\Classes;
+
+use Illuminate\Http\Request as LaravelRequest;
+use SerenityNow\Cacheroute\Models\CacheRoute;
+use Closure;
+
+class RouteCacheMiddleware
+{
+    public function handle(LaravelRequest $request, Closure $next)
+    {
+        //bail if table does not exist or
+        //route not in the list of routes to be cached
+        $hasTable = \Schema::hasTable('serenitynow_cacheroute_routes');
+        $cacheRow = $this->shouldBeCached($request);
+        $ajaxRequest = $request->ajax();
+
+        if (!$hasTable || !$cacheRow || $ajaxRequest) {
+            return $next($request);
+        }
+
+        return $this->cacheResponse($request, $next, $cacheRow['cache_ttl']);
+    }
+
+    /**
+     * @param LaravelRequest $request
+     * @param Closure $next
+     * @param $ttl
+     * @return mixed
+     */
+    protected function cacheResponse(LaravelRequest $request, Closure $next, $ttl)
+    {
+        $cacheKey = $this->getCacheKey($request->url());
+        if (\Cache::has($cacheKey)) {
+            return \Response::make($this->getCachedContent($cacheKey, $request, \Cache::get($cacheKey)), 200);
+        }
+
+        $response = $next($request);
+        \Cache::put($cacheKey, $response->getContent(), $ttl);
+        return $response;
+    }
+
+    /**
+     * add instrumentation to help with debug. Adding ?debug
+     * to a cached url will precede the content with "CACHED"
+     *
+     * @param $cacheKey
+     * @param $request
+     * @param $content
+     * @return string
+     */
+    protected function getCachedContent($cacheKey, $request, $content)
+    {
+        $isDebugRequest = $request->exists('debug') || $request->exists('cache-info');
+        if ($isDebugRequest) {
+            return $content.'
+            <div class="cache-notice" style="display: block; position: fixed; width: 50%; background: #fff; padding: 20px 30px 25px; left: 50%; border: 1px solid #aaa; margin-left: calc(-50% / 2); bottom: 10%; z-index: 500; box-shadow: 0 0 20px rgba(0,0,0,0.2); font-size: 16px; font-size: 1.6rem;">
+                <div class="title" style="margin: -20px -30px 10px; background: #999; color: #fff; padding: 10px 30px; text-align: center;">CACHED CONTENT</div>
+                <span class="cache_key" style="display: inline-block; width: 100%; background: #fff; padding: 10px 10px 10px 0; margin-bottom: -10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                    <span class="title" style="float: left; width:45px; color: #000; font-weight: bold; line-height: 30px;">URL: </span>
+                    <input readonly class="value" style="float: left; width: calc(100% - 45px); border:1px solid #000; color: red; padding: 5px 7px; height: 30px; background: #eee" type="text" value="'.$request->url().'">
+                </span>
+                <span class="cache_key" style="display: inline-block; width: 100%; background: #fff; color: red; padding: 10px 10px 10px 0; margin-bottom: -10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                    <span class="title" style="float: left; width:45px; color: #000; font-weight: bold; line-height: 30px;">KEY: </span>
+                    <input readonly class="value" style="float: left; width: calc(100% - 45px); border:1px solid #000; color: red; padding: 5px 7px; height: 30px; background: #eee" type="text" value="'.$cacheKey.'">
+                </span>
+                <hr style="border:none;">
+                <a href="'.$request->url().'" class="cancel" style="float: left; background: #aaa; color: #fff; padding: 10px 15px; margin-top: 20px; text-decoration: none;">Cancel</a>
+                <a href="?cache-clear" class="alert alert-info" style="float: right; background: #1991d1; color: #fff; padding: 10px 15px; margin-top: 20px; text-decoration: none;">Clear this now</a>
+            </div>';
+        }
+
+        if ($request->exists('cache-clear')) {
+            \Cache::forget($cacheKey);
+            return \Redirect::to($request->url());
+        }
+
+        return $content;
+    }
+
+    //generate a cache key based on the url
+
+    /**
+     * @param $url
+     * @return string
+     */
+    protected function getCacheKey($url)
+    {
+        return 'SerenityNow.Cacheroute.' . str_slug($url);
+    }
+
+    /**
+     * @param $request
+     * @return bool
+     */
+    protected function shouldBeCached($request)
+    {
+        $cacheRouteRows = \Cache::remember('SerenityNow.Cacheroute.AllCachedRoutes',
+            \Config::get('cms.urlCacheTtl'),
+            function () {
+                return CacheRoute::orderBy('sort_order')->get()->toArray();                
+            }
+        );
+
+        foreach ($cacheRouteRows as $cacheRow) {
+            if (count($cacheRow) && $request->is($cacheRow['route_pattern'])) {
+                return $cacheRow;
+            }
+        }
+        return false;
+    }
+}

--- a/plugins/serenitynow/cacheroute/controllers/CacheRoutes.php
+++ b/plugins/serenitynow/cacheroute/controllers/CacheRoutes.php
@@ -1,0 +1,42 @@
+<?php namespace SerenityNow\Cacheroute\Controllers;
+
+use Backend\Classes\Controller;
+use BackendMenu;
+use Artisan;
+use Flash;
+
+class CacheRoutes extends Controller
+{
+    public $implement = [
+        'Backend\Behaviors\ListController',
+        'Backend\Behaviors\FormController',
+        'Backend\Behaviors\ReorderController'
+    ];
+
+    public $listConfig = 'config_list.yaml';
+    public $formConfig = 'config_form.yaml';
+    public $reorderConfig = 'config_reorder.yaml';
+
+    public $requiredPermissions = [
+        'serenitynow.cacheroute.manage_cacheroute'
+    ];
+
+    /**
+     * CacheRoutes constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        BackendMenu::setContext('SerenityNow.Cacheroute', 'CacheRoute');
+    }
+
+    /**
+     *
+     */
+    public function onClear()
+    {
+        Artisan::call('cache:clear');
+        Flash::success('ALL cached content cleared');
+    }
+}

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/_list_toolbar.htm
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/_list_toolbar.htm
@@ -1,0 +1,25 @@
+<div data-control="toolbar">
+        <a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes/create') ?>" class="btn btn-primary oc-icon-plus"><?= e(trans('backend::lang.form.create')) ?></a>
+        <a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes/reorder') ?>" class="btn btn-primary oc-icon-sitemap"><?= e(trans('backend::lang.reorder.default_title')) ?></a>
+        <button
+        class="btn btn-default oc-icon-trash-o"
+        disabled="disabled"
+        onclick="$(this).data('request-data', {
+            checked: $('.control-list').listWidget('getChecked')
+        })"
+        data-request="onDelete"
+        data-request-confirm="<?= e(trans('backend::lang.list.delete_selected_confirm')) ?>"
+        data-trigger-action="enable"
+        data-trigger=".control-list input[type=checkbox]"
+        data-trigger-condition="checked"
+        data-request-success="$(this).prop('disabled', true)"
+        data-stripe-load-indicator>
+        <?= e(trans('backend::lang.list.delete_selected')) ?>
+    </button>
+        <button
+        class="btn btn-warning oc-icon-trash-o"
+        data-request="onClear"
+        data-stripe-load-indicator>
+            Clear ALL cached content
+        </button>
+</div>

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/_reorder_toolbar.htm
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/_reorder_toolbar.htm
@@ -1,0 +1,3 @@
+<div data-control="toolbar">
+    <a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>" class="btn btn-primary oc-icon-caret-left"><?= e(trans('backend::lang.form.return_to_list')) ?></a>
+</div>

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/config_form.yaml
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/config_form.yaml
@@ -1,0 +1,11 @@
+name: CacheRoutes
+modelClass: SerenityNow\Cacheroute\Models\CacheRoute
+form: $/serenitynow/cacheroute/models/cacheroute/fields.yaml
+defaultRedirect: serenitynow/cacheroute/cacheroutes
+create:
+    redirect: 'serenitynow/cacheroute/cacheroutes/update/:id'
+    redirectClose: serenitynow/cacheroute/cacheroutes
+update:
+    redirect: serenitynow/cacheroute/cacheroutes
+    redirectClose: serenitynow/cacheroute/cacheroutes
+preview: {  }

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/config_list.yaml
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/config_list.yaml
@@ -1,0 +1,14 @@
+title: CacheRoutes
+modelClass: SerenityNow\Cacheroute\Models\CacheRoute
+list: $/serenitynow/cacheroute/models/cacheroute/columns.yaml
+recordUrl: 'serenitynow/cacheroute/cacheroutes/update/:id'
+noRecordsMessage: 'backend::lang.list.no_records'
+showSetup: true
+showCheckboxes: true
+defaultSort:
+     column: sort_order
+     direction: asc
+toolbar:
+    buttons: list_toolbar
+    search:
+        prompt: 'backend::lang.list.search_prompt'

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/config_reorder.yaml
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/config_reorder.yaml
@@ -1,0 +1,5 @@
+title: CacheRoutes
+modelClass: SerenityNow\Cacheroute\Models\CacheRoute
+nameFrom: route_pattern
+toolbar:
+    buttons: reorder_toolbar

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/create.htm
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/create.htm
@@ -1,0 +1,46 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>">CacheRoutes</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-primary">
+                    <?= e(trans('backend::lang.form.create')) ?>
+                </button>
+                <button 
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-default">
+                    <?= e(trans('backend::lang.form.create_and_close')) ?>
+                </button>
+                <span class="btn-text">
+                    <?= e(trans('backend::lang.form.or')) ?> <a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>"><?= e(trans('backend::lang.form.cancel')) ?></a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+    <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
+    <p><a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>" class="btn btn-default"><?= e(trans('backend::lang.form.return_to_list')) ?></a></p>
+<?php endif ?>

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/index.htm
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/index.htm
@@ -1,0 +1,1 @@
+<?= $this->listRender() ?>

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/preview.htm
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/preview.htm
@@ -1,0 +1,22 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>">CacheRoutes</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <div class="form-preview">
+        <?= $this->formRenderPreview() ?>
+    </div>
+
+<?php else: ?>
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+<?php endif ?>
+
+<p>
+    <a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>" class="btn btn-default oc-icon-chevron-left">
+        <?= e(trans('backend::lang.form.return_to_list')) ?>
+    </a>
+</p>

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/reorder.htm
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/reorder.htm
@@ -1,0 +1,8 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>">CacheRoutes</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?= $this->reorderRender() ?>

--- a/plugins/serenitynow/cacheroute/controllers/cacheroutes/update.htm
+++ b/plugins/serenitynow/cacheroute/controllers/cacheroutes/update.htm
@@ -1,0 +1,54 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>">CacheRoutes</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-request-data="redirect:0"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-primary">
+                    <?= e(trans('backend::lang.form.save')) ?>
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-default">
+                    <?= e(trans('backend::lang.form.save_and_close')) ?>
+                </button>
+                <button
+                    type="button"
+                    class="oc-icon-trash-o btn-icon danger pull-right"
+                    data-request="onDelete"
+                    data-load-indicator="<?= e(trans('backend::lang.form.deleting')) ?>"
+                    data-request-confirm="<?= e(trans('backend::lang.form.confirm_delete')) ?>">
+                </button>
+
+                <span class="btn-text">
+                    <?= e(trans('backend::lang.form.or')) ?> <a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>"><?= e(trans('backend::lang.form.cancel')) ?></a>
+                </span>
+            </div>
+        </div>
+    <?= Form::close() ?>
+
+<?php else: ?>
+    <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
+    <p><a href="<?= Backend::url('serenitynow/cacheroute/cacheroutes') ?>" class="btn btn-default"><?= e(trans('backend::lang.form.return_to_list')) ?></a></p>
+<?php endif ?>

--- a/plugins/serenitynow/cacheroute/lang/en/lang.php
+++ b/plugins/serenitynow/cacheroute/lang/en/lang.php
@@ -1,0 +1,11 @@
+<?php return [
+    'plugin' => [
+        'name' => 'CacheRoute',
+        'description' => 'Speeds up your application by caching output associated with specified routes',
+        'route_pattern' => 'Route Pattern',
+        'cache_ttl' => 'TTL',
+        'cache_ttl_comment' => 'TTL In Minutes',
+        'manage_cache_route' => 'Manage CacheRoute',
+        'sort_order' => 'Sort Order',
+    ],
+];

--- a/plugins/serenitynow/cacheroute/models/CacheRoute.php
+++ b/plugins/serenitynow/cacheroute/models/CacheRoute.php
@@ -1,0 +1,31 @@
+<?php namespace SerenityNow\Cacheroute\Models;
+
+use Model;
+
+/**
+ * Model
+ */
+class CacheRoute extends Model
+{
+    use \October\Rain\Database\Traits\Validation;
+    use \October\Rain\Database\Traits\Sortable;
+
+    /*
+     * Validation
+     */
+    public $rules = [
+        'route_pattern' => 'required|unique:serenitynow_cacheroute_routes',
+        'cache_ttl'     => 'integer',
+    ];
+
+    /*
+     * Disable timestamps by default.
+     * Remove this line if timestamps are defined in the database table.
+     */
+    public $timestamps = false;
+
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'serenitynow_cacheroute_routes';
+}

--- a/plugins/serenitynow/cacheroute/models/cacheroute/columns.yaml
+++ b/plugins/serenitynow/cacheroute/models/cacheroute/columns.yaml
@@ -1,0 +1,14 @@
+columns:
+    route_pattern:
+        label: 'serenitynow.cacheroute::lang.plugin.route_pattern'
+        type: text
+        searchable: true
+        sortable: true
+    cache_ttl:
+        label: 'serenitynow.cacheroute::lang.plugin.cache_ttl'
+        type: number
+        sortable: true
+    sort_order:
+        label: 'serenitynow.cacheroute::lang.plugin.sort_order'
+        type: number
+        sortable: true

--- a/plugins/serenitynow/cacheroute/models/cacheroute/fields.yaml
+++ b/plugins/serenitynow/cacheroute/models/cacheroute/fields.yaml
@@ -1,0 +1,14 @@
+fields:
+    route_pattern:
+        label: 'serenitynow.cacheroute::lang.plugin.route_pattern'
+        oc.commentPosition: ''
+        span: auto
+        required: 1
+        type: text
+    cache_ttl:
+        label: 'serenitynow.cacheroute::lang.plugin.cache_ttl'
+        span: auto
+        default: '10'
+        required: 1
+        type: text
+        comment: 'serenitynow.cacheroute::lang.plugin.cache_ttl_comment'   

--- a/plugins/serenitynow/cacheroute/plugin.yaml
+++ b/plugins/serenitynow/cacheroute/plugin.yaml
@@ -1,0 +1,17 @@
+plugin:
+    name: 'serenitynow.cacheroute::lang.plugin.name'
+    description: 'serenitynow.cacheroute::lang.plugin.description'
+    author: 'Shankar Manamalkav'
+    icon: oc-icon-fighter-jet
+    homepage: ''
+permissions:
+    serenitynow.cacheroute.manage_cacheroute:
+        tab: 'serenitynow.cacheroute::lang.plugin.name'
+        label: 'serenitynow.cacheroute::lang.plugin.manage_cache_route'
+navigation:
+    CacheRoute:
+        label: 'serenitynow.cacheroute::lang.plugin.name'
+        url: serenitynow/cacheroute/cacheroutes
+        icon: icon-fighter-jet
+        permissions:
+            - serenitynow.cacheroute.manage_cacheroute

--- a/plugins/serenitynow/cacheroute/updates/builder_table_create_serenitynow_cacheroute_routes.php
+++ b/plugins/serenitynow/cacheroute/updates/builder_table_create_serenitynow_cacheroute_routes.php
@@ -1,0 +1,23 @@
+<?php namespace SerenityNow\Cacheroute\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableCreateSerenitynowCacherouteRoutes extends Migration
+{
+    public function up()
+    {
+        Schema::create('serenitynow_cacheroute_routes', function($table)
+        {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->string('route_pattern', 255);
+            $table->integer('cache_ttl');
+        });
+    }
+    
+    public function down()
+    {
+        Schema::dropIfExists('serenitynow_cacheroute_routes');
+    }
+}

--- a/plugins/serenitynow/cacheroute/updates/builder_table_update_serenitynow_cacheroute_routes.php
+++ b/plugins/serenitynow/cacheroute/updates/builder_table_update_serenitynow_cacheroute_routes.php
@@ -1,0 +1,23 @@
+<?php namespace SerenityNow\Cacheroute\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableUpdateSerenitynowCacherouteRoutes extends Migration
+{
+    public function up()
+    {
+        Schema::table('serenitynow_cacheroute_routes', function($table)
+        {
+            $table->integer('sort_order')->nullable()->unsigned();
+        });
+    }
+    
+    public function down()
+    {
+        Schema::table('serenitynow_cacheroute_routes', function($table)
+        {
+            $table->dropColumn('sort_order');
+        });
+    }
+}

--- a/plugins/serenitynow/cacheroute/updates/version.yaml
+++ b/plugins/serenitynow/cacheroute/updates/version.yaml
@@ -1,0 +1,14 @@
+1.0.1:
+    - 'Initialize plugin.'
+1.0.2:
+    - 'Created table serenitynow_cacheroute_routes'
+    - builder_table_create_serenitynow_cacheroute_routes.php
+1.0.3:
+    - 'Updated table serenitynow_cacheroute_routes to have Sort_order - required for reorder'
+    - builder_table_update_serenitynow_cacheroute_routes.php
+1.0.4:
+    - 'Remove sort_order field from create form'
+    - 'Set default sort order for list (sort_order asc)'
+    - 'add icon for reorder button'
+1.0.5:  
+    - 'Several updates to cache-debugging appearance and behavior by mrbohnke'


### PR DESCRIPTION
This provides a significant speedup by caching the CMS' pages. This way, the database no longer needs to be queried and templates no longer need to be rendered to display pages.

The October CacheRoute plugin source is here: https://github.com/mnshankar/oc-cacheroute-plugin
This pull request includes commit https://github.com/mnshankar/oc-cacheroute-plugin/commit/f0d91ef04f7c600407fa2f955835dfe35a20d3f8.

There's no need to bother setting up the plugin for development.

Recommended configuration for production **(the order matters!)**:

| Route pattern | TTL (Time To Live)      |
|---------------|-------------------------|
| `backend/*`   | 0 minutes               |
| `download`    | 0 minutes               |
| `/`           | 5 minutes               |
| `article/*`   | 5 minutes               |
| `news*`       | 5 minutes               |
| `devblog*`    | 5 minutes               |
| `*`           | 525600 minutes (1 year) |

Static pages are cached for a long duration, pages featuring dynamic (blog) content are cached for a short duration, and backend pages are not cached at all. The download per-OS redirect is also not cached either as that causes issues; only the OS-specific download pages are cached.

For `news*` and `devblog*`, it's important not to add a slash as we want to also match the first page of the list (whose URL is just `/news` or `/devblog`).

Make sure to run `php artisan plugin:refresh serenitynow.cacheroute` in the October folder after deploying the plugin.

Remember to clear the cache after a deployment by running `php artisan cache:clear` in the October folder. Also, after configuring the route patterns, clear the cache using the October backend menu option.

## How much of a speedup does this provide?

### Without the plugin

```
❯ hey http://localhost:8000/community

Summary:
  Total:	10.7954 secs
  Slowest:	2.7755 secs
  Fastest:	0.0528 secs
  Average:	2.3684 secs
  Requests/sec:	18.5263


Response time histogram:
  0.053 [1]	|
  0.325 [5]	|■
  0.597 [5]	|■
  0.870 [5]	|■
  1.142 [6]	|■■
  1.414 [5]	|■
  1.686 [5]	|■
  1.959 [5]	|■
  2.231 [5]	|■
  2.503 [5]	|■
  2.775 [153]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■


Latency distribution:
  10% in 1.0830 secs
  25% in 2.6293 secs
  50% in 2.7064 secs
  75% in 2.7372 secs
  90% in 2.7564 secs
  95% in 2.7656 secs
  99% in 2.7751 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0018 secs, 0.0528 secs, 2.7755 secs
  DNS-lookup:	0.0017 secs, 0.0011 secs, 0.0026 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0001 secs
  resp wait:	2.3656 secs, 0.0500 secs, 2.7729 secs
  resp read:	0.0008 secs, 0.0007 secs, 0.0012 secs

Status code distribution:
  [200]	200 responses
```

### With the plugin

```
❯ hey http://localhost:8000/community

Summary:
  Total:	3.5234 secs
  Slowest:	0.9366 secs
  Fastest:	0.0246 secs
  Average:	0.7651 secs
  Requests/sec:	56.7632


Response time histogram:
  0.025 [1]	|
  0.116 [5]	|■
  0.207 [5]	|■
  0.298 [6]	|■■
  0.389 [5]	|■
  0.481 [5]	|■
  0.572 [6]	|■■
  0.663 [5]	|■
  0.754 [5]	|■
  0.845 [6]	|■■
  0.937 [151]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■


Latency distribution:
  10% in 0.3640 secs
  25% in 0.8551 secs
  50% in 0.8602 secs
  75% in 0.8627 secs
  90% in 0.9174 secs
  95% in 0.9298 secs
  99% in 0.9346 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0025 secs, 0.0246 secs, 0.9366 secs
  DNS-lookup:	0.0022 secs, 0.0000 secs, 0.0036 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0005 secs
  resp wait:	0.7620 secs, 0.0187 secs, 0.9337 secs
  resp read:	0.0005 secs, 0.0001 secs, 0.0040 secs

Status code distribution:
  [200]	200 responses
```