### PR TITLE
Improve formatting of shell instructions and extra links for Downloads

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -46,6 +46,10 @@
   --codeblock-background-color: #282b2e;
   --codeblock-color: #e0e2e4;
 
+  --platform-code-background-color: #e5ebf1;
+
+  --digital-store-background-color: #2d4c74;
+
   --teams-odd-color: rgba(160, 160, 160, 0.15);
   --teams-even-color: rgba(160, 160, 160, 0.05);
   --teams-subteams-color: rgba(255, 255, 255, 0.4);
@@ -110,6 +114,10 @@
     --code-background-color: #333639;
     --codeblock-background-color: #333639;
     --codeblock-color: hsla(0, 0%, 100%, 0.9);
+
+    --platform-code-background-color: #282b2e;
+
+    --digital-store-background-color: #2d4c74;
 
     --teams-odd-color: rgba(120, 120, 120, 0.15);
     --teams-even-color: rgba(120, 120, 120, 0.05);

--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -51,22 +51,27 @@ description = "Download layout"
   .digital-stores-download {
     display: flex;
     align-items: center;
-    background-color: #2d4c74;
     margin-top: 16px;
     color: var(--dark-color-text-hl);
     font-size: 16px;
     text-decoration: none;
-    padding: 8px 16px;
   }
 
-  .digital-stores-download strong {
-    color: var(--dark-color-text-hl);
+  .digital-stores-logo {
+    background-color: var(--digital-store-background-color);
+    padding: 8px 8px;
+  }
+
+  .digital-stores-logo img {
+    vertical-align: middle;
+  }
+
+  .digital-stores-name {
+    color: var(--base-color-text-hl);
+    font-size: 13px;
     font-weight: 600;
-    margin-left: 8px;
-  }
-
-  .digital-stores-download img {
-    margin-right: 16px;
+    text-transform: uppercase;
+    padding: 8px 16px;
   }
 
   .version-overview {
@@ -82,10 +87,11 @@ description = "Download layout"
     margin-bottom: 0px;
   }
 
-  .version-overview h2 > em {
+  .version-overview .version-link {
     color: var(--primary-color);
     font-style: normal;
     margin-left: 16px;
+    text-decoration: none;
   }
 
   .version-overview .date {
@@ -94,6 +100,10 @@ description = "Download layout"
 
   .version-overview img {
     filter: drop-shadow(var(--base-shadow));
+  }
+
+  .platform-details pre {
+    background-color: var(--platform-code-background-color);
   }
 
   .extras .card {
@@ -128,7 +138,7 @@ description = "Download layout"
   <div class="flex responsive eqsize">
     <div class="version-overview">
       <img src="{{ 'assets/download/godot_logo.svg' | theme }}" alt="" width="200" height="200" alt="">
-      <h2>Godot <em>{{stable_version}}</em></h2>
+      <h2>Godot <a class="version-link" href="#links">{{stable_version}}</a></h2>
       <i class="date">released {{ stable_version_date | date('j F Y') }}</i>
 
       <div style="margin-top:32px; line-height: 1.6; font-size: 85%">
@@ -140,17 +150,21 @@ description = "Download layout"
       </div>
       <div class="digital-stores">
         <a class="digital-stores-download card" href="https://godotengine.itch.io/godot" title="Godot Engine on itch.io">
-          <img src="{{ 'assets/download/itch_logo.svg' | theme }}" width="28" height="28" alt="">
-          <strong>itch.io</strong>
+          <div class="digital-stores-logo">
+            <img src="{{ 'assets/download/itch_logo.svg' | theme }}" width="28" height="28" alt="">
+          </div>
+          <div class="digital-stores-name">itch.io</div>
         </a>
         <a class="digital-stores-download card" href="https://store.steampowered.com/app/404790" title="Godot Engine on Steam">
-          <img src="{{ 'assets/download/steam_logo.svg' | theme }}" width="28" height="28" alt="">
-          <strong>Steam</strong>
+          <div class="digital-stores-logo">
+            <img src="{{ 'assets/download/steam_logo.svg' | theme }}" width="28" height="28" alt="">
+          </div>
+          <div class="digital-stores-name">Steam</div>
         </a>
       </div>
     </div>
 
-    <div>
+    <div id="links" class="platform-details">
       <div class="card">
         <div class="base-padding">
           <h4>Standard version</h4>

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -41,10 +41,10 @@ is_hidden = 0
   </p>
   <p>
     You can also get Godot with <a href="https://brew.sh/">Homebrew</a>
-    or <a href="https://www.macports.org">MacPorts</a>:
   </p>
-  <ul>
-    <li><pre><code>brew install --cask godot</code></pre></li>
-    <li><pre><code>sudo port install godot</code></pre></li>
-  </ul>
+  <pre><code>brew install --cask godot</code></pre>
+  <p>
+    or <a href="https://www.macports.org">MacPorts</a>
+  </p>
+  <pre><code>sudo port install godot</code></pre>
 {% endput %}

--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -39,13 +39,8 @@ is_hidden = 0
 
 {% put instructions %}
   <p>You can also get Godot with <a href="https://scoop.sh/">Scoop</a>.</p>
-  <ul>
-    <li>
-      <pre><code>scoop bucket add extras</code></pre>
-    </li>
-    <li>
-      <pre><code>scoop install godot</code></pre>
-    </li>
-  </ul>
+  <pre><code>scoop bucket add extras
+scoop install godot</code></pre>
+
   <p>Windows executables are code-signed by <em>Prehensile Tales B.V.</em></p>
 {% endput %}


### PR DESCRIPTION
https://github.com/godotengine/godot-website/issues/410 made me look at how we show the shell/CLI commands on the downloads page, and the formatting looked quite bad. I've added more visual distinction and removed listings. scoop commands should be used together, so they are now in the same code block, and for macOS commands are alternatives, so they are properly spread.

**Windows**
[Dark](https://user-images.githubusercontent.com/11782833/179520343-6a24c606-0028-421e-ace2-cbb5a499a012.png)
[Light](https://user-images.githubusercontent.com/11782833/179520387-bc6889a7-c577-43ca-91d1-7c72c8685111.png)

**macOS**
[Dark](https://user-images.githubusercontent.com/11782833/179520425-92bb81dd-2763-4997-b2ce-927eaf7e5cfe.png)
[Light](https://user-images.githubusercontent.com/11782833/179520446-ff0515b5-d2f4-4b03-9900-b9da250a8936.png)

-----

While I was editing the download page, I've decided to also improve a couple other things. The version number is now clickable and scrolls the section with links into view. Not much difference on desktop, but should be useful on mobile. It also just looks clickable, so this makes sense to me overall.

I've also adjusted the digital store links, so they stand out less and just look a bit neater and fitting the rest of our design:
[Dark](https://user-images.githubusercontent.com/11782833/179520858-254b96da-37e6-41a5-ba00-8dfa60e2ad6c.png)
[Light](https://user-images.githubusercontent.com/11782833/179520874-bde4b56f-29fe-4cdc-9116-e3699ff0df5d.png)

