### PR TITLE
Add a warning for logged in users when viewing an unpublished article

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -117,7 +117,12 @@ categoryPage = "article"
       </figure>
 
       <div class="info">
-        <h1>{{ post.title }}</h1>
+        <h1>
+          {% if not post.published or post.published_at > date() %}
+          <a href="/backend/rainlab/blog/posts/update/{{ post.id }}#secondarytab-rainlabbloglangposttab-manage" data-barba-prevent><abbr title="This article isn't marked as published on the CMS backend, or its publication date is set in the future. To make it display publicly, go to the post's Manage page, check Published and set a publication date in the past.">[UNPUBLISHED]</abbr></a>
+          {% endif %}
+          {{ post.title }}
+        </h1>
         <h4 class="author">
           By: {{ post.user.full_name }}
           <span class="date"> {{ post.published_at|date('M d, Y') }}</span>


### PR DESCRIPTION
Unpublished articles can be previewed by logged in users, but they can't be seen by non-logged in users.

The link brings you to the CMS backend's relevant post and tab so that you can quickly check the **Published** checkbox and set a publication date in the past.

## Preview

![image](https://user-images.githubusercontent.com/180032/111497303-47abd680-8741-11eb-8d83-9f7245580a5f.png)