### PR TITLE
Set up continuous integration using GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: Continuous integration
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.3'
+          tools: composer:v1
+          extensions: curl, fileinfo, gd, mbstring, openssl, pdo, pdo_mysql, xml, zip
+          # Disable Xdebug to improve performance.
+          coverage: none
+
+      - name: Install October and set up MySQL database
+        run: |
+          sudo systemctl start mysql
+          echo -e '[client]\nuser="root"\npassword="root"' > "$HOME/.my.cnf"
+          mysql -e 'CREATE DATABASE IF NOT EXISTS `database`;'
+          # https://stackoverflow.com/questions/52364415/php-with-mysql-8-0-error-the-server-requested-authentication-method-unknown-to
+          mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+
+          mkdir -p october
+          pushd october
+          php -r "eval('?>'.file_get_contents('https://octobercms.com/api/installer'));"
+          php artisan key:generate
+          # Set up the database.
+          sed -i "s/'password'   => ''/'password'   => 'root'/g" config/database.php
+          sed -i "s/'activeTheme' => 'demo'/'activeTheme' => 'godotengine'/g" config/cms.php
+          php artisan october:up
+
+          cp -r ../plugins/* plugins
+          cp -r ../themes/* themes
+          php artisan plugin:refresh paulvonzimmerman.patreon
+          env -C plugins/paulvonzimmerman/patreon composer install
+          php artisan plugin:refresh pikanji.agent
+          php artisan plugin:refresh rainlab.blog
+          php artisan plugin:refresh serenitynow.cacheroute
+          php artisan plugin:refresh sobored.rss
+
+      - name: Run Lighthouse CI
+        run: |
+          npm install @lhci/cli@0.6.x
+          npx lhci autorun

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ conf.json
 !/docker/mariadb/init/000-setup.sql
 /docker/mariadb/init/*.sql
 /docker/mariadb/storage
+
+# Continuous integration
+!.github/
+!lighthouserc.js

--- a/docker/mariadb/bash.sh
+++ b/docker/mariadb/bash.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 docker exec -it godotengine-org--mariadb /bin/bash

--- a/docker/mariadb/log.sh
+++ b/docker/mariadb/log.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 sudo docker logs -f godotengine-org--mariadb

--- a/docker/mariadb/mysql.sh
+++ b/docker/mariadb/mysql.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 docker exec -it godotengine-org--mariadb mysql

--- a/docker/php/bash.sh
+++ b/docker/php/bash.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 sudo docker exec -it godotengine-org--php /bin/bash

--- a/docker/php/install-plugin.sh
+++ b/docker/php/install-plugin.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 USERID=${SUDO_UID}
 if [ -z "${USERID}" ]; then

--- a/docker/php/log.sh
+++ b/docker/php/log.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 sudo docker logs -f godotengine-org--php

--- a/docker/restart.sh
+++ b/docker/restart.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
-sudo docker-compose down && sudo OCTOBER_VERSION=${OCTOBER_VERSION} docker-compose up --build -d
+sudo docker-compose down && sudo OCTOBER_VERSION="${OCTOBER_VERSION-}" docker-compose up --build -d

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,50 @@
+module.exports = {
+    ci: {
+      collect: {
+        url: [
+          'http://localhost:8000/',
+
+          // Test news lists and one article.
+          'http://localhost:8000/news',
+          'http://localhost:8000/devblog',
+          'http://localhost:8000/article/first-blog-post',
+
+          'http://localhost:8000/features',
+
+          'http://localhost:8000/community',
+          'http://localhost:8000/community/user-groups',
+          'http://localhost:8000/events',
+          'http://localhost:8000/events/past',
+
+          'http://localhost:8000/download/linux',
+          'http://localhost:8000/download/osx',
+          'http://localhost:8000/download/windows',
+          'http://localhost:8000/download/server',
+
+          // Test showcase list and one item.
+          'http://localhost:8000/showcase',
+          'http://localhost:8000/showcase/kingdoms-of-the-dump',
+
+          // Pages under the "More" navbar link.
+          'http://localhost:8000/contact',
+          'http://localhost:8000/donate',
+          'http://localhost:8000/code-of-conduct',
+          'http://localhost:8000/privacy-policy',
+          'http://localhost:8000/license',
+        ],
+        // Print "Listening" immediately so that lighthouse-ci starts as soon as possible.
+        startServerCommand: 'env -C october php -S localhost:8000 & echo Listening',
+      },
+      assert: {
+        assertions: {
+          // Performance testing is flaky, so we don't require a minimum performance score.
+          "categories:accessibility": ["error", {"minScore": 0.8}],
+          "categories:best-practices": ["error", {"minScore": 0.8}],
+          "categories:seo": ["error", {"minScore": 0.75}],
+        },
+      },
+      upload: {
+        target: 'temporary-public-storage',
+      },
+    },
+  };


### PR DESCRIPTION
This also uses the unofficial Bash strict mode for shell scripts.

@akien-mga Could you [install the Lighthouse CI app](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/getting-started.md#github-app-method-recommended) on the godot-website repository, please? This way, I can configure GitHub checks that will appear below each pull request. This is more convenient than having to dig through the CI logs to see what failed.

Once you've installed the app, do the following:

- Copy the app token provided on the authorization confirmation page and add it to your build environment as `LHCI_GITHUB_APP_TOKEN`.
- Add the following to `.github/workflows/ci.yml` below `name: Run Lighthouse CI`:

```yaml
env:
  LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
```