### PR TITLE
Hide the GodotCon banner on mobile

### DIFF
--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -8,7 +8,7 @@ description = "header partial"
 <body data-barba="wrapper">
 {% styles %}
 <header>
-  <a href="/article/online-godotcon-july-2021-call-participation" style="
+  <a href="/article/online-godotcon-july-2021-call-participation" class="hide-on-mobile" style="
     position: absolute;
     top: 3.5rem;
     right: -4rem;


### PR DESCRIPTION
I couldn't find a way to fix this since `position: absolute` makes `overflow: hidden` ineffective.

I would have preferred to keep the banner on mobile, but this will do for now.

This closes #319.