### PR TITLE
Update Home and Download pages for Godot 3.3's release

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -2,7 +2,7 @@ description = "Download layout"
 ==
 <?php
   function onInit() {
-    $this["stable_version"] = "3.2.3";
+    $this["stable_version"] = "3.3";
   }
 ?>
 ==
@@ -119,7 +119,7 @@ description = "Download layout"
     <div class="version-overview">
       <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" width="200" height="200" alt="">
       <h2>Godot <em>{{stable_version}}</em></h2>
-      <i class="date">released September 17, 2020</i>
+      <i class="date">released April 21, 2021</i>
       <p></p>
     </div>
 
@@ -189,7 +189,7 @@ description = "Download layout"
           <h3>Export templates (Mono / C#)</h3>
           <p>
             Used to export your C# games to the supported platforms.
-            Currently, the C# version can export to desktop platforms (Linux, macOS and Windows), Android, iOS, and HTML/WebAssembly.
+            Currently, the C# version can export to desktop platforms (Linux, macOS and Windows), Android, iOS, and HTML5/WebAssembly.
           </p>
         </div>
       </a>
@@ -232,17 +232,10 @@ description = "Download layout"
         </div>
       </a>
 
-      <a href="https://downloads.tuxfamily.org/godotengine/3.1.2/" class="base-padding card">
+      <a href="https://downloads.tuxfamily.org/godotengine/" class="base-padding card">
         <div>
-          <h3>Godot 3.1.2 downloads</h3>
-          <p>Looking for the previous stable branch? It's here!</p>
-        </div>
-      </a>
-
-      <a href="https://downloads.tuxfamily.org/godotengine/2.1.6/" class="base-padding card">
-        <div>
-          <h3>Godot 2.1.6 downloads</h3>
-          <p>Looking for the older 2.1 branch? It's here!</p>
+          <h3>Old Godot downloads</h3>
+          <p>Looking for the previous stable releases? They're here!</p>
         </div>
       </a>
 

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -157,7 +157,7 @@ postPage = "{{ :slug }}"
       </p>
 
       <a href="/download" class="btn download">
-        <div class="main">Download</div><div class="opt">3.2</div>
+        <div class="main">Download</div><div class="opt">3.3</div>
       </a>
       <a href="/features" class="btn flat btn-white-text">Learn more</a>
     </div>

--- a/themes/godotengine/pages/download/linux.htm
+++ b/themes/godotengine/pages/download/linux.htm
@@ -12,13 +12,13 @@ is_hidden = 0
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_x11.64.zip">
-      64-bit
+      64-bit (x86_64)
     </a>
   </div>
 
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_x11.32.zip">
-      32-bit
+      32-bit (x86)
     </a>
   </div>
 {% endput %}
@@ -27,12 +27,12 @@ is_hidden = 0
 {% put mono_downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_x11_64.zip">
-      64-bit
+      64-bit (x86_64)
     </a>
   </div>
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_x11_32.zip">
-      32-bit
+      32-bit (x86)
     </a>
   </div>
 {% endput %}

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -11,8 +11,8 @@ is_hidden = 0
 {##}
 {% put downloads %}
   <div class="btn split download">
-    <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_osx.64.zip">
-      64-bit
+    <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_osx.universal.zip">
+      Universal 64-bit (x86_64 + Apple Silicon)
     </a>
   </div>
 {% endput %}
@@ -20,23 +20,27 @@ is_hidden = 0
 {% put mono_downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_osx.64.zip">
-      64-bit
+      64-bit (x86_64 only)
     </a>
   </div>
 {% endput %}
 
 {% put instructions %}
   <p>
-    Godot is currently not code-signed for macOS. See the last section of
-    <a href="https://support.apple.com/en-us/HT202491">this page</a>
-    for instructions on allowing Godot to run anyway. Alternatively, you can install
-    <a href="https://store.steampowered.com/app/404790">Godot from Steam</a> to work around this.
+    Since Godot 3.3, Godot is code-signed and notarized for macOS. This means
+    it should run out of the box even if Gatekeeper is enabled on the system
+    (which is the default).
   </p>
   <p>
-    You can also get Godot with <a href="https://brew.sh/">Homebrew</a> or <a href="https://www.macports.org">MacPorts</a>.
-    Note that the version available on Homebrew isn't code-signed either.
-    Software released through MacPorts does not need to be code-signed to run;
-    this means Godot on MacPorts is not affected by Gatekeeper restrictions.
+    For older Godot versions, see the last section of
+    <a href="https://support.apple.com/en-us/HT202491">this page</a>
+    for instructions on allowing Godot to run anyway. Alternatively, you can install
+    <a href="https://store.steampowered.com/app/404790">Godot from Steam</a>
+    and switch to an older branch in the Steam application settings to work around this.
+  </p>
+  <p>
+    You can also get Godot with <a href="https://brew.sh/">Homebrew</a>
+    or <a href="https://www.macports.org">MacPorts</a>:
   </p>
   <ul>
     <li><pre><code>brew install --cask godot</code></pre></li>

--- a/themes/godotengine/pages/download/server.htm
+++ b/themes/godotengine/pages/download/server.htm
@@ -12,12 +12,12 @@ is_hidden = 0
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_linux_headless.64.zip">
-      Headless (64-bit)
+      Headless (64-bit, x86_64)
     </a>
   </div>
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_linux_server.64.zip">
-      Server (64-bit)
+      Server (64-bit, x86_64)
     </a>
   </div>
 {% endput %}
@@ -25,12 +25,12 @@ is_hidden = 0
 {% put mono_downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_linux_headless_64.zip">
-      Headless (64-bit)
+      Headless (64-bit, x86_64)
     </a>
   </div>
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_linux_server_64.zip">
-      Server (64-bit)
+      Server (64-bit, x86_64)
     </a>
   </div>
 {% endput %}

--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -12,12 +12,12 @@ is_hidden = 0
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_win64.exe.zip">
-      64-bit
+      64-bit (x86_64)
     </a>
   </div>
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_win32.exe.zip">
-      32-bit
+      32-bit (x86)
     </a>
   </div>
 {% endput %}
@@ -25,12 +25,12 @@ is_hidden = 0
 {% put mono_downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_win64.zip">
-      64-bit
+      64-bit (x86_64)
     </a>
   </div>
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_win32.zip">
-      32-bit
+      32-bit (x86)
     </a>
   </div>
   <p><strong>Note:</strong> The 32-bit Mono binaries do not run on 64-bit Windows systems at the time being. Make sure to export 64-bit Mono binaries for your 64-bit target platforms.</p>


### PR DESCRIPTION
- Update the status on macOS code signing of official releases.
- Display the architecture for each download (even if it's x86 only), since non-x86 devices are becoming increasingly common.
- Consolidate the old Godot releases cards into a single card.