### PR TITLE
Improve pagination appearance

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -434,16 +434,36 @@ footer a {
 .pagination {
   margin-top: 64px;
   justify-content: center;
+  /* Remove spacing between list items when `display` is `block`. */
+  font-size: 0;
 }
 
 .pagination a {
   color: inherit;
   display: inline-block;
+  background-color: var(--button-background-color);
+  padding: 0.7rem 0.7rem;
+  min-width: 1.4rem;
+  font-size: initial;
   font-weight: 600;
   text-align: center;
   text-decoration: none;
-  margin-right: 12px;
-  min-width: 16px;
+  box-shadow: var(--base-shadow);
+}
+
+.pagination a.active {
+  background-color: hsl(220, 100%, 62.5%);
+  color: white;
+}
+
+.pagination a:not(:last-child) {
+  border-right: 1px solid var(--card-footer-color);
+}
+
+.pagination a.pagination-previous,
+.pagination a.pagination-next {
+  padding-left: 1.2rem;
+  padding-right: 1.2rem;
 }
 
 /* Make blog article images readable on a dark background. */
@@ -460,13 +480,7 @@ article .content img {
   .pagination {
     display: block;
     justify-content: initial;
-    line-height: 40px;
     text-align: center;
-  }
-
-  .pagination a {
-    min-width: 28px;
-    min-height: 28px;
   }
 }
 

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -99,7 +99,7 @@ description = "News layout"
 
   <div class="flex pagination">
     {% if posts.currentPage > 1 %}
-      <a href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage-1) }) }}">&larr; Prev</a>
+      <a class="pagination-previous" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage-1) }) }}">&larr; Previous</a>
     {% endif %}
 
     {% for page in 1..posts.lastPage %}
@@ -109,7 +109,7 @@ description = "News layout"
     {% endfor %}
 
     {% if posts.lastPage > posts.currentPage %}
-      <a href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage+1) }) }}">Next &rarr;</a>
+      <a class="pagination-next" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage+1) }) }}">Next &rarr;</a>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
- Use wider, taller square buttons for page numbers to make them easier to click/tap.
- Implement active highlighting on dark theme (it was previously missing).

## Preview

### Light theme

![2021-03-10_20 00 58](https://user-images.githubusercontent.com/180032/110682680-7ecb3680-81db-11eb-8652-07dacf5748de.png)

### Dark theme

*There's a 1-pixel offset for the Previous/Next buttons on Firefox in mobile view; I'm not sure how to fix it.*

![2021-03-10_20 01 14](https://user-images.githubusercontent.com/180032/110682683-7f63cd00-81db-11eb-8f31-c305a657f031.png)