### PR TITLE
Improve date display for news articles

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -7,6 +7,7 @@
   --base-color-text-hl: #454b59;
   --base-color-text-title: #546b99;
   --base-color-text-subtitle: #8a9cc2;
+  --base-color-text-subtitle-date: #9aacd2;
 
   --dark-color: #333f67;
   --dark-color-text: lightsteelblue;
@@ -57,6 +58,7 @@
     --base-color-text-hl: hsla(0, 0%, 100%, 1);
     --base-color-text-title: hsla(200, 00%, 100%, 0.85);
     --base-color-text-subtitle: hsla(200, 00%, 100%, 0.7);
+    --base-color-text-subtitle-date: hsla(200, 00%, 100%, 0.5);
 
     --dark-color: #263256;
     --dark-color-text: lightsteelblue;
@@ -662,7 +664,7 @@ a.btn.download > .opt {
 }
 
 .author .date {
-  color: var(--base-color-text-subtitle);
+  color: var(--base-color-text-subtitle-date);
   padding-left: 24px;
 }
 
@@ -909,6 +911,12 @@ pre > code {
 
   .tabs {
     overflow: scroll;
+  }
+
+  .author .date {
+    display: block;
+    margin-top: 0.25rem;
+    padding-left: 0;
   }
 }
 @media (max-width: 500px) {

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -120,7 +120,7 @@ categoryPage = "article"
         <h1>{{ post.title }}</h1>
         <h4 class="author">
           By: {{ post.user.full_name }}
-          <span class="date"> {{ post.published_at|date('M d, Y') }}</span>
+          <span class="date"> {{ post.published_at|date('j F Y') }}</span>
         </h4>
       </div>
 

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -39,6 +39,12 @@ description = "News layout"
   .news-item .date-big {
     line-height: .75;
   }
+
+  @media (max-width: 900px) {
+    .news-item .content .date {
+      text-align: left;
+    }
+  }
 </style>
 
 <div class="head">
@@ -91,7 +97,10 @@ description = "News layout"
             <h3 class="title">
               {{ post.title }}
             </h3>
-            <h4 class="author"> By: {{ post.user.full_name }} <span class="date"> {{ post.published_at|date('M d - Y') }} </span> </h4>
+            <h4 class="author">
+              By: {{ post.user.full_name }}
+              <span class="date">{{ post.published_at|date('j F Y') }}</span>
+            </h4>
             <p>{{ post.excerpt |raw }}</p>
           </div>
         </div>


### PR DESCRIPTION
- In the list of news, display the date on its own line on mobile.
- Fade out the date slightly compared to the author name.
- Use consistent date format across pages.

## Preview

### Desktop

![image](https://user-images.githubusercontent.com/180032/111014654-0f08a780-83a5-11eb-85b5-72a1c39c3098.png)

![image](https://user-images.githubusercontent.com/180032/111014690-3fe8dc80-83a5-11eb-9da8-d77391c79e29.png)

### Mobile

![image](https://user-images.githubusercontent.com/180032/111014663-1cbe2d00-83a5-11eb-82fc-dcb6601e346b.png)

![image](https://user-images.githubusercontent.com/180032/111014681-365f7480-83a5-11eb-8bc0-ca8051a56446.png)
