### PR TITLE
Fix open source redirect on the homepage

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -288,7 +288,7 @@ postPage = "{{ :slug }}"
       </div>
     </a>
 
-    <a href="/features#collaborate" data-barba-prevent>
+    <a href="#get_involved" data-barba-prevent>
       <div class="feature">
         <img
           src="{{ 'assets/home/features/oss.svg' | theme }}"


### PR DESCRIPTION
The open source link in the features section of the main page (see picture below) previously pointed to `/features#collaborate` (same as the link next to it).
![image](https://user-images.githubusercontent.com/95430286/146675204-a7ba0dca-6768-4d00-b154-b117c6295066.png)
This commit changes it so that it points to `#get_involved`.
Alternatively, it would also make sense for it to point to [the contributing article on the wiki](https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html) or [the Github organization](https://github.com/godotengine).
