### PR TITLE
Link feature tiles on the homepage to sections on the Features page

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -198,96 +198,111 @@ postPage = "{{ :slug }}"
   <h2>A different way to make games</h2>
 
   <div class="flex eqsize responsive features-row">
-    <div class="feature">
-      <img
-        src="{{ 'assets/home/features/innovative.png' | theme }}"
-        alt=""
-        width="1"
-        height="1"
-        style="background: linear-gradient(90deg, #333747 11%, #2d3342 50%, #2d3342 68%, #272d3c 87%)"
-        loading="lazy"
-      >
-      <div class="dark base-padding">
-        <h4>Innovative design</h4>
-        <p>Big or small ideas adapt seamlessly to Godot's node-based architecture, making your life easier.</p>
+    <a href="/features#design" data-barba-prevent>
+      <div class="feature">
+        <img
+          src="{{ 'assets/home/features/innovative.png' | theme }}"
+          alt=""
+          width="1"
+          height="1"
+          style="background: linear-gradient(90deg, #333747 11%, #2d3342 50%, #2d3342 68%, #272d3c 87%)"
+          loading="lazy"
+        >
+        <div class="dark base-padding">
+          <h4>Innovative design</h4>
+          <p>Big or small ideas adapt seamlessly to Godot's node-based architecture, making your life easier.</p>
+        </div>
       </div>
-    </div>
-    <div class="feature">
-      <img
-        src="{{ 'assets/home/features/3d.jpg' | theme }}"
-        alt=""
-        width="1"
-        height="1"
-        style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)"
-        loading="lazy"
-      >
-      <div class="dark base-padding">
-        <h4>Gorgeous 3D</h4>
-        <p>Innovative 3D renderer design, which makes your art look great with minimal effort.</p>
+    </a>
+
+    <a href="/features#features_3d" data-barba-prevent>
+      <div class="feature">
+        <img
+          src="{{ 'assets/home/features/3d.jpg' | theme }}"
+          alt=""
+          width="1"
+          height="1"
+          style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)"
+          loading="lazy"
+        >
+        <div class="dark base-padding">
+          <h4>Gorgeous 3D</h4>
+          <p>Innovative 3D renderer design, which makes your art look great with minimal effort.</p>
+        </div>
       </div>
-    </div>
+    </a>
   </div>
 
   <div class="flex eqsize responsive features-row">
-    <div class="feature">
-      <img
-        src="{{ 'assets/home/features/2d.jpg' | theme }}"
-        alt=""
-        width="1"
-        height="1"
-        style="background: linear-gradient(90deg, #252928 4%, #2c312f 13%, #252928 21%, #141213 33%)"
-        loading="lazy"
-      >
-      <div class="dark base-padding">
-        <h4>Beautiful 2D</h4>
-        <p>Dedicated 2D engine that works in pixel coordinates, with plenty of built-in tools.</p>
+    <a href="/features#features_2d" data-barba-prevent>
+      <div class="feature">
+        <img
+          src="{{ 'assets/home/features/2d.jpg' | theme }}"
+          alt=""
+          width="1"
+          height="1"
+          style="background: linear-gradient(90deg, #252928 4%, #2c312f 13%, #252928 21%, #141213 33%)"
+          loading="lazy"
+        >
+        <div class="dark base-padding">
+          <h4>Beautiful 2D</h4>
+          <p>Dedicated 2D engine that works in pixel coordinates, with plenty of built-in tools.</p>
+        </div>
       </div>
-    </div>
-    <div class="feature">
-      <img
-        src="{{ 'assets/home/features/easy_code.png' | theme }}"
-        alt=""
-        width="1"
-        height="1"
-        style="background: linear-gradient(90deg, #252a35 46%, #252a35 53%, #202630 76%, #202630 89%)"
-        loading="lazy"
-      >
-      <div class="dark base-padding">
-        <h4>Easy to program</h4>
-        <p>Object-oriented API with language options such as GDScript, C#, C++ and visual scripting.</p>
+    </a>
+
+    <a href="/features#script" data-barba-prevent>
+      <div class="feature">
+        <img
+          src="{{ 'assets/home/features/easy_code.png' | theme }}"
+          alt=""
+          width="1"
+          height="1"
+          style="background: linear-gradient(90deg, #252a35 46%, #252a35 53%, #202630 76%, #202630 89%)"
+          loading="lazy"
+        >
+        <div class="dark base-padding">
+          <h4>Easy to program</h4>
+          <p>Object-oriented API with language options such as GDScript, C#, C++ and visual scripting.</p>
+        </div>
       </div>
-    </div>
+    </a>
   </div>
 
   <div class="flex eqsize responsive features-row">
-    <div class="feature">
-      <img
-        src="{{ 'assets/home/features/team_friendly.svg' | theme }}"
-        alt=""
-        width="1"
-        height="1"
-        style="background-color: #335767"
-        loading="lazy"
-      >
-      <div class="dark base-padding">
-        <h4>Team-friendly</h4>
-        <p>From architecture and tools to VCS integration, Godot is designed for everyone in your team.</p>
+    <a href="/features#collaborate" data-barba-prevent>
+      <div class="feature">
+        <img
+          src="{{ 'assets/home/features/team_friendly.svg' | theme }}"
+          alt=""
+          width="1"
+          height="1"
+          style="background-color: #335767"
+          loading="lazy"
+        >
+        <div class="dark base-padding">
+          <h4>Team-friendly</h4>
+          <p>From architecture and tools to VCS integration, Godot is designed for everyone in your team.</p>
+        </div>
       </div>
-    </div>
-    <div class="feature">
-      <img
-        src="{{ 'assets/home/features/oss.svg' | theme }}"
-        alt=""
-        width="1"
-        height="1"
-        style="background-color: #333667"
-        loading="lazy"
-      >
-      <div class="dark base-padding">
-        <h4>Open Source</h4>
-        <p>Truly open development: anyone who contributes to Godot benefits equally from others’ contributions.</p>
+    </a>
+
+    <a href="/features#collaborate" data-barba-prevent>
+      <div class="feature">
+        <img
+          src="{{ 'assets/home/features/oss.svg' | theme }}"
+          alt=""
+          width="1"
+          height="1"
+          style="background-color: #333667"
+          loading="lazy"
+        >
+        <div class="dark base-padding">
+          <h4>Open Source</h4>
+          <p>Truly open development: anyone who contributes to Godot benefits equally from others’ contributions.</p>
+        </div>
       </div>
-    </div>
+    </a>
   </div>
 </section>
 


### PR DESCRIPTION
`data-barba-prevent` was added to the links as Barba.js doesn't support scrolling to hash links.

This closes #290.