### PR TITLE
Improve pagination display logic for news articles

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -438,7 +438,8 @@ footer a {
   font-size: 0;
 }
 
-.pagination a {
+.pagination a,
+.pagination-disabled {
   color: inherit;
   display: inline-block;
   background-color: var(--button-background-color);
@@ -449,6 +450,11 @@ footer a {
   text-align: center;
   text-decoration: none;
   box-shadow: var(--base-shadow);
+}
+
+.pagination-disabled {
+  opacity: 50%;
+  user-select: none;
 }
 
 .pagination a.active {

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -100,16 +100,45 @@ description = "News layout"
   <div class="flex pagination">
     {% if posts.currentPage > 1 %}
       <a class="pagination-previous" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage-1) }) }}">&larr; Previous</a>
+    {% else %}
+      <div class="pagination-previous pagination-disabled">&larr; Previous</div>
     {% endif %}
 
-    {% for page in 1..posts.lastPage %}
+    {# Shortcuts to get to the first two pages. #}
+    {% if posts.currentPage - 2 > 1 %}
+      <a href="{{ this.page.baseFileName|page({ (pageParam): 1 }) }}">1</a>
+    {% endif %}
+    {% if posts.currentPage - 2 > 2 %}
+      <a href="{{ this.page.baseFileName|page({ (pageParam): 2 }) }}">2</a>
+      {# Only display the ellipsis if at least one page is omitted. #}
+      {% if posts.currentPage - 2 > 3 %}
+        <div class="pagination-disabled">&hellip;</div>
+      {% endif %}
+    {% endif %}
+
+    {# Display at least 5 page buttons regardless of the current page. #}
+    {% for page in max(1, min(posts.currentPage - 2, posts.lastPage - 4))..max(5, min(posts.currentPage + 2, posts.lastPage)) %}
       <a class="{{ posts.currentPage == page ? 'active' : null }}"
          href="{{ this.page.baseFileName|page({ (pageParam): page }) }}">{{ page }}
       </a>
     {% endfor %}
 
+    {# Shortcuts to get to the last two pages. #}
+    {% if posts.currentPage + 2 < posts.lastPage - 1 %}
+      {# Only display the ellipsis if at least one page is omitted. #}
+      {% if posts.currentPage + 2 < posts.lastPage - 2 %}
+        <div class="pagination-disabled">&hellip;</div>
+      {% endif %}
+      <a href="{{ this.page.baseFileName|page({ (pageParam): posts.lastPage - 1 }) }}">{{  posts.lastPage - 1 }}</a>
+    {% endif %}
+    {% if posts.currentPage + 2 < posts.lastPage %}
+      <a href="{{ this.page.baseFileName|page({ (pageParam): posts.lastPage }) }}">{{ posts.lastPage }}</a>
+    {% endif %}
+
     {% if posts.lastPage > posts.currentPage %}
       <a class="pagination-next" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage+1) }) }}">Next &rarr;</a>
+    {% else %}
+      <div class="pagination-next pagination-disabled">Next &rarr;</div>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-website/pull/297.

Inspired by GitHub's pagination display logic:

- Display 5 page links close to the current page, but always display the first two and last two pages. Add ellipses if at least one page is omitted between two ranges.
- Disable Previous and Next links instead of hiding them entirely. This makes the pagination bar size more predictable for the user.

## Preview

### Light theme

![2021-03-10_23 53 28](https://user-images.githubusercontent.com/180032/110709223-2c4e4200-81fc-11eb-8d62-5261a1726f31.png)

### Dark theme

![2021-03-10_23 53 46](https://user-images.githubusercontent.com/180032/110709225-2ce6d880-81fc-11eb-9128-61e90ef4b69e.png)