### PR TITLE
Add `security.txt` file for standardized security issue reporting

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:contact@godotengine.org
+Expires: Fri, 31 Dec 2021 23:59 +0000
+Preferred-Languages: en
+Canonical: https://godotengine.org/.well-known/security.txt
+Policy: https://github.com/godotengine/.github/blob/master/SECURITY.md


### PR DESCRIPTION
See https://securitytxt.org/ and https://github.com/godotengine/godot/pull/45701#issuecomment-799897418 (which I had missed).

As per the specification, the file should be updated once every year to make sure it doesn't go stale.

I've checked on the production instance and `.well-known/security.txt` can be accessed fine. (I removed the file until this PR is merged.)

**Edit:** The presence and validity of the `security.txt` file can be tested here: https://gotsecuritytxt.com/query/godotengine.org