### PR TITLE
Add a dropdown menu for the More link in the navigation bar

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -293,6 +293,10 @@ header .container {
   overflow: initial;
 }
 
+.only-on-mobile {
+  display: none;
+}
+
 #logo-link {
   margin-right: 48px;
   /* Make the logo's clickable area as tall as for other navigation links. */
@@ -336,8 +340,8 @@ nav a:hover,
 
 nav ul {
   list-style: none;
-  margin: 0px;
-  padding-left: 0px;
+  margin: 0;
+  padding-left: 0;
 }
 
 nav > ul {
@@ -347,17 +351,17 @@ nav > ul {
 }
 
 nav > ul > :first-child {
-  padding-left: 0px;
+  padding-left: 0;
 }
 
 nav > ul > :last-child {
-  padding-right: 0px;
+  padding-right: 0;
 }
 
-nav > ul > li {
-  padding-left: 16px;
-  padding-right: 16px;
-  margin-bottom: 0px;
+nav > ul li {
+  padding-left: 1rem;
+  padding-right: 1rem;
+  margin-bottom: 0;
   margin-left: -1rem;
   margin-right: -1rem;
 }
@@ -805,7 +809,7 @@ pre > code {
   nav > ul {
     margin-bottom: 16px;
   }
-  nav ul > li {
+  nav ul li {
     padding: 0;
     padding-top: 16px;
     width: 100%;
@@ -835,6 +839,10 @@ pre > code {
 @media (max-width: 900px) {
   .hide-on-mobile {
     display: none;
+  }
+
+  .only-on-mobile {
+    display: initial;
   }
 
   a.patreonLink,
@@ -914,6 +922,34 @@ pre > code {
 @media (max-width: 500px) {
   #sfc_graphic {
     width: 100%;
+  }
+}
+
+@media (min-width: 901px) {
+  .nav-dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  .nav-dropdown-content {
+    display: none;
+    position: absolute;
+    min-width: 12rem;
+    background-color: var(--navbar-background-color);
+    box-shadow: 0 0.5rem 0.5rem 0 hsla(0, 0%, 0%, 0.2);
+    margin-top: 1.125rem;
+    z-index: 1;
+  }
+
+  .nav-dropdown-content li a {
+    display: inline-block;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    width: calc(100% - 2rem);
+  }
+
+  .nav-dropdown:hover .nav-dropdown-content {
+    display: block;
   }
 }
 

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -25,7 +25,25 @@ description = "header partial"
         <li {% if selected == 'features' %} class="active" {% endif %}><a href="/features">Features</a></li>
         <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news">News</a></li>
         <li {% if this.page.id == 'community' %} class="active" {% endif %}><a href="/community">Community</a></li>
-        <li {% if selected == 'more' %} class="active" {% endif %}><a href="/contact">More</a></li>
+        <div class="only-on-mobile" style="width: 100%">
+          <li {% if this.page.id == 'showcase' %} class="active" {% endif %}"><a href="/showcase">Showcase</a></li>
+          <li {% if selected == 'more' %} class="active" {% endif %}"><a href="/contact">More</a></li>
+        </div>
+        <div class="hide-on-mobile">
+          <li class="nav-dropdown {% if selected == 'more' %} active {% endif %}">
+            <a href="/contact">More&nbsp;&nbsp;↓</a>
+            <ul class="nav-dropdown-content">
+              <li><a href="/showcase">Showcase</a></li>
+              <li><a href="https://editor.godotengine.org/releases/latest/">Web Editor</a></li>
+              <hr>
+              <li><a href="/contact">Contact</a></li>
+              <li><a href="/privacy-policy">Privacy</a></li>
+              <li><a href="/code-of-conduct">Code of Conduct</a></li>
+              <li><a href="/license">License</a></li>
+              <li><a href="/donate">Donate</a></li>
+            </ul>
+          </li>
+        </div>
       </ul>
 
       <ul class="right">


### PR DESCRIPTION
This makes the showcase and Web editor more prominent.

The Web editor link is hidden on mobile as the Web editor isn't supported on any mobile browser as of writing.

This closes https://github.com/godotengine/godot-website/issues/212.

## Preview

### Light theme

![image](https://user-images.githubusercontent.com/180032/111099389-b45a8180-8545-11eb-91e2-f110a11bb7a2.png)

### Dark theme

![image](https://user-images.githubusercontent.com/180032/111099415-c1777080-8545-11eb-946b-bad682683acf.png)