### PR TITLE
Making the nav bar follow the scroll view

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -311,7 +311,6 @@ h4 {
 
 header {
   /* Show on top of GodotCon banner (if any). */
-  position: relative;
   z-index: 2;
 
   width: 100vw;

--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -51,6 +51,10 @@
   --teams-subteams-color: rgba(255, 255, 255, 0.4);
 }
 
+html {
+  scroll-padding-top: 64px; /* Navbar height */
+}
+
 .nav-logo.dark-logo {
   display: none;
 }
@@ -315,7 +319,9 @@ header {
   background-color: var(--navbar-background-color);
   display: flex;
   align-items: center;
-  box-shadow: var(--base-shadow);
+  position: fixed;
+  top: 0px;
+  box-shadow: 0 0 40px -10px #0000007d;
 }
 
 header > div.container {
@@ -324,6 +330,10 @@ header > div.container {
 
 header .container {
   overflow: initial;
+}
+
+.header-gap {
+  height: 64px;
 }
 
 .only-on-mobile {
@@ -563,10 +573,10 @@ article .content img {
   padding: 0px;
   margin: 0px;
   background-image: url("../home/background.jpg");
-  background-position: top;
+  background-position: 50% 0;
   background-size: cover;
   background-blend-mode: darken;
-  height: 600px;
+  height: 500px;
   max-height: 50vh;
   /* For `.main-image-text`. */
   position: relative;

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -379,6 +379,15 @@ postPage = "{{ :slug }}"
   </div>
 </section>
 
+<script>
+  // Parallax effect on the hero image
+  window.addEventListener('scroll', function () {
+    let hero = document.querySelector('.main-image');
+    let bgPos = getComputedStyle(hero).backgroundPosition.split(' ');
+    hero.style.backgroundPosition = bgPos[0] + ' ' + (window.scrollY * 0.5) + 'px';
+  });
+</script>
+
 {% partial "footer" %}
 
 </html>

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -40,5 +40,6 @@ description = "header partial"
     </nav>
   </div>
 </header>
+<div class="header-gap"></div>
 
 <main data-barba="container" data-barba-namespace="default">


### PR DESCRIPTION
Maybe I should have split this into two PRs, but I can split it if needed.

On this PR:
- Made it so that the nav bar follows your screen.
- Added `scroll-padding-top` to the `html` so that when you open an anchored link the nav is not covering the content
- Softened the nav bar shadow since it was too hard and small
- I added a small parallax effect on the home page so that it feels a bit less static
- Made the hero image a bit shorter because it was covering too much screen


https://user-images.githubusercontent.com/2206700/179080356-ecdb638c-d37c-4fb5-880e-af9846f7c1f2.mp4


