### PR TITLE
Fix Barba.js not taking external Godot websites into account

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -216,7 +216,7 @@ description = "Download layout"
         </div>
       </a>
 
-      <a class="card" href="https://godotengine.org/asset-library/asset?category=10&support[official]=1" data-barba-prevent>
+      <a class="card" href="https://godotengine.org/asset-library/asset?category=10&support[official]=1">
         <div class="base-padding">
           <h3>Demos</h3>
           <p>Example projects to get you started.</p>

--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -68,7 +68,7 @@ is_hidden = 0
 
   <div id="extras">
     {# Inline scripts aren't supported by Barba.js. #}
-    <a href="/community/user-groups" class="card base-padding" id="user-groups" data-barba-prevent>
+    <a href="/community/user-groups" class="card base-padding" id="user-groups">
       <h3>User groups</h3>
       <p>Find local Godot user groups run by community members.</p>
     </a>
@@ -84,7 +84,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://godotengine.org/qa" data-barba-prevent>
+      <a href="https://godotengine.org/qa">
         <img
           src="{{ 'assets/community/icon_qa.png'|theme }}"
           width="350"
@@ -95,7 +95,7 @@ is_hidden = 0
         >
       </a>
       <div class="base-padding">
-        <h3><a href="https://godotengine.org/qa" data-barba-prevent>Questions &amp; Answers</a></h3>
+        <h3><a href="https://godotengine.org/qa">Questions &amp; Answers</a></h3>
         <p>Place to ask questions and search for answers from the community.</p>
       </div>
     </div>

--- a/themes/godotengine/pages/privacy-policy.htm
+++ b/themes/godotengine/pages/privacy-policy.htm
@@ -29,9 +29,9 @@ is_hidden = 0
     <li>you visit the Godot web site (<a href="/">godotengine.org</a>), hosted by <a href="https://www.tuxfamily.org/">TuxFamily</a> (see the TuxFamily privacy policy: <a href="https://faq.tuxfamily.org/Privacy/En">https://faq.tuxfamily.org/Privacy/En</a>);</li>
     <li>you access the Asset Library in the Godot editor application to browse or download assets;</li>
     <li>you sign up as a Godot Patreon (<a href="https://patreon.com/godotengine">https://patreon.com/godotengine</a>) or otherwise donate to Godot (<a href="/donate">https://godotengine.org/donate</a>);</li>
-    <li>you sign up and log in to an account on the Godot Chat platform (<a href="https://chat.godotengine.org" data-barba-prevent>https://chat.godotengine.org</a>), and use it to participate in private and public discussions;</li>
-    <li>you sign up and log in to an account on Godot's Q&amp;A site (<a href="https://godotengine.org/qa" data-barba-prevent>https://godotengine.org/qa</a>), and use it to ask or answer questions;</li>
-    <li>you sign up and log in to an account on Godot's Asset Library (<a href="https://godotengine.org/asset-library" data-barba-prevent>https://godotengine.org/asset-library</a>), and use it to submit content;</li>
+    <li>you sign up and log in to an account on the Godot Chat platform (<a href="https://chat.godotengine.org">https://chat.godotengine.org</a>), and use it to participate in private and public discussions;</li>
+    <li>you sign up and log in to an account on Godot's Q&amp;A site (<a href="https://godotengine.org/qa">https://godotengine.org/qa</a>), and use it to ask or answer questions;</li>
+    <li>you sign up and log in to an account on Godot's Asset Library (<a href="https://godotengine.org/asset-library">https://godotengine.org/asset-library</a>), and use it to submit content;</li>
     <li>you use one of Godot's publicly logged project IRC channels (#godotengine-atelier, #godotengine-devel, #godotengine-meeting) on the Freenode IRC network;</li>
     <li>you sign up for one of our public mailing lists hosted by TuxFamily;</li>
     <li>you participate in surveys or evaluations;</li>

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -60,8 +60,21 @@ description = "footer partial"
       // Increase timeout from the default value (2000) as our server is relatively slow to respond.
       // Otherwise, the current page will be reloaded instead of loading the new page.
       timeout: 10000,
-      // Ignore lightbox links.
-      prevent: ({ el }) => el.classList && el.classList.contains('lightbox'),
+
+      // Ignore:
+      // - lightbox links,
+      // - user groups page (due to inline JavaScript being used),
+      // - links that are "external" websites,
+      // - direct PDF files.
+      prevent: ({ el }) => {
+        const isLightBox = el.classList && el.classList.contains('lightbox');
+        const isUserGroupsPage = el.href && el.href.includes('/community/user-groups');
+        const isQaUrl = el.href && el.href.includes('/qa');
+        const isAssetLibUrl = el.href && el.href.includes('/asset-library');
+        const isPdf = el.href && el.href.includes('.pdf');
+        return isLightBox || isUserGroupsPage || isQaUrl || isAssetLibUrl || isPdf;
+      },
+
       transitions: [
         {
           name: 'default',

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -31,7 +31,7 @@ description = "header partial"
       <ul class="right">
         <li {% if selected == 'download' %} class="active" {% endif %}><a href="/download">Download</a></li>
         <li><a href="https://docs.godotengine.org">Learn</a></li>
-        <li><a href="https://godotengine.org/asset-library/asset" data-barba-prevent>Assets</a></li>
+        <li><a href="https://godotengine.org/asset-library/asset">Assets</a></li>
         {% component 'Goal' %}
       </ul>
     </nav>


### PR DESCRIPTION
This removes the need for individual `data-barba-prevent` attributes.

This closes #269.