### PR TITLE
Update dates on page of upcoming events

### DIFF
--- a/themes/godotengine/pages/events.htm
+++ b/themes/godotengine/pages/events.htm
@@ -7,12 +7,12 @@ is_hidden = 0
 {##}
 <section id="upcoming" class="events">
 
-  <h2>2020</h2>
+  <h2>2022</h2>
 
-  <p>No more events scheduled for 2020 due to Covid-19.</p>
+  <p>No events scheduled for 2022 yet.</p>
 
-  <h2>2021</h2>
+  <h2>2023</h2>
 
-  <p>No events scheduled for 2021 yet.</p>
+  <p>No events scheduled for 2023 yet.</p>
 
 </section>


### PR DESCRIPTION
When I found this page I thought it would be good to show updated dates even if we don't have any upcoming events yet as it feels less 'abandoned'.