### PR TITLE
Fix home graphic overflowing the viewport on mobile in desktop mode

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -33,6 +33,7 @@ postPage = "{{ :slug }}"
 
   .full-graphic > img {
     width: auto;
+    max-width: 50vw;
     height: 100%;
   }
 
@@ -112,18 +113,19 @@ postPage = "{{ :slug }}"
     color: var(--dark-color-text-title);
   }
 
+  .img-auto-size {
+    width: 100%;
+    height: auto;
+  }
+
   @media (max-width: 900px) {
     .features-row > :first-child {
       margin-right: 0px;
     }
+
     .features-row > :last-child {
       margin-left: 0px;
     }
-  }
-
-  .img-auto-size {
-    width: 100%;
-    height: auto;
   }
 </style>
 


### PR DESCRIPTION
This closes #91.

Mobile mode still looks much better than desktop mode, but that's expected :slightly_smiling_face: 

## Preview

![Screenshot_20210307-180526](https://user-images.githubusercontent.com/180032/110248127-d6fe0080-7f6f-11eb-8ceb-39af83a8c9a1.jpg)