### PR TITLE
Add "Godot Engine logo" to the "alt" attribute when necessary to "press.html"

### DIFF
--- a/themes/godotengine/pages/press.htm
+++ b/themes/godotengine/pages/press.htm
@@ -38,7 +38,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_color_dark.png' | theme }}" alt="Godot Engine logo (colored (for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_color_dark.png' | theme }}" alt="Godot Engine logo (colored for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
     </a>
 
     <li>

--- a/themes/godotengine/pages/press.htm
+++ b/themes/godotengine/pages/press.htm
@@ -47,7 +47,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}" alt="Godot Engine (monochrome for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}" alt="Godot Engine logo (monochrome for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -100,7 +100,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}" alt="Godot Engine logo(monochrome for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}" alt="Godot Engine logo (monochrome for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
     </a>
   </ul>
 

--- a/themes/godotengine/pages/press.htm
+++ b/themes/godotengine/pages/press.htm
@@ -29,7 +29,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_color_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_color_light.png' | theme }}" alt="Godot Engine logo (colored for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -38,7 +38,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_color_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_color_dark.png' | theme }}" alt="Godot Engine logo (colored (for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
     </a>
 
     <li>
@@ -47,7 +47,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_monochrome_light.png' | theme }}" alt="Godot Engine (monochrome for light backgrounds)" width="317" height="128" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -56,7 +56,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_large_monochrome_dark.png' | theme }}" alt="Godot Engine logo (monochrome for dark backgrounds)" width="317" height="128" style="background-color:#2e3236" loading="lazy">
     </a>
   </ul>
 
@@ -73,7 +73,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_color_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="272" height="96" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_color_light.png' | theme }}" alt="Godot Engine logo (colored for light backgrounds)" width="272" height="96" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -82,7 +82,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_color_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_color_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_color_dark.png' | theme }}" alt="Godot Engine logo (colored for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
     </a>
 
     <li>
@@ -91,7 +91,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="272" height="96" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_monochrome_light.png' | theme }}" alt="Godot Engine logo (monochrome for light backgrounds)" width="272" height="96" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -100,7 +100,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_small_monochrome_dark.png' | theme }}" alt="Godot Engine logo(monochrome for dark backgrounds)" width="272" height="96" style="background-color:#2e3236" loading="lazy">
     </a>
   </ul>
 
@@ -117,7 +117,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_color_light.png' | theme }}" alt="Colored (for light backgrounds)" width="336" height="384" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_color_light.png' | theme }}" alt="Godot Engine logo (colored for light backgrounds)" width="336" height="384" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -126,7 +126,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}" alt="Colored (for dark backgrounds)" width="336" height="384" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_color_dark.png' | theme }}" alt="Godot Engine logo (colored for dark backgrounds)" width="336" height="384" style="background-color:#2e3236" loading="lazy">
     </a>
 
     <li>
@@ -135,7 +135,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="336" height="384" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_monochrome_light.png' | theme }}" alt="Godot Engine logo (monochrome for light backgrounds)" width="336" height="384" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -144,7 +144,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="336" height="384" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/logo_vertical_monochrome_dark.png' | theme }}" alt="Godot Engine logo (monochrome for dark backgrounds)" width="336" height="384" style="background-color:#2e3236" loading="lazy">
     </a>
   </ul>
 
@@ -165,7 +165,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/icon_color_outline.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/icon_color_outline.png' | theme }}">
-      <img src="{{ 'assets/press/icon_color_outline.png' | theme }}" alt="Colored with outline" height="96" width="96" style="background-color:#478cbf" loading="lazy">
+      <img src="{{ 'assets/press/icon_color_outline.png' | theme }}" alt="Godot Engine logo (colored with outline)" height="96" width="96" style="background-color:#478cbf" loading="lazy">
     </a>
 
     <li>
@@ -174,7 +174,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_light.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_light.png' | theme }}">
-      <img src="{{ 'assets/press/icon_monochrome_light.png' | theme }}" alt="Monochrome (for light backgrounds)" width="96" height="96" style="background-color:#fcfcfc" loading="lazy">
+      <img src="{{ 'assets/press/icon_monochrome_light.png' | theme }}" alt="Godot Engine logo (monochrome for light backgrounds)" width="96" height="96" style="background-color:#fcfcfc" loading="lazy">
     </a>
 
     <li>
@@ -183,7 +183,7 @@ is_hidden = 0
       <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_dark.png' | theme }}">PNG</a>
     </li>
     <a data-barba-prevent href="{{ 'assets/press/icon_monochrome_dark.png' | theme }}">
-      <img src="{{ 'assets/press/icon_monochrome_dark.png' | theme }}" alt="Monochrome (for dark backgrounds)" width="96" height="96" style="background-color:#2e3236" loading="lazy">
+      <img src="{{ 'assets/press/icon_monochrome_dark.png' | theme }}" alt="Godot Engine logo (monochrome for dark backgrounds)" width="96" height="96" style="background-color:#2e3236" loading="lazy">
     </a>
   </ul>
 


### PR DESCRIPTION
Add "Godot Engine logo" to the `alt` attribute when necessary to `press.html`. To make it less confusing for people.