### PR TITLE
Update IRC community link to point to Libera Chat

### DIFF
--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -274,7 +274,7 @@ is_hidden = 0
 
   <div>
     <div class="card">
-      <a href="https://webchat.freenode.net/?channels=#godotengine">
+      <a href="https://web.libera.chat/#godotengine">
         <img
           src="{{ 'assets/community/icon_irc.png'|theme }}"
           width="350"
@@ -285,10 +285,10 @@ is_hidden = 0
         >
       </a>
       <div class="base-padding">
-        <h3><a href="https://webchat.freenode.net/?channels=#godotengine">IRC</a></h3>
+        <h3><a href="https://web.libera.chat/#godotengine">IRC</a></h3>
         <p>
           Old-fashioned but reliable chat platform. Significantly less active than Discord.<br>
-          <code>#godotengine @ chat.freenode.net</code>
+          <code>#godotengine @ libera.chat</code>
         </p>
         <p><strong>
           As of January 2021, core developer chat has moved to the Godot Contributors Chat platform listed above.

--- a/themes/godotengine/pages/maintenance.htm
+++ b/themes/godotengine/pages/maintenance.htm
@@ -16,7 +16,7 @@
   <ul>
     <li><a href="https://godotengine.org/qa">Questions &amp; Answers</a></li>
     <li><a href="https://discord.gg/4JBkykG">Discord</a></li>
-    <li><a href="https://webchat.freenode.net/?channels=#godotengine">IRC</a></li>
+    <li><a href="https://web.libera.chat/#godotengine">IRC</a></li>
     <li><a href="https://matrix.to/#/#godotengine:matrix.org">Matrix</a></li>
     <li><a href="https://www.facebook.com/groups/godotengine/">Facebook</a></li>
     <li><a href="https://reddit.com/r/godot/">Reddit</a></li>

--- a/themes/godotengine/pages/privacy-policy.htm
+++ b/themes/godotengine/pages/privacy-policy.htm
@@ -32,7 +32,7 @@ is_hidden = 0
     <li>you sign up and log in to an account on the Godot Chat platform (<a href="https://chat.godotengine.org">https://chat.godotengine.org</a>), and use it to participate in private and public discussions;</li>
     <li>you sign up and log in to an account on Godot's Q&amp;A site (<a href="https://godotengine.org/qa">https://godotengine.org/qa</a>), and use it to ask or answer questions;</li>
     <li>you sign up and log in to an account on Godot's Asset Library (<a href="https://godotengine.org/asset-library">https://godotengine.org/asset-library</a>), and use it to submit content;</li>
-    <li>you use one of Godot's publicly logged project IRC channels (#godotengine-atelier, #godotengine-devel, #godotengine-meeting) on the Freenode IRC network;</li>
+    <li>you use one of Godot's publicly logged project IRC channels (#godotengine-atelier, #godotengine-devel, #godotengine-meeting) on the Libera Chat IRC network;</li>
     <li>you sign up for one of our public mailing lists hosted by TuxFamily;</li>
     <li>you participate in surveys or evaluations;</li>
     <li>you submit questions or comments to us.</li>
@@ -43,7 +43,7 @@ is_hidden = 0
 
   <p>When you create an account on the Godot website (including the Godot Chat platform, the Q&amp;A platform, the Asset Library and October CMS), it collects your username and email address for authentication. Additional information may be collected if you choose to fill in optional fields in your user profile (e.g. full name, location, profile picture).</p>
 
-  <p>When you join or send messages to any of the IRC channels listed above, that activity is logged and published publicly for others interested in the project. This logging includes the user nickname specified when connecting to Freenode and your messages in those public channels.</p>
+  <p>When you join or send messages to any of the IRC channels listed above, that activity is logged and published publicly for others interested in the project. This logging includes the user nickname specified when connecting to Libera Chat and your messages in those public channels.</p>
 
   <p>Anonymized site visit statistics (<a href="https://stats.tuxfamily.org/godotengine.org">https://stats.tuxfamily.org/godotengine.org</a>) and download statistics (<a href="https://stats.download.tuxfamily.org/godotengine">https://stats.download.tuxfamily.org/godotengine</a>) are collected and published publicly by our TuxFamily hosting.</p>
 


### PR DESCRIPTION
Most of the activity has moved to Libera Chat now. I tested the web chat URL and it works as expected :slightly_smiling_face: 