### PR TITLE
Privacy policy: Add Godot Chat platform

### DIFF
--- a/themes/godotengine/pages/privacy-policy.htm
+++ b/themes/godotengine/pages/privacy-policy.htm
@@ -29,6 +29,7 @@ is_hidden = 0
     <li>you visit the Godot web site (<a href="/">godotengine.org</a>), hosted by <a href="https://www.tuxfamily.org/">TuxFamily</a> (see the TuxFamily privacy policy: <a href="https://faq.tuxfamily.org/Privacy/En">https://faq.tuxfamily.org/Privacy/En</a>);</li>
     <li>you access the Asset Library in the Godot editor application to browse or download assets;</li>
     <li>you sign up as a Godot Patreon (<a href="https://patreon.com/godotengine">https://patreon.com/godotengine</a>) or otherwise donate to Godot (<a href="/donate">https://godotengine.org/donate</a>);</li>
+    <li>you sign up and log in to an account on the Godot Chat platform (<a href="https://chat.godotengine.org" data-barba-prevent>https://chat.godotengine.org</a>), and use it to participate in private and public discussions;</li>
     <li>you sign up and log in to an account on Godot's Q&amp;A site (<a href="https://godotengine.org/qa" data-barba-prevent>https://godotengine.org/qa</a>), and use it to ask or answer questions;</li>
     <li>you sign up and log in to an account on Godot's Asset Library (<a href="https://godotengine.org/asset-library" data-barba-prevent>https://godotengine.org/asset-library</a>), and use it to submit content;</li>
     <li>you use one of Godot's publicly logged project IRC channels (#godotengine-atelier, #godotengine-devel, #godotengine-meeting) on the Freenode IRC network;</li>
@@ -40,7 +41,7 @@ is_hidden = 0
   <p>When you use the Asset Library in the Godot Engine application, HTTPS requests are made to the Asset Library website, and may contain: Godot Engine version, search query, selected assets, and user IP. The Asset Library processes this data without storing it, but our TuxFamily hosting's HTTP server may log these requests. Such logs are subject to TuxFamily's privacy policy (<a href="https://faq.tuxfamily.org/Privacy/En">https://faq.tuxfamily.org/Privacy/En</a>).<br>
   This is the only personal data collected by the Godot Engine application.</p>
 
-  <p>When you create an account on the Godot website (including the Q&amp;A platform, the Asset Library and October CMS), it collects your username and email address for authentication. Additional information may be collected if you choose to fill in optional fields in your user profile (e.g. full name, location, profile picture).</p>
+  <p>When you create an account on the Godot website (including the Godot Chat platform, the Q&amp;A platform, the Asset Library and October CMS), it collects your username and email address for authentication. Additional information may be collected if you choose to fill in optional fields in your user profile (e.g. full name, location, profile picture).</p>
 
   <p>When you join or send messages to any of the IRC channels listed above, that activity is logged and published publicly for others interested in the project. This logging includes the user nickname specified when connecting to Freenode and your messages in those public channels.</p>
 
@@ -166,7 +167,7 @@ is_hidden = 0
 
   <p>Godot reserves the right to change this policy from time to time. If we do make changes, the revised Privacy Statement will be posted on this site. A notice will be posted on our homepage for 30 days whenever this privacy statement is changed in a material way.</p>
 
-  <p>This Privacy Statement was last amended on 2020-06-30.<br>
+  <p>This Privacy Statement was last amended on 2021-01-21.<br>
   You can review the change history at <a href="https://github.com/godotengine/godot-website/commits/master/themes/godotengine/pages/privacy-policy.htm">https://github.com/godotengine/godot-website/commits/master/themes/godotengine/pages/privacy-policy.htm</a>.</p>
 
   <h3 class="title">Attribution and License</h3>


### PR DESCRIPTION
Like other platforms we host, it only collects the bare minimal and what
is strictly related to its expected functionalities (user accounts, posting
content).