### PR TITLE
Revamp blog category presentation

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -689,6 +689,19 @@ a.btn.download > .opt {
   padding-left: 24px;
 }
 
+.tags {
+  margin-top: -3rem;
+  margin-bottom: 3rem;
+}
+
+.tag {
+  display: inline-block;
+  border-radius: 1000px;
+  background-color: var(--card-background-color);
+  padding: 0.25rem 0.75rem;
+  margin: 0.1rem;
+}
+
 .card {
   background-color: var(--card-background-color);
   color: var(--base-color-text);

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -127,6 +127,12 @@ categoryPage = "article"
           By: {{ post.user.full_name }}
           <span class="date"> {{ post.published_at|date('j F Y') }}</span>
         </h4>
+
+        <div class="tags">
+          {% for category in post.categories %}
+            <a href="/news/{{ category.slug }}/{{ blogPosts.posts.currentPage }}" title="{{ category.description }}"><div class="tag">{{ category.name }}</div></a>
+          {% endfor %}
+        </div>
       </div>
 
       {{ post.content_html|raw }}

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -189,7 +189,7 @@ postPage = "{{ :slug }}"
           <hr>
         {% endif %}
       {% endfor %}
-      <div class="text-center base-padding"><a href="/news" class="btn flat no-margin">More</a></div>
+      <div class="text-center base-padding"><a href="/news/default/1" class="btn flat no-margin">More</a></div>
     </div>
 
   </div>

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -52,11 +52,6 @@ description = "News layout"
     <div class="main">
       <h1 class="intro-title">{{ this.page.title }}</h1>
     </div>
-
-    <div class="tabs">
-      <a href="/news" class="title-font {% if this.page.id == 'news' %} active {% endif %}">All</a>
-      <a href="/devblog" class="title-font {% if this.page.id == 'devblog' %} active {% endif %}">Devblog</a>
-    </div>
   </div>
 </div>
 
@@ -80,6 +75,30 @@ description = "News layout"
       height: 40px;
     "
   ></iframe>
+
+  <h3 style="margin-top: 1rem; margin-bottom: 4rem">Categories</h3>
+  <div class="tags">
+    {# The category slug is an empty string if the legacy news URL (`/news`) is browsed to. #}
+    <a
+      href="/news/default/{{ blogPosts.posts.currentPage }}"
+      title="Show all categories"
+      {% if blogCategories.currentCategorySlug == "default" or blogCategories.currentCategorySlug == "" %} style="font-weight: bold" {% endif %}
+    ><div class="tag">All</div></a>
+    {% for category in blogCategories.categories %}
+      <a
+        href="/news/{{ category.slug }}/{{ blogPosts.posts.currentPage }}"
+        title="{{ category.description }}"
+        {% if category.slug == blogCategories.currentCategorySlug %} style="font-weight: bold" {% endif %}
+      ><div class="tag">{{ category.name }}</div></a>
+    {% endfor %}
+  </div>
+
+  {# The category slug is an empty string if the legacy news URL (`/news`) is browsed to. #}
+  {% if blogCategories.currentCategorySlug == "default" or blogCategories.currentCategorySlug == "" %}
+    <h3 style="margin-top: -1rem; margin-bottom: -1rem">All posts</h3>
+  {% else %}
+    <h3 style="margin-top: -1rem; margin-bottom: -1rem">Posts from category: {{ blogCategories.currentCategorySlug|capitalize }}</h3>
+  {% endif %}
 
   {% partial "pagination" %}
 

--- a/themes/godotengine/pages/devblog.htm
+++ b/themes/godotengine/pages/devblog.htm
@@ -12,3 +12,10 @@ sortOrder = "published_at desc"
 categoryPage = "article"
 postPage = "article"
 ==
+<?php
+function onStart()
+{
+  return Redirect::to('/news/default/1');
+}
+?>
+==

--- a/themes/godotengine/pages/news.htm
+++ b/themes/godotengine/pages/news.htm
@@ -1,15 +1,18 @@
 title = "News"
-url = "/news/:page?"
+url = "/news/:slug?/:page?"
 layout = "news"
 description = "Keep up-to-date with the latest Godot Engine development news."
 is_hidden = 0
 
 [blogPosts]
 pageNumber = "{{ :page }}"
-categoryFilter = ""
+categoryFilter = "{{ :slug }}"
 postsPerPage = 25
 noPostsMessage = "No posts found"
 sortOrder = "published_at desc"
 categoryPage = "article"
 postPage = "article"
+
+[blogCategories]
+slug = "{{ :slug }}"
 ==

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -16,7 +16,7 @@ description = "footer partial"
       <p><a href="/privacy-policy">Privacy Policy</a> &ndash; <a href="/code-of-conduct">Code of Conduct</a></p>
     </div>
     <ul id="sitemap">
-      <li><a href="/news">News</a></li>
+      <li><a href="/news/default/1">News</a></li>
       <li><a href="/community">Community</a></li>
       <li><a href="/features">Features</a></li>
       <li><a href="/showcase">Showcase</a></li>

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -23,7 +23,7 @@ description = "header partial"
     <nav id="nav">
       <ul class="left">
         <li {% if selected == 'features' %} class="active" {% endif %}><a href="/features">Features</a></li>
-        <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news">News</a></li>
+        <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news/default/1">News</a></li>
         <li {% if this.page.id == 'community' %} class="active" {% endif %}><a href="/community">Community</a></li>
         <div class="only-on-mobile" style="width: 100%">
           <li {% if this.page.id == 'showcase' %} class="active" {% endif %}"><a href="/showcase">Showcase</a></li>


### PR DESCRIPTION
- Categories are now presented as tag pills on each article.
- Categories can be clicked to show all posts belonging to a category.
- List of categories is displayed at the top of the news archive.
- Remove obsolete News and Devblog tabs.
  - `/devblog` now redirects to the news archive.

Individual post URLs remain unchanged.

**Note:** The "News" category shown here will cause the URL to become `/news/news/(page)`, which looks a bit awkward. We could fix this by changing the prefix from `/news` to `/blog` or `/articles`.

Once this is deployed to production, I'll recategorize all blog posts with the following categories:

- **News** (anything that doesn't belong to another categories)
- **Events** (event announcements)
- **Release** (for stable releases only)
- **Pre-release** (for alpha/beta/RC releases only)
- **Progress report**
- **Showcase** (interviews and showreel posts)

## Preview

![image](https://user-images.githubusercontent.com/180032/167910284-8cb589de-f2c3-42d4-9edb-dc85315837f9.png)