### PR TITLE
Limit zoom levels to reasonable values on the community map

### DIFF
--- a/themes/godotengine/pages/user-groups.htm
+++ b/themes/godotengine/pages/user-groups.htm
@@ -189,6 +189,8 @@ function onStart() {
     const myMap = L.map('community-map').setView([40, 0], 3);
     L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
       attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+      // Use more reasonable zoom level limits where tiles are still displayed.
+      minZoom: 2,
       maxZoom: 18,
       id: 'mapbox/streets-v11',
       tileSize: 512,


### PR DESCRIPTION
Without the minimum zoom level limit, the map's tiles will disappear at zoom level 0.