### PR TITLE
Ignore third-party Leaflet.js files in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,4 +17,5 @@
 /themes/godotengine/assets/css/highlight.obsidian.min.css
 /themes/godotengine/assets/css/normalize.min.css
 /themes/godotengine/assets/css/tobii.min.css
+/themes/godotengine/assets/leaflet/
 /themes/godotengine/assets/js/


### PR DESCRIPTION
This is required for CI to pass.