### PR TITLE
Make the news search button blue on the light theme

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -48,6 +48,13 @@
   display: none;
 }
 
+.article-search-bar {
+  /* Make the Search button blue instead of green to better match the Godot theme. */
+  /* We need to do this using a CSS filter since it's an iframe. */
+  /* This breaks the text selection color inside the iframe, but it's a minor issue. */
+  filter: hue-rotate(110deg) saturate(80%);
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --transparent-cover: rgb(51, 63, 103, 0.4);


### PR DESCRIPTION
This makes it fit better with the rest of the Godot website appearance. Thanks to @dalexeev for the suggestion :slightly_smiling_face: 

## Preview

![image](https://user-images.githubusercontent.com/180032/111821288-c0966400-88e2-11eb-9834-bdfe463dcdef.png)
