### PR TITLE
Move latest version identifier and release date to an included file

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -1,16 +1,12 @@
 description = "Download layout"
 ==
-<?php
-  function onInit() {
-    $this["stable_version"] = "3.3.1";
-  }
-?>
-==
 {##}
 <!DOCTYPE html>
 <html lang="en">
 {% partial "head" %}
 {% partial "header" selected="download" %}
+{% set stable_version = include('version', {'key': 'identifier'}) %}
+{% set stable_version_date = include('version', {'key': 'date'}) %}
 
 <style>
   .btn.download {
@@ -119,7 +115,7 @@ description = "Download layout"
     <div class="version-overview">
       <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" width="200" height="200" alt="">
       <h2>Godot <em>{{stable_version}}</em></h2>
-      <i class="date">released May 18, 2021</i>
+      <i class="date">released {{ stable_version_date | date('j F Y') }}</i>
       <p></p>
     </div>
 

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -157,7 +157,7 @@ postPage = "{{ :slug }}"
       </p>
 
       <a href="/download" class="btn download">
-        <div class="main">Download</div><div class="opt">3.3.1</div>
+        <div class="main">Download</div><div class="opt">{% include('version') with {'key': 'identifier'} %}</div>
       </a>
       <a href="/features" class="btn flat btn-white-text">Learn more</a>
     </div>

--- a/themes/godotengine/pages/download/linux.htm
+++ b/themes/godotengine/pages/download/linux.htm
@@ -9,6 +9,7 @@ is_hidden = 0
 ?>
 ==
 {##}
+{% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_x11.64.zip">

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -9,6 +9,7 @@ is_hidden = 0
 ?>
 ==
 {##}
+{% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_osx.universal.zip">

--- a/themes/godotengine/pages/download/server.htm
+++ b/themes/godotengine/pages/download/server.htm
@@ -9,6 +9,7 @@ is_hidden = 0
 ?>
 ==
 {##}
+{% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_linux_headless.64.zip">

--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -9,6 +9,7 @@ is_hidden = 0
 ?>
 ==
 {##}
+{% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
   <div class="btn split download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_win64.exe.zip">

--- a/themes/godotengine/partials/version.htm
+++ b/themes/godotengine/partials/version.htm
@@ -1,0 +1,7 @@
+{%- if key == 'identifier' -%}
+3.3.1
+{%- elseif key == 'date' -%}
+2021-05-18
+{%- else -%}
+ERROR: Unknown version.htm include key
+{%- endif -%}


### PR DESCRIPTION
This centralizes the latest version information in a single file, `themes/godotengine/partials/version.htm`.

The date formatting was also changed to match the one used for blog posts.