### PR TITLE
Add a page on Godot's governance model (revised)

### DIFF
--- a/themes/godotengine/layouts/more.htm
+++ b/themes/godotengine/layouts/more.htm
@@ -21,6 +21,9 @@ description = "More layout"
       <a href="/privacy-policy" class="title-font {% if this.page.id == 'privacy-policy' %} active {% endif %}">
         Privacy
       </a>
+      <a href="/governance" class="title-font {% if this.page.id == 'governance' %} active {% endif %}">
+        Governance
+      </a>
       <a href="/code-of-conduct" class="title-font {% if this.page.id == 'code-of-conduct' %} active {% endif %}">
         Code of Conduct
       </a>

--- a/themes/godotengine/pages/contact.htm
+++ b/themes/godotengine/pages/contact.htm
@@ -36,27 +36,10 @@ is_hidden = 0
   <hr>
 
   <h3 class="title" id="plc">Project Leadership Committee (PLC)</h3>
-  <p>
-    The Godot project is legally represented by
-    <a href="https://sfconservancy.org">Software Freedom Conservancy</a> (SFC),
-    a USA-based charity that helps promote, improve, develop, and defend
-    <abbr title="Free, Libre, and Open Source Software">FLOSS</abbr> projects.
+  <p style="font-style: italic">
+    Information about the Project Leadership Committee was moved to the
+    <a href="/governance">Governance</a> page.
   </p>
-  <p>
-    The Project Leadership Committee (PLC) is a group of core contributors who
-    represent the Godot project within SFC. It can be reached via the
-    <em>plc@godotengine.org</em> email address. It is currently composed of:
-  </p>
-  <ul>
-    <li>Ariel Manzur - <em>ariel@godotengine.org</em></li>
-    <li>Bastiaan Olij - <em>bastiaan@godotengine.org</em></li>
-    <li>George Marques - <em>george@godotengine.org</em></li>
-    <li>Hein-Pieter van Braam-Stewart - <em>hp@godotengine.org</em></li>
-    <li>Ilaria Cislaghi - <em>ilaria@godotengine.org</em></li>
-    <li>Juan Linietsky - <em>juan@godotengine.org</em></li>
-    <li>Julian Murgia - <em>julian@godotengine.org</em></li>
-    <li>Rémi Verschelde - <em>remi@godotengine.org</em></li>
-  </ul>
 
   <h3 class="title" id="devs">Godot&nbsp;Engine team</h3>
   <p>

--- a/themes/godotengine/pages/governance.htm
+++ b/themes/godotengine/pages/governance.htm
@@ -1,0 +1,204 @@
+title = "Governance"
+url = "/governance"
+layout = "more"
+description = "Governance model"
+is_hidden = 0
+==
+{##}
+{% put title %} Governance model {% endput %}
+
+<div class="container">
+
+  <h3>Legal status</h3>
+  <p>
+    On its own, Godot has no legal status. Godot exists as a member project of
+    the <a href="https://sfconservancy.org">Software Freedom Conservancy</a>
+    (SFC). The SFC provides a home and infrastructure for Free, Libre, and Open
+    Source Software (FLOSS) projects by aggregating the work necessary for
+    running a non-profit organization including accounting and legal compliance.
+    For more information about what the SFC provides, please refer to <a
+    href="https://sfconservancy.org/projects/services/">their website</a>.
+  </p>
+  <p>
+    <strong>As no company is behind Godot, it can't be sold or purchased by another company.</strong>
+  </p>
+  <p>
+    While the SFC provides the corporate infrastructure to support the Godot
+    project, it doesn't make decisions for the project. Instead it provides a
+    set of rules for how the member projects operate and provides financial
+    oversight to make sure that money is spent in a responsible way that
+    advances the project and fits with Conservancy's 501(c)(3) mission to
+    promote, advance, and defend software freedom. Each member project has a
+    Project Leadership Committee that instructs the SFC on how to spend that
+    project's funding.
+  </p>
+
+  <h3>The Project Leadership Committee</h3>
+  <p>
+    The Project Leadership Committee (PLC) is responsible for making all funding
+    and institutional decisions for the Godot project. The PLC is made of the
+    project founders (Ariel Manzur and Juan Linietsky) as well as trusted
+    contributors and community members. As spaces open up on the PLC, current
+    members may reach out to contributors and community members with a proven
+    track record and deep understanding of the project and ask them to join.
+  </p>
+  <p>
+    The PLC must be made of a balance of contributors with technical expertise,
+    and community members who bring the perspective of the community at large.
+    The PLC is subject to rules set by the Software Freedom Conservancy. For
+    more information about the PLC's policies please refer to the
+    <a href="https://sfconservancy.org/projects/policies/">Software Freedom
+    Conservancy's project policies</a>.
+  </p>
+
+  <p>
+    The PLC currently consists of the following members:
+  </p>
+  <ul>
+    <li>Ariel Manzur — <i>ariel@godotengine.org</i></li>
+    <li>Bastiaan Olij — <i>bastiaan@godotengine.org</i></li>
+    <li>George Marques — <i>george@godotengine.org</i></li>
+    <li>Hein-Pieter van Braam-Stewart — <i>hp@godotengine.org</i></li>
+    <li>Ilaria Cislaghi — <i>ilaria@godotengine.org</i></li>
+    <li>Juan Linietsky — <i>juan@godotengine.org</i></li>
+    <li>Julian Murgia — <i>julian@godotengine.org</i></li>
+    <li>Rémi Verschelde — <i>remi@godotengine.org</i></li>
+  </ul>
+
+  <h3>Advisors</h3>
+  <p>
+    The PLC has enlisted the help of its most trusted and veteran contributors
+    whom they call <em>the advisors</em>. The advisors are consulted on usage
+    of funds as well as institutional matters. It is important to note,
+    however, that while the advice of the advisory panel is weighed heavily,
+    the final authority on these matters remains with the PLC.  In practice,
+    the PLC rarely makes an important decision without at least discussing it
+    with the advisors first.
+  </p>
+  <p>
+    Like the PLC, contributors do not apply to become advisors. Instead the
+    process of joining the advisors group is organic; trusted contributors may
+    be asked to join after showing dedication, expertise, and leadership
+    within the Godot community. As a result, the advisors are a diverse group
+    of individuals with expertise in all areas of Godot development.
+  </p>
+
+  <h3>Funding decisions</h3>
+  <p>
+    All donations and sponsorships go directly to the SFC. The Godot PLC makes
+    all decisions on how the funds are used, following rules established by
+    Software Freedom Conservancy. These rules dictate that funding can only be
+    used for the benefit of the project. Usage of funds generally includes:
+  </p>
+  <ul>
+    <li>Hiring contributors</li>
+    <li>Organizing events</li>
+    <li>Reimbursements for travelling to events</li>
+    <li>Purchasing hardware required for contributors to work on Godot</li>
+  </ul>
+  <p>
+    While the exact costs spent remain private, we do our best to publish how
+    much we get and how much we spend. All funding decisions are ultimately
+    approved by the Software Freedom Conservancy which has strict (but
+    reasonable) <a href="https://sfconservancy.org/projects/policies/conservancy-travel-policy.html"
+    >limits on spending, hourly rates, and reimbursements</a>.
+    As such, no one hired receives more than industry standard rates.
+  </p>
+
+  <h3>Technical decisions</h3>
+  <p>
+    Technical decisions are made by Area Owners and the project leaders.
+    Godot has the following established roles:
+  </p>
+
+  <h4>Leadership</h4>
+  <ul>
+    <li>Juan Linietsky — Technical and Project Lead</li>
+    <li>Rémi Verschelde — Project Manager</li>
+  </ul>
+  <p>
+    The project leaders have final say on all code merges. In theory, this means
+    the leaders will have the final say when maintainers cannot agree. In
+    practice, this authority rarely needs to be invoked because decisions are
+    made by maintainers in consultation with the community.
+  </p>
+
+  <h4>Teams and area owners</h4>
+  <p>
+    Teams are groups of contributors interested in a specific area of the
+    engine. Teams provide a way for contributors to have focused discussions
+    with other people with similar expertise and interests. The opinion and
+    expertise of team members is valued in discussions, but ultimately the
+    authority over an area of the engine belongs solely to the area owner and
+    the project leadership. Area owners are entrusted with final say for code
+    merges in their areas. Area owners are trusted contributors who are chosen
+    by the project leadership and have shown knowledge of the specific area of
+    the engine and the engine's philosophy as a whole.
+  </p>
+  <p style="font-style: italic">
+    Teams have not been formally announced yet, but a list will be published in the future.
+  </p>
+  <p>
+    In practice, area owners aim for consensus among contributors, especially
+    among the relevant team. The "rule of thumb" is to not merge code if
+    significant disputes exist over a change. However the final decision still
+    remains with the area owner. The Godot project strives for rich, public,
+    technical discussions where anyone can contribute and agree on the way to
+    move forward. Additionally, the leadership and area owners consult with
+    other contributors and the community as much as possible every time new
+    features and improvements are planned.
+  </p>
+
+  <h4>Community</h4>
+  <p>
+    We strive to make our relationship with the community as symbiotic as
+    possible within the limits of feasibility. The Godot community is made up of
+    users, contributors, maintainers, and project leadership. Godot exists
+    because its community trusts the work we do, so we try to entrust the
+    community with deciding the general direction of the project as much and as
+    openly as possible. This is how we see the process as community-driven:
+  </p>
+  <ul>
+    <li>
+      <strong>Open development:</strong> All development (code that makes it
+      into the engine, docs, website, etc) is made via
+      <a href="https://github.com/godotengine/godot/pulls">Pull Requests</a>.
+      They are open for anyone to see, review and comment on. From the
+      leadership to the new contributors, everyone is required to create them in
+      order for their work to be included. Pull Requests are approved and merged
+      by the respective area maintainers while, again, always striving to
+      promote agreement before moving forward. All improvements to the engine
+      are made through the Pull Requests of community members.
+    </li>
+    <li>
+      <strong>Open discussion:</strong> Before doing any significant amount of
+      work, we encourage maintainers, contributors, and community to open and
+      discuss features and proposals in the <a href="https://github.com/godotengine/godot-proposals"
+      >Godot proposals repository</a>.
+      This allows all contributors to have a much better understanding of how users expect
+      the new feature to be used. Because the primary aim of Godot is to produce
+      a useful tool, we ask those who open proposals to discuss real-world use
+      cases based on problems they are having with their current projects. This
+      allows maintainers and contributors to have a much more "down to earth"
+      understanding of user's requirements. This philosophy is best explained in
+      the <a href="https://docs.godotengine.org/en/latest/community/contributing/best_practices_for_engine_contributors.html"
+      >engine contributor guidelines</a>.
+    </li>
+    <li>
+      <strong>Community-minded:</strong> The Godot project is developed by and
+      for the community. No corporate entity exists behind Godot that
+      prioritizes one feature over another. Priorities are set by project
+      leadership and area maintainers based on the feedback of the community in
+      bug reports, proposals, and discussions in the various community channels.
+      Ultimately, it is the community that determines the direction of the
+      project.
+    </li>
+  </ul>
+  <p>
+    Every improvement to the engine, whether it is a feature or bug fix, is
+    driven forward by Godot's community of contributors, users, maintainers, and
+    leadership. Godot wouldn't exist in its current form without the countless
+    contributions it receives from community members every day.
+  </p>
+
+</div>

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -38,9 +38,11 @@ description = "header partial"
               <hr>
               <li><a href="/contact">Contact</a></li>
               <li><a href="/privacy-policy">Privacy</a></li>
+              <li><a href="/governance">Governance</a></li>
               <li><a href="/code-of-conduct">Code of Conduct</a></li>
               <li><a href="/license">License</a></li>
               <li><a href="/donate">Donate</a></li>
+              <li><a href="/press">Press Kit</a></li>
             </ul>
           </li>
         </div>


### PR DESCRIPTION
Compared to https://github.com/godotengine/godot-website/pull/215, this is a newer revision of the governance document.

The PLC contact information was moved to the Governance page.

This also adds the Press Kit link to the More navigation bar dropdown.