### PR TITLE
Use current year in footer, update LICENSE to 2022

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
-Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.
-Copyright (c) 2014-2021 Godot Engine contributors (cf. https://github.com/godotengine/godot/blob/master/AUTHORS.md).
+Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.
+Copyright (c) 2014-2022 Godot Engine contributors (cf. https://github.com/godotengine/godot/blob/master/AUTHORS.md).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/themes/godotengine/pages/license.htm
+++ b/themes/godotengine/pages/license.htm
@@ -47,8 +47,8 @@ is_hidden = 0
 </p>
 
 <pre>
-Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.
-Copyright (c) 2014-2021 Godot Engine contributors.
+Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.
+Copyright (c) 2014-2022 Godot Engine contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -8,7 +8,7 @@ description = "footer partial"
   <div class="container flex">
     <div id="copyright">
       <p>
-        © 2007-2021 Juan Linietsky, Ariel Manzur and <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank" rel="noopener">contributors</a><br>
+        © 2007-{{ "now"|date("Y") }} Juan Linietsky, Ariel Manzur and <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank" rel="noopener">contributors</a><br>
         Godot is a member of the <a href="https://sfconservancy.org/" target_="_blank" rel="noopener">Software Freedom Conservancy</a>.<br>
         Kindly hosted by <a href="https://tuxfamily.org" target="_blank" rel="noopener">TuxFamily.org</a>.<br>
         <a href="https://github.com/godotengine/godot-website" target="_blank" rel="noopener">Website source code on GitHub</a>.


### PR DESCRIPTION
- Use the current year in the footer automatically
- Update the license to 2022 in two places