### PR TITLE
Remove link to Better Collada exporter as it's unmaintained

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -227,17 +227,8 @@ description = "Download layout"
         <div>
           <h3>Blender ESCN exporter</h3>
           <p>
-            Blender add-on to export scenes to Godot's scene format directly.
-          </p>
-        </div>
-      </a>
-
-      <a href="https://downloads.tuxfamily.org/godotengine/collada-exporter/BetterColladaExporter-latest.zip" class="base-padding card">
-        <div>
-          <h3>Better Collada exporter</h3>
-          <p>
-            An improved Collada exporter for Blender 2.7x.<br>
-            <strong>Not compatible with Blender 2.80 or later.</strong>
+            Blender add-on to export scenes to Godot's scene format directly.<br>
+            Godot also supports glTF 2.0 and OBJ.
           </p>
         </div>
       </a>


### PR DESCRIPTION
This also clarifies that Godot isn't limited to importing ESCN scenes, as it can import glTF 2.0 and OBJ.

See discussion in https://github.com/godotengine/godot-proposals/issues/2130 before merging.