### PR TITLE
Add a legend to the homepage's background image

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -470,7 +470,7 @@ article .content img {
   padding-bottom: 64px;
 }
 
-#main_image {
+.main-image {
   background-color: var(--transparent-cover);
   padding: 0px;
   margin: 0px;
@@ -480,6 +480,25 @@ article .content img {
   background-blend-mode: darken;
   height: 600px;
   max-height: 50vh;
+  /* For `.main-image-text`. */
+  position: relative;
+}
+
+.main-image-text {
+  position: absolute;
+  bottom: 1rem;
+  right: 2rem;
+  opacity: 0.75;
+  background-color: hsla(0, 0%, 0%, 0.5);
+  border-radius: 9999px;
+  padding: 0.125rem 0.75rem;
+  text-shadow: 0 0.125rem 0.125rem hsl(0, 0%, 0%);
+}
+
+.main-image-text,
+.main-image-text a {
+  color: white;
+  text-decoration: none;
 }
 
 svg.icon {
@@ -834,7 +853,7 @@ pre > code {
   .flex.eqsize.responsive {
     flex-direction: column;
   }
-  #main_image {
+  .main-image {
     height: 30vh;
   }
 

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -132,7 +132,11 @@ postPage = "{{ :slug }}"
   Make sure to update this gradient when the home background image is changed.
 #}
 <div style="background: linear-gradient(90deg, #6a515c 2%, #4d253c 14%, #5d4753 31%, #6c4448 53%, #3b2847 86%, #3c2848 93%)">
-  <div id="main_image"></div>
+  <div class="main-image" style="position: relative">
+    <div class="main-image-text">
+      <a href="https://kivano.games/"><i>TailQuest: Defense</i> by Kivano Games</a>
+    </div>
+  </div>
 </div>
 
 <section id="main_message" class="dark">


### PR DESCRIPTION
This can be used for attribution purposes.

## Preview

*Check the bottom-right corner. The legend is clickable and points to the project developer's website.*

![Homepage](https://user-images.githubusercontent.com/180032/106218722-26664980-61d8-11eb-8deb-e98c5dc92f68.png)
