### PR TITLE
Make docker setup work consistently cross-platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files
+* text=auto eol=lf

--- a/docker/php/init/docker-entrypoint.sh
+++ b/docker/php/init/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Checking if MariaDB is reachable..."
 exec wait-for-it.sh mariadb:3306 -s -t 30 -- init.sh

--- a/docker/php/init/init.sh
+++ b/docker/php/init/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Only do this once.
 CONTAINER_ALREADY_STARTED="/tmp/CONTAINER_ALREADY_STARTED"


### PR DESCRIPTION
Found out the hard way that once I get those same files through git, it no longer works. Forcing line endings to be Unix-like fixes the issue. We have the same configuration in the main repo, so this should be good for everyone.

Also normalized bash reference.