### PR TITLE
Update brew command for OSX download page

### DIFF
--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -37,6 +37,6 @@ is_hidden = 0
     Note that the version available on Homebrew isn't code-signed either.
   </p>
   <ul>
-    <li><pre><code>brew cask install godot</code></pre></li>
+    <li><pre><code>brew install --cask godot</code></pre></li>
   </ul>
 {% endput %}


### PR DESCRIPTION
`brew cask <command>` is deprecated and `brew <command> --cask` is preferred.  Currently running the command throws an error `Calling brew cask install is disabled! Use brew install [--cask] instead.`

https://github.com/Homebrew/discussions/discussions/340

The change updates the command to use the `--cask` flag.