### PR TITLE
Fix Open Graph image meta tag on articles

### DIFF
--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -24,7 +24,7 @@ description = "head partial"
   <meta property="og:title" name="twitter:title" content="{{ post.title }}">
   <meta property="og:description" name="twitter:description" content="{{ post.summary }}">
   <meta property="og:type" content="article">
-  <meta name="og:image" name="twitter:image" content="{{ post.featured_images[0].path }}">
+  <meta property="og:image" name="twitter:image" content="{{ post.featured_images[0].path }}">
   <meta name="twitter:card" content="summary_large_image">
   {% else %}
   <title>Godot Engine - {{ this.page.title }}</title>


### PR DESCRIPTION
The `name` attribute was duplicated, which meant the `twitter:image` value usually "won" over the `og:image` value.