### PR TITLE
Fix the navigation bar dropdown being drawn behind the homepage message

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -20,7 +20,6 @@ postPage = "{{ :slug }}"
   #main_message {
     background-color: var(--dark-color);
     position: relative;
-    z-index: 2;
   }
 
   #main_message .container {


### PR DESCRIPTION
This was caused by an unnecessary `z-index` override in the homepage's main message block.

This closes https://github.com/godotengine/godot-website/issues/361.

## Preview

![image](https://user-images.githubusercontent.com/180032/132997310-74c00782-6c4c-4e00-8a35-c03f34e48423.png)