### PR TITLE
Fix images flickering when hovered in blog posts

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -187,6 +187,13 @@ body a {
   transition: 0.1s filter;
 }
 
+body a,
+a.btn.flat {
+  /* Use `filter` on all states to prevent the clickable area from changing */
+  /* when an image is hovered (see GH-369). */
+  filter: brightness(100%);
+}
+
 body a:hover,
 a.btn.flat:hover {
   filter: brightness(117.5%);

--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -37,7 +37,7 @@ description = "head partial"
 
   <link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
   <link rel="icon" href="{{ 'assets/favicon.png'|theme }}">
-  <link rel="stylesheet" href="{{ 'assets/css/main.css?4' | theme }}">
+  <link rel="stylesheet" href="{{ 'assets/css/main.css?5' | theme }}">
   <link rel="stylesheet" href="{{ 'assets/css/tobii.min.css?1' | theme }}">
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-Bold.woff2?1' | theme }}" crossorigin>
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-ExtraBold.woff2?1' | theme }}" crossorigin>


### PR DESCRIPTION
This fix sets `filter` on all states, so that the browsers compute the selectable area in the same way regardless of the element's hover state.

Tested on Firefox 95 and Chromium 94.

This closes https://github.com/godotengine/godot-website/issues/369.