### PR TITLE
Add instructions for installing Godot using MacPorts

### DIFF
--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -36,7 +36,7 @@ is_hidden = 0
     You can also get Godot with <a href="https://brew.sh/">Homebrew</a> or <a href="https://www.macports.org">MacPorts</a>.
     Note that the version available on Homebrew isn't code-signed either.
     Software released through MacPorts does not need to be code-signed to run;
-    this means it is not affected by Gatekeeper restrictions.
+    this means Godot on MacPorts is not affected by Gatekeeper restrictions.
   </p>
   <ul>
     <li><pre><code>brew install --cask godot</code></pre></li>

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -33,10 +33,11 @@ is_hidden = 0
     <a href="https://store.steampowered.com/app/404790">Godot from Steam</a> to work around this.
   </p>
   <p>
-    You can also get Godot with <a href="https://brew.sh/">Homebrew</a>.
+    You can also get Godot with <a href="https://brew.sh/">Homebrew</a> or <a href="https://www.macports.org">MacPorts</a>.
     Note that the version available on Homebrew isn't code-signed either.
   </p>
   <ul>
     <li><pre><code>brew install --cask godot</code></pre></li>
+    <li><pre><code>sudo port install godot</code></pre></li>
   </ul>
 {% endput %}

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -35,6 +35,8 @@ is_hidden = 0
   <p>
     You can also get Godot with <a href="https://brew.sh/">Homebrew</a> or <a href="https://www.macports.org">MacPorts</a>.
     Note that the version available on Homebrew isn't code-signed either.
+    Software released through MacPorts does not need to be code-signed to run;
+    this means it is not affected by Gatekeeper restrictions.
   </p>
   <ul>
     <li><pre><code>brew install --cask godot</code></pre></li>


### PR DESCRIPTION
Greetings Godot devs,

I am the creator and maintainer of the Godot package for the [MacPorts](https://www.macports.org) package management system. Godot Engine has been available as an official MacPorts package since May of 2020. Since then, I have sent a couple of e-mails to [contact@godotengine.org](mailto:contact@godotengine.org) (which were replied to by Remi Verschelde), to have some instructions added for MacPorts to the macOS [Download page](https://godotengine.org/download/osx), but nothing appears to have gotten added. So I thought that I would try submitting a PR myself.