### PR TITLE
Remove redundant quote in header template

### DIFF
--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -26,8 +26,8 @@ description = "header partial"
         <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news/default/1">News</a></li>
         <li {% if this.page.id == 'community' %} class="active" {% endif %}><a href="/community">Community</a></li>
         <div class="only-on-mobile" style="width: 100%">
-          <li {% if this.page.id == 'showcase' %} class="active" {% endif %}"><a href="/showcase">Showcase</a></li>
-          <li {% if selected == 'more' %} class="active" {% endif %}"><a href="/contact">More</a></li>
+          <li {% if this.page.id == 'showcase' %} class="active" {% endif %}><a href="/showcase">Showcase</a></li>
+          <li {% if selected == 'more' %} class="active" {% endif %}><a href="/contact">More</a></li>
         </div>
         <div class="hide-on-mobile">
           <li class="nav-dropdown {% if selected == 'more' %} active {% endif %}">


### PR DESCRIPTION
Corrects
```
<li ">...</li>
<li ">...</li>
```
to
```
<li >...</li>
<li >...</li>
```
on [view-source:https://godotengine.org/](view-source:https://godotengine.org/) L49-L50