### PR TITLE
Fix tabs having extra padding in mobile view

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -928,7 +928,7 @@ pre > code {
   }
 
   .tabs {
-    overflow: scroll;
+    overflow: auto;
   }
 
   .author .date {


### PR DESCRIPTION
**#353 Tabs in news page has white padding when viewed in narrow window**

This PR changes the tab container on mobile view to use `overflow: auto` instead of `overflow: scroll`. The auto behavior will trigger scrolling when necessary (highly unlikely with only two tabs), but removes the scrollbar padding otherwise.

Before:
![Screen Shot 2021-09-13 at 3 13 25 PM](https://user-images.githubusercontent.com/5777240/133163759-f096739f-d4d0-44f9-9b89-50c1f9a7ac63.png)

After:
![Screen Shot 2021-09-13 at 3 13 34 PM](https://user-images.githubusercontent.com/5777240/133163766-88a69ec3-0f1e-449f-a9a3-e502249c2733.png)
