### PR TITLE
Add a banner for GodotCon July 2021

### DIFF
--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -8,6 +8,22 @@ description = "header partial"
 <body data-barba="wrapper">
 {% styles %}
 <header>
+  <a href="/article/online-godotcon-july-2021-call-participation" style="
+    position: absolute;
+    top: 3.5rem;
+    right: -4rem;
+    transform: rotateZ(45deg);
+    z-index: 9999;
+    padding: 0.5rem 3.5rem;
+    background-color: #49a1be;
+    box-shadow: 0 2px 2px hsla(0, 0%, 0%, 0.3);
+    color: white;
+    text-decoration: none;
+    font-weight: 700;
+  ">
+    GodotCon July 2021!
+  </a>
+</a>
   <div class="container flex align-center">
     <input type="checkbox" id="nav_toggle_cb">
     <div id="nav_head">


### PR DESCRIPTION
Based on the design from https://github.com/godotengine/godot-website/pull/263, but with a different color and non-fixed positioning.

## Preview

![image](https://user-images.githubusercontent.com/180032/113451703-db002f80-9402-11eb-9309-760b0a2e16a2.png)