### PR TITLE
Privacy policy: Remove redundant blanket statement about third party services

### DIFF
--- a/themes/godotengine/pages/privacy-policy.htm
+++ b/themes/godotengine/pages/privacy-policy.htm
@@ -45,8 +45,6 @@ is_hidden = 0
 
   <p>When you join or send messages to any of the IRC channels listed above, that activity is logged and published publicly for others interested in the project. This logging includes the user nickname specified when connecting to Freenode and your messages in those public channels.</p>
 
-  <p>Third party services that Godot uses may also collect data from you and have their own privacy policies which specify what they do with the data they collect.</p>
-
   <p>Anonymized site visit statistics (<a href="https://stats.tuxfamily.org/godotengine.org">https://stats.tuxfamily.org/godotengine.org</a>) and download statistics (<a href="https://stats.download.tuxfamily.org/godotengine">https://stats.download.tuxfamily.org/godotengine</a>) are collected and published publicly by our TuxFamily hosting.</p>
 
   <p>Godot may also collect personal data from individuals (with their consent) at conventions, trade shows and expositions. The types of personal data collected may include (but are not limited to):</p>
@@ -167,7 +165,7 @@ is_hidden = 0
 
   <p>Godot reserves the right to change this policy from time to time. If we do make changes, the revised Privacy Statement will be posted on this site. A notice will be posted on our homepage for 30 days whenever this privacy statement is changed in a material way.</p>
 
-  <p>This Privacy Statement was last amended on 2021-01-21.<br>
+  <p>This Privacy Statement was last amended on 2021-02-01.<br>
   You can review the change history at <a href="https://github.com/godotengine/godot-website/commits/master/themes/godotengine/pages/privacy-policy.htm">https://github.com/godotengine/godot-website/commits/master/themes/godotengine/pages/privacy-policy.htm</a>.</p>
 
   <h3 class="title">Attribution and License</h3>


### PR DESCRIPTION
The only third party service which users interact with through our hosted services
is TuxFamily, and their privacy policy is already linked earlier in that section.
The only data collected by TuxFamily is access logs, kept for one year as required
by French law.

---

For the reference, Godot users typically use other third-party services with their own privacy policies such as GitHub, Reddit, Discord, etc., but those are not platforms to which we send user information ourselves. If users choose to subscribe to those platforms to communicate with the Godot community, the relationship is with those third-parties directly.