### PR TITLE
Revert "Add a fixed banner for GodotCon 2021"

### DIFF
--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -8,22 +8,6 @@ description = "header partial"
 <body data-barba="wrapper">
 {% styles %}
 <header>
-  <a href="/article/online-godotcon-2021-schedule" style="
-    position: fixed;
-    top: 3rem;
-    right: -4rem;
-    transform: rotateZ(45deg);
-    z-index: 9999;
-    padding: 0.5rem 4rem;
-    background-color: #fd4;
-    box-shadow: 0 2px 2px hsla(0, 0%, 0%, 0.3);
-    color: #333;
-    text-decoration: none;
-    font-weight: 700;
-  ">
-    GodotCon 2021!
-  </a>
-</a>
   <div class="container flex align-center">
     <input type="checkbox" id="nav_toggle_cb">
     <div id="nav_head">


### PR DESCRIPTION
GodotCon 2021 is now over. You can view all the videos here: https://www.youtube.com/watch?v=bjuUtddnUok

Thanks for participating! :slightly_smiling_face:

This reverts commit af68e0d1d103e3e1e94310e5dc6631d22dfe0fd3.