### PR TITLE
Prevent line breaks between "Godot" and "Engine"

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -334,7 +334,7 @@ postPage = "{{ :slug }}"
     <img id="sfc_graphic" src="{{ 'assets/home/sfc.svg' | theme }}" alt="Software Freedom Conservancy logo" width="1" height="1" class="img-auto-size"  loading="lazy">
     <h3 class="text-center">Donate</h3>
     <p class="small auto-margin">
-      You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot Engine even more awesome!
+      You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot&nbsp;Engine even more awesome!
     </p>
 
     <a href="/donate" class="btn flat btn-white-text">Learn more</a>

--- a/themes/godotengine/pages/contact.htm
+++ b/themes/godotengine/pages/contact.htm
@@ -57,9 +57,9 @@ is_hidden = 0
     <li>Rémi Verschelde - <em>remi@godotengine.org</em></li>
   </ul>
 
-  <h3 class="title" id="devs">Godot Engine team</h3>
+  <h3 class="title" id="devs">Godot&nbsp;Engine team</h3>
   <p>
-    The Godot Engine team is made of hundreds of developers around the world,
+    The Godot&nbsp;Engine team is made of hundreds of developers around the world,
     with both regular and occasional contributors.
   </p>
 

--- a/themes/godotengine/pages/donate.htm
+++ b/themes/godotengine/pages/donate.htm
@@ -8,7 +8,7 @@ is_hidden = 0
 
 {% put head_text %}
   <p class="small">
-    Godot Engine is a not-for-profit, community-driven free and open source project.
+    Godot&nbsp;Engine is a not-for-profit, community-driven free and open source project.
     It is legally represented by <a href="https://sfconservancy.org/">Software Freedom Conservancy</a>,
     a USA-based charity that helps promote, improve, develop, and defend <abbr title="Free, Libre, and Open Source Software">FLOSS</abbr> projects.
   </p>
@@ -22,7 +22,7 @@ is_hidden = 0
 
 <p>We use donations for:</p>
 <ul>
-  <li>Hiring developers so that they can work part-time or full-time on Godot Engine, making the project progress faster.</li>
+  <li>Hiring developers so that they can work part-time or full-time on Godot&nbsp;Engine, making the project progress faster.</li>
   <li>Hiring artists to create high quality demo artwork under a permissive license.</li>
   <li>Purchasing hardware required to develop Godot.</li>
   <li>Pay for hosting of some web services.</li>
@@ -38,7 +38,7 @@ is_hidden = 0
 <h3 class="title">Patreon</h3>
 
 <p>
-  Patreon is a platform for creators to crowdfund their work via monthly donations. Godot Engine launched a <a href="https://www.patreon.com/godotengine">Patreon page</a> with the aim to collect enough money each month to hire some of its developers part-time or full-time, starting with its lead developer Juan Linietsky
+  Patreon is a platform for creators to crowdfund their work via monthly donations. Godot&nbsp;Engine launched a <a href="https://www.patreon.com/godotengine">Patreon page</a> with the aim to collect enough money each month to hire some of its developers part-time or full-time, starting with its lead developer Juan Linietsky
 </p>
 
 <a class="patronImgLink" href="https://www.patreon.com/bePatron?u=5597979" ><img alt="Become a patron!" height="37px" src="{{ 'assets/community/become_a_patron_button.png'|theme }}"> </a>

--- a/themes/godotengine/pages/events/past.htm
+++ b/themes/godotengine/pages/events/past.htm
@@ -63,7 +63,7 @@ is_hidden = 0
 
     <p>A Call for Proposals <a href="/article/meet-community-fosdem-and-godotcon-2020">has been posted</a>, and speakers will be announced in January.</p>
 
-    <p>This is an event for you (and us) to meet together and get to strengthen the existing bonds between Godot contributors and users. Everyone is welcome to join, and the entrance will be free. Even if you aren't familiar with Godot Engine yet, this can be a nice opportunity to discover a great game engine and an even greater community!</p>
+    <p>This is an event for you (and us) to meet together and get to strengthen the existing bonds between Godot contributors and users. Everyone is welcome to join, and the entrance will be free. Even if you aren't familiar with Godot&nbsp;Engine yet, this can be a nice opportunity to discover a great game engine and an even greater community!</p>
 
     <p>To spread the word about the event, you can use the <a href="/storage/app/media/events/godotcon-2020/godotcon_brussels_banner_2020.png">GodotCon Brussels 2020 banner</a>.</p>
 
@@ -130,7 +130,7 @@ is_hidden = 0
 
     <p>A Call for Proposals will be posted soon, and speakers will be announced in late December or January.</p>
 
-    <p>This is an event for you (and us) to meet together and get to strengthen the existing bonds between Godot contributors and users. Everyone is welcome to join, and the entrance will be free. Even if you aren't familiar with Godot Engine yet, this can be a nice opportunity to discover a great game engine and an even greater community!</p>
+    <p>This is an event for you (and us) to meet together and get to strengthen the existing bonds between Godot contributors and users. Everyone is welcome to join, and the entrance will be free. Even if you aren't familiar with Godot&nbsp;Engine yet, this can be a nice opportunity to discover a great game engine and an even greater community!</p>
 
     <p>To spread the word about the event, you can use the <a href="/storage/app/media/events/godotcon-2019/godotcon_brussels_banner_2019.png">GodotCon Brussels 2019 banner</a>.</p>
 
@@ -180,7 +180,7 @@ is_hidden = 0
 
     <h4>Godot stand (with goodies!)</h4>
 
-    <p>Like last year, we will have a <a href="https://fosdem.org/2018/stands/">Godot Engine stand</a>. It will be located in Building K (<a href="https://fosdem.org/2018/schedule/buildings/#k">Campus plan</a>, <a href="https://www.openstreetmap.org/?mlat=50.81474&mlon=4.38164#map=17/50.81474/4.38164">OpenStreetMap</a>).
+    <p>Like last year, we will have a <a href="https://fosdem.org/2018/stands/">Godot&nbsp;Engine stand</a>. It will be located in Building K (<a href="https://fosdem.org/2018/schedule/buildings/#k">Campus plan</a>, <a href="https://www.openstreetmap.org/?mlat=50.81474&mlon=4.38164#map=17/50.81474/4.38164">OpenStreetMap</a>).
     We invite all Godot users and contributors from Europe and beyond to join us there and help us man the stand, distribute goodies and talk to the other visitors about our engine.</p>
 
     <h4>Meeting the community</h4>
@@ -200,7 +200,7 @@ is_hidden = 0
     <img src="/storage/app/media/events/godotcon-2018/godotcon_banner_2018.png" alt="GodotCon 2018 banner" height="320px">
 
     <p>After last year's big success, we organize another GodotCon right after FOSDEM, and still in Brussels so that you can attend both events at once.
-    GodotCon is the yearly meetup of the Godot Engine community, open to all interested users and contributions, whether complete beginners/new users or core developers.</p>
+    GodotCon is the yearly meetup of the Godot&nbsp;Engine community, open to all interested users and contributions, whether complete beginners/new users or core developers.</p>
 
     <p>The entrance is free, and we will have various talks and workshops prepared by contributors and users of the engine, as well as different related activities.
     The main point is to all meet together with our laptops and hack at some Godot games or the engine itself, while getting to know the community in person and learn from experienced users.</p>
@@ -262,7 +262,7 @@ is_hidden = 0
 
     <h4>Godot stand (with goodies!)</h4>
 
-    <p>This year will be Godot's first official participation with a <a href="https://fosdem.org/2017/stands/">Godot Engine stand</a>. It will be located in Building H (<a href="https://fosdem.org/2017/schedule/buildings/#h">Campus plan</a>).
+    <p>This year will be Godot's first official participation with a <a href="https://fosdem.org/2017/stands/">Godot&nbsp;Engine stand</a>. It will be located in Building H (<a href="https://fosdem.org/2017/schedule/buildings/#h">Campus plan</a>).
     We invite all Godot users and contributors from Europe and beyond to join us there and help us man the stand, distribute goodies and talk to the other visitors about our engine.</p>
 
     <p>Want to help us with the stand, designing or ordering goodies and stand material (table cloth, kakemono, etc.)? Get in touch with us on <a href="/community">one of the community channels</a> (especially IRC ;)).

--- a/themes/godotengine/pages/license.htm
+++ b/themes/godotengine/pages/license.htm
@@ -9,31 +9,31 @@ is_hidden = 0
 
 <h3 class="title">The engine</h3>
 <p>
-  Godot Engine is <a href="https://en.wikipedia.org/wiki/Free_and_open_source_software">free and open source software</a>
+  Godot&nbsp;Engine is <a href="https://en.wikipedia.org/wiki/Free_and_open_source_software">free and open source software</a>
   released under the permissive <a href="https://github.com/godotengine/godot/blob/master/LICENSE.txt">MIT license</a> (also named Expat license).
 </p>
 <p>This license grants users a number of freedoms:</p>
 <ul>
-  <li>You are free to use Godot Engine, for any purpose</li>
-  <li>You can study how Godot Engine works and change it</li>
-  <li>You can distribute unmodified and changed versions of Godot Engine, even commercially and under a different license (including proprietary)</li>
+  <li>You are free to use Godot&nbsp;Engine, for any purpose</li>
+  <li>You can study how Godot&nbsp;Engine works and change it</li>
+  <li>You can distribute unmodified and changed versions of Godot&nbsp;Engine, even commercially and under a different license (including proprietary)</li>
 </ul>
 <p>
-  The only restriction to that third freedom is that you need to distribute the copyright notice and license statement of Godot Engine whenever you redistribute it.
-  So your derivative product may have a different license, but should still state in its documentation that it derives from the MIT licensed Godot Engine (see below).
+  The only restriction to that third freedom is that you need to distribute the copyright notice and license statement of Godot&nbsp;Engine whenever you redistribute it.
+  So your derivative product may have a different license, but should still state in its documentation that it derives from the MIT licensed Godot&nbsp;Engine (see below).
 </p>
 
 <h3 class="title">Your game</h3>
 <p>
-  Godot Engine's license terms and copyright do not apply to the content you create with it; you are free to license your games how you see best fit,
+  Godot&nbsp;Engine's license terms and copyright do not apply to the content you create with it; you are free to license your games how you see best fit,
   and will be their sole copyright owner(s).
 </p>
 <p>
-  Note however that the Godot Engine binary that you would distribute with your game is a copy of the "Software" as defined in the license,
+  Note however that the Godot&nbsp;Engine binary that you would distribute with your game is a copy of the "Software" as defined in the license,
   and you are therefore required to include the copyright notice and license statement somewhere in your documentation.
 </p>
 <p>
-  The Godot Engine developers consider that a link to this page (<a href="/license">godotengine.org/license</a>) in your game documentation or credits would be an
+  The Godot&nbsp;Engine developers consider that a link to this page (<a href="/license">godotengine.org/license</a>) in your game documentation or credits would be an
   acceptable way to satisfy the license terms.
 </p>
 <p>
@@ -42,7 +42,7 @@ is_hidden = 0
 
 <h3 class="title">License text</h3>
 <p>
-  A plain text version of the license is available from Godot Engine's GitHub repository: <a href="https://github.com/godotengine/godot/blob/master/LICENSE.txt">LICENSE.txt</a>.<br />
+  A plain text version of the license is available from Godot&nbsp;Engine's GitHub repository: <a href="https://github.com/godotengine/godot/blob/master/LICENSE.txt">LICENSE.txt</a>.<br />
   A list of contributors is also available: <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md">AUTHORS.md</a>.
 </p>
 
@@ -73,15 +73,15 @@ SOFTWARE.
 
 <h3 class="title">Third-party components</h3>
 <p>
-  Godot Engine uses several third-party libraries and code snippets, which are distributed under their own license and copyright statements.
-  All such components are compatible with the terms of Godot Engine's MIT license.
+  Godot&nbsp;Engine uses several third-party libraries and code snippets, which are distributed under their own license and copyright statements.
+  All such components are compatible with the terms of Godot&nbsp;Engine's MIT license.
   You can refer to <a href="https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt">this list</a>
-  for a comprehensive overview of all third-party components used in Godot Engine and their respective licenses.
+  for a comprehensive overview of all third-party components used in Godot&nbsp;Engine and their respective licenses.
 </p>
 
 <h3 class="title">Disclaimer</h3>
 <p>
-  The above explanations of Godot Engine's license terms and their implications for its users do not constitute legal advice.
-  They reflect the Godot Engine team's understanding of their own license terms and that of their third-party components;
+  The above explanations of Godot&nbsp;Engine's license terms and their implications for its users do not constitute legal advice.
+  They reflect the Godot&nbsp;Engine team's understanding of their own license terms and that of their third-party components;
   in case of doubt, please refer to your lawyer.
 </p>

--- a/themes/godotengine/pages/showcase/pixelorama.htm
+++ b/themes/godotengine/pages/showcase/pixelorama.htm
@@ -14,7 +14,7 @@ is_hidden = 0
 {% put description %}
 <p>
   Pixelorama is a free & open source pixel art sprite editor, with animation
-  support. It is made entirely with the Godot Engine. Current features as of
+  support. It is made entirely with the Godot&nbsp;Engine. Current features as of
   version v0.8:
 </p>
 <ul>


### PR DESCRIPTION
The engine name should be written on a single line whenever possible.

## Preview

### Before

![image](https://user-images.githubusercontent.com/180032/110215731-a359a280-7eab-11eb-8a4d-d53064ca25a1.png)

### After

![image](https://user-images.githubusercontent.com/180032/110215736-aa80b080-7eab-11eb-829b-1ab703ec45c2.png)