### PR TITLE
Fix off-center "Learn more" button on the homepage

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -762,7 +762,7 @@ pre > code {
   .container > :first-child {
     padding-left: 0px;
   }
-  .container > :last-child {
+  .container > :last-child:not(a.btn) {
     padding-right: 0px;
   }
 }


### PR DESCRIPTION
This commit fixes #376 by adding an aditional condition to a css selector.
