### PR TITLE
Add information for Barcelona 2022 events.

### DIFF
--- a/themes/godotengine/pages/events.htm
+++ b/themes/godotengine/pages/events.htm
@@ -9,7 +9,44 @@ is_hidden = 0
 
   <h2>2022</h2>
 
-  <p>No events scheduled for 2022 yet.</p>
+   <ul>
+    <li>2 &amp; 3 June: <a href="#godotsprint"><em>Godot Sprint</em></a>, Barcelona, Spain</li>
+    <li>4 June: <a href="#godotmeeting"><em>Godot User Meeting</em></a>, Barcelona, Spain</li>
+  </ul>
+
+  <a id="godotsprint"></a>
+  <div class="card base-padding">
+    <h3>Godot Sprint Barcelona 2022</h3>
+
+    <img src="/storage/app/uploads/public/626/a6c/7d0/626a6c7d07e5f570805755.png" alt="Godot Sprint and User Meeting Barcelona 2022 banner">
+
+    <p>The two days before <a href="#godotmeeting">Godot User Meeting 2022</a>, we organize what we call the Godot Sprint, with the intent for contributors to meet IRL and <em>get some work done</em>! This contributor sprint will be primarily intended for existing engine and documentation contributors, so that we can work on current topics together, review Pull Requests, discuss the roadmap, etc. We will also welcome users who aren't contributors yet but would like to get involved, be it with C++ engine contributions, documentation writing or the creation of other teaching materials (demos, courses, etc.). <strong>More information <a href="/article/godot-sprint-and-user-meeting-barcelona-june-2022">here</a></strong></p>
+
+    <p>Entrance will be free.</p>
+
+    <ul>
+      <li><strong>Date:</strong> Thu 2 June &amp; Fri 3 June 2022, 10 am - 19 pm both days</li>
+      <li><strong>Location:</strong> <a href="https://lleialtat.cat/">La Lleialtat Santsenca</a>, C/ Olzinelles 31, 08014 Barcelona, Spain (<a href="https://www.openstreetmap.org/?mlat=41.37289&mlon=2.13665#map=18/41.37289/2.13665&layers=N">OpenStreetMap</a>)</li>
+      <li><strong>Entrance fee:</strong> Free</li>
+      <li><strong>Registration:</strong> <strong>Mandatory</strong>. Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfKYj38RLoJ93Fp31Hj5CxbeP5kDlt_fw0POI0fiRwMm1uAxw/viewform">fill this form</a> ASAP so that we know who will be there and can organize the event accordingly.</li>
+    </ul>
+  </div>
+
+  <a id="godotmeeting"></a>
+  <div class="card base-padding">
+    <h3>Godot User Meeting 2022</h3>
+
+    <img src="/storage/app/uploads/public/626/a6c/7d0/626a6c7d07e5f570805755.png" alt="Godot Sprint and User Meeting Barcelona 2022 banner">
+
+    <p>Taking the opportunity that many contributors gather for the <a href="#godotsprint">Godot Sprint</a>, we are organizing a Godot User Meeting. It will be great opportunity to meet some engine developers and other users, bring a demo of your game and attend a couple of Godot-related talks. <strong>More information <a href="/article/godot-sprint-and-user-meeting-barcelona-june-2022">here</a></strong></p>
+
+    <ul>
+      <li><strong>Date:</strong> Sat 4 June 2022, 10 am - 19 pm</li>
+      <li><strong>Location:</strong> <a href="https://lleialtat.cat/">La Lleialtat Santsenca</a>, C/ Olzinelles 31, 08014 Barcelona, Spain (<a href="https://www.openstreetmap.org/?mlat=41.37289&mlon=2.13665#map=18/41.37289/2.13665&layers=N">OpenStreetMap</a>)</li>
+      <li><strong>Entrance fee:</strong> Free</li>
+      <li><strong>Registration:</strong> <strong>Mandatory</strong>. Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfKYj38RLoJ93Fp31Hj5CxbeP5kDlt_fw0POI0fiRwMm1uAxw/viewform">fill this form</a> ASAP so that we know who will be there and can organize the event accordingly.</li>
+    </ul>
+  </div>
 
   <h2>2023</h2>
 


### PR DESCRIPTION
Add information for Barcelona 2022 events. I didn't fully test this changes since I don't have the proper local setup. It would be good to test it in a local running instance before merging.