### PR TITLE
Add logo previews on press kit page

### DIFF
--- a/themes/godotengine/pages/press.htm
+++ b/themes/godotengine/pages/press.htm
@@ -28,21 +28,26 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_light.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_light.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_large_color_light.png' | theme }}" alt="Colored (for light backgrounds)" height="128" style="background-color:#fcfcfc;">
     <li>
       <strong>Colored</strong> (for dark backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_large_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" height="128" style="background-color:#2e3236;">
     <li>
       <strong>Monochrome</strong> (for light backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" height="128" style="background-color:#fcfcfc;">
     <li>
       <strong>Monochrome</strong> (for dark backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_dark.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" height="128" style="background-color:#2e3236;">
+
   </ul>
 
   <hr>
@@ -57,21 +62,25 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_light.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_light.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_small_color_light.png' | theme }}" alt="Colored (for light backgrounds)" height="96" style="background-color:#fcfcfc;">
     <li>
       <strong>Colored</strong> (for dark backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_dark.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_dark.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_small_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" height="96" style="background-color:#2e3236;">
     <li>
       <strong>Monochrome</strong> (for light backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_light.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" height="96" style="background-color:#fcfcfc;">
     <li>
       <strong>Monochrome</strong> (for dark backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" height="96" style="background-color:#2e3236;">
   </ul>
 
   <hr>
@@ -86,21 +95,25 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_light.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_light.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_vertical_color_light.png' | theme }}" alt="Colored (for light backgrounds)" height="384" style="background-color:#fcfcfc;">
     <li>
       <strong>Colored</strong> (for dark backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_dark.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" height="384" style="background-color:#2e3236;">
     <li>
       <strong>Monochrome</strong> (for light backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_light.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" height="384" style="background-color:#fcfcfc;">
     <li>
       <strong>Monochrome</strong> (for dark backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_dark.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" height="384" style="background-color:#2e3236;">
   </ul>
 
   <h3 class="title">Godot Engine icons</h3>
@@ -110,21 +123,25 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/icon_color.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/icon_color.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/icon_color.png' | theme }}" alt="Colored" height="96">
     <li>
       <strong>Colored with outline</strong> (only use if the background color clashes with the icon):
       <a data-barba-prevent href="{{ 'assets/press/icon_color_outline.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/icon_color_outline.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/icon_color.png' | theme }}" alt="Colored with outline" height="96" style="background-color:#478CBF;">
     <li>
       <strong>Monochrome</strong> (for light backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_light.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_light.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/icon_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" height="96" style="background-color:#fcfcfc;">
     <li>
       <strong>Monochrome</strong> (for dark backgrounds):
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_dark.svg' | theme }}">SVG</a>,
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_dark.png' | theme }}">PNG</a>
     </li>
+    <img src="{{ 'assets/press/icon_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" height="96" style="background-color:#2e3236;">
   </ul>
 
   <h3 class="title">Godot Engine naming and pronounciation</h3>


### PR DESCRIPTION
It would be great if we could visualize a preview of each logo just scrolling by the page