### PR TITLE
Update Godot Mono prerequisites: .NET SDK

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -134,7 +134,7 @@ description = "Download layout"
           <ul>
             <li>OpenGL 2.1 / OpenGL ES 2.0 compatible hardware</li>
             <li>
-              <strong>For the Mono version:</strong> MSBuild<br />(from <a href="https://visualstudio.microsoft.com/downloads/?q=build+tools">Visual Studio Build Tools</a> or the <a href="https://www.mono-project.com/download/stable/">Mono SDK</a>)
+              <strong>For the Mono version:</strong> <a href="https://dotnet.microsoft.com/download">.NET SDK</a> or the <a href="https://www.mono-project.com/download/stable/">Mono SDK</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Update the Godot Mono prerequisites on https://godotengine.org/download to make it match up with the docs:
https://docs.godotengine.org/en/stable/getting_started/scripting/c_sharp/c_sharp_basics.html#prerequisites

@neikeq mentioned in https://github.com/godotengine/godot/issues/41734#issuecomment-690764782 (Sep 10, 2020) that disabling non-`dotnet CLI` build tools is being considered, so funneling more people towards the .NET SDK seems to me like a good idea even if VS Build Tools and Mono SDK are working right now. (Although based on people getting help in the Godot C# Discord, they do seem to cause issues pretty often, and switching over to `dotnet CLI` normally clears them up.)

(The .NET SDK corresponds to the `dotnet CLI` Build Tool option in the Editor Settings.)

Fixes https://github.com/godotengine/godot-website/issues/321