### PR TITLE
Fix video height in articles

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -50,6 +50,7 @@ categoryPage = "article"
 
   article img, article video {
     max-width: 100%;
+    height: auto;
     display: block;
     margin: auto;
     margin-top: 16px;


### PR DESCRIPTION
Previously, videos took more vertical space than they needed.