### PR TITLE
Cross-link the Teams page from the Governance page

### DIFF
--- a/themes/godotengine/pages/governance.htm
+++ b/themes/godotengine/pages/governance.htm
@@ -125,18 +125,15 @@ is_hidden = 0
 
   <h4>Teams and area owners</h4>
   <p>
-    Teams are groups of contributors interested in a specific area of the
-    engine. Teams provide a way for contributors to have focused discussions
-    with other people with similar expertise and interests. The opinion and
-    expertise of team members is valued in discussions, but ultimately the
-    authority over an area of the engine belongs solely to the area owner and
-    the project leadership. Area owners are entrusted with final say for code
-    merges in their areas. Area owners are trusted contributors who are chosen
-    by the project leadership and have shown knowledge of the specific area of
-    the engine and the engine's philosophy as a whole.
-  </p>
-  <p style="font-style: italic">
-    Teams have not been formally announced yet, but a list will be published in the future.
+    <a href="/teams">Engine teams</a> are groups of contributors interested in
+    a specific area of the engine. Teams provide a way for contributors to have
+    focused discussions with other people with similar expertise and interests.
+    The opinion and expertise of team members is valued in discussions, but
+    ultimately the authority over an area of the engine belongs solely to the
+    area owner and the project leadership. Area owners are entrusted with final
+    say for code merges in their areas. Area owners are trusted contributors who
+    are chosen by the project leadership and have shown knowledge of the specific
+    area of the engine and the engine's philosophy as a whole.
   </p>
   <p>
     In practice, area owners aim for consensus among contributors, especially


### PR DESCRIPTION
This removes the note that teams will be published in the future (already published) and adds a link to the page. Swapped the first "Teams" for "Engine teams" so that the link stands out more.