### PR TITLE
Add a search box for articles

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -119,6 +119,11 @@
   .dark-desaturate {
     filter: saturate(0%);
   }
+
+  /* Dark theme hack for the DuckDuckGo search iframe. */
+  .article-search-bar {
+    filter: invert(80%) hue-rotate(180deg);
+  }
 }
 
 /* Montserrat Bold */

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -55,6 +55,26 @@ description = "News layout"
 </div>
 
 <div class="container">
+  {#
+    Add a background to roughly match the iframe's appearance during loading.
+    This makes the pop-in during loading less noticeable.
+  #}
+  <iframe
+    src="https://duckduckgo.com/search.html?site=godotengine.org/article&width=285&prefill=Search articles"
+    frameborder="0"
+    class="article-search-bar"
+    style="
+      background-color:white;
+      box-shadow: 0 0 4px hsla(0, 0%, 0%, 1) inset;
+      border-radius: 3px;
+      overflow:hidden;
+      margin:0 0 1rem 0;
+      padding:0;
+      width:343px;
+      height:40px;
+    "
+  ></iframe>
+
   {% set posts = blogPosts.posts %}
   {% for post in posts %}
     <a href="{{ 'article'|page({ slug: post.slug }) }}" style="text-decoration: none">


### PR DESCRIPTION
This uses [DuckDuckGo site search](https://duckduckgo.com/search_box) with a preconfigured URL. It's not perfect by any means, but it's better than nothing.

The search bar will use a dark theme (hacked around with CSS filters) if the rest of the website is also using the dark theme.

See #219.

## Preview

### Light theme

![image](https://user-images.githubusercontent.com/180032/110213815-f595c600-7ea1-11eb-8acf-a277ac196f41.png)

### Dark theme

![image](https://user-images.githubusercontent.com/180032/110213803-e1ea5f80-7ea1-11eb-8ee5-6002aaa75186.png)
