### PR TITLE
Display all categories from the blog on the homepage

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -2,7 +2,6 @@ description = "home layout"
 
 [blogPosts]
 pageNumber = "{{ :page }}"
-categoryFilter = "news"
 postsPerPage = 4
 noPostsMessage = "No posts found"
 sortOrder = "published_at desc"


### PR DESCRIPTION
This is required by the [blog category reorganization](https://github.com/godotengine/godot-website/pull/393), as news posts are no longer necessary in the News category.