### PR TITLE
Fix hover/focus button outlines on the Download page

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -24,13 +24,12 @@ description = "Download layout"
   }
 
   .btn.split {
-    border: 2px solid var(--primary-color);
     display: inline-flex;
     flex-basis: content;
   }
 
   .btn.split > a {
-    padding: 8px 16px 8px 16px;
+    padding: 10px 20px;
     width: auto;
   }
 


### PR DESCRIPTION
This also increases the horizontal padding of download buttons slightly for a better appearance.

This closes #286.