### PR TITLE
Press kit: Change previews background color to match website theme

### DIFF
--- a/themes/godotengine/pages/press.htm
+++ b/themes/godotengine/pages/press.htm
@@ -29,7 +29,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_color_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="317" height="128" style="background-color:#eff1f5" loading="lazy">
     </a>
 
     <li>
@@ -38,7 +38,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="317" height="128" style="background-color:#25282b" loading="lazy">
     </a>
 
     <li>
@@ -47,7 +47,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="317" height="128" style="background-color:#eff1f5" loading="lazy">
     </a>
 
     <li>
@@ -56,7 +56,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="317" height="128" style="background-color:#25282b" loading="lazy">
     </a>
   </ul>
 
@@ -73,7 +73,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_color_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="272" height="96" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="272" height="96" style="background-color:#eff1f5" loading="lazy">
     </a>
 
     <li>
@@ -82,7 +82,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_color_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="272" height="96" style="background-color:#25282b" loading="lazy">
     </a>
 
     <li>
@@ -91,7 +91,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="272" height="96" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="272" height="96" style="background-color:#eff1f5" loading="lazy">
     </a>
 
     <li>
@@ -100,7 +100,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="272" height="96" style="background-color:#25282b" loading="lazy">
     </a>
   </ul>
 
@@ -117,7 +117,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="336" height="384" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="336" height="384" style="background-color:#eff1f5" loading="lazy">
     </a>
 
     <li>
@@ -126,7 +126,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="336" height="384" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="336" height="384" style="background-color:#25282b" loading="lazy">
     </a>
 
     <li>
@@ -135,7 +135,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="336" height="384" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="336" height="384" style="background-color:#eff1f5" loading="lazy">
     </a>
 
     <li>
@@ -144,7 +144,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="336" height="384" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="336" height="384" style="background-color:#25282b" loading="lazy">
     </a>
   </ul>
 
@@ -174,7 +174,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/icon_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="96" height="96" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/icon_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="96" height="96" style="background-color:#eff1f5" loading="lazy">
     </a>
 
     <li>
@@ -183,7 +183,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/icon_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="96" height="96" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/icon_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="96" height="96" style="background-color:#25282b" loading="lazy">
     </a>
   </ul>
 


### PR DESCRIPTION
Except for outlined icon since we need to demonstrate the clash