### PR TITLE
Tweak display of preformatted blocks (code and licenses)

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -746,6 +746,8 @@ pre {
   padding: 8px;
   border-radius: 2px;
   overflow-y: auto;
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 pre > code {

--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -37,7 +37,7 @@ description = "head partial"
 
   <link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
   <link rel="icon" href="{{ 'assets/favicon.png'|theme }}">
-  <link rel="stylesheet" href="{{ 'assets/css/main.css?5' | theme }}">
+  <link rel="stylesheet" href="{{ 'assets/css/main.css?6' | theme }}">
   <link rel="stylesheet" href="{{ 'assets/css/tobii.min.css?1' | theme }}">
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-Bold.woff2?1' | theme }}" crossorigin>
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-ExtraBold.woff2?1' | theme }}" crossorigin>


### PR DESCRIPTION
This decreases the font size to allow longer lines to fit without wrapping. Line height was also increased to improve readability.

## Preview

*Chromium 94 on Linux is used for the screenshots.*

### Before

![2022-01-03_23 05 33](https://user-images.githubusercontent.com/180032/147985754-da6236cc-5cda-43a9-a261-a7cb0a85b751.png)

### After

![2022-01-03_23 05 21](https://user-images.githubusercontent.com/180032/147985751-59ccdc9d-d432-43c3-8e2e-f1c07dcbb2f2.png)