### PR TITLE
Link to the GitHub Releases mirror on the Download page

### DIFF
--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -153,9 +153,10 @@ description = "Download layout"
           {% placeholder instructions %}
         </div>
 
-        <div class="footer base-padding">
+        <div class="footer base-padding" style="line-height: 1.6; font-size: 85%">
           You can find previous releases on the
-          <a href="https://downloads.tuxfamily.org/godotengine">download repository</a>.
+          <a href="https://downloads.tuxfamily.org/godotengine">download repository</a>.<br>
+          Slow download? Try the mirror on <a href="https://github.com/godotengine/godot/releases">GitHub Releases</a>.
         </div>
       </div>
 


### PR DESCRIPTION
This is useful for users having issues with slow downloads from TuxFamily's servers.

## Preview

![image](https://user-images.githubusercontent.com/180032/131130203-6985d4b0-a0d4-40c6-a841-e2081ceb7f9c.png)
