### PR TITLE
More grammatically proper headline for the landing page

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -144,7 +144,7 @@ postPage = "{{ :slug }}"
   <div class="container flex eqsize responsive">
 
     <div class="padded">
-      <h2>The game engine you waited&nbsp;for.</h2>
+      <h2>The game engine you've been waiting&nbsp;for.</h2>
       <p>
         Godot provides a huge set of common tools, so you can just focus on
         making your game without reinventing the wheel.


### PR DESCRIPTION
"The game engine you waited for" is a bit awkward in English, it's all in past tense as though the addressee once was looking for an engine like this but is not necessarily seeking one right now. "The game engine **you've been waiting** for" is a more typical way of saying what I believe the original author meant. You can google the idiom and will find many examples acknowledging it, here is one of the first that pops up:  https://www.gymglish.com/en/gymglish/english-translation/the-moment-youve-been-waiting-for