### PR TITLE
Move the About link in the header to reduce significance

### DIFF
--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -22,12 +22,12 @@ description = "header partial"
     <nav id="nav">
       <ul class="left">
         <li {% if selected == 'features' %} class="active" {% endif %}><a href="/features">Features</a></li>
-        <li {% if selected == 'more' %} class="active" {% endif %}><a href="/contact">About</a></li>
-        <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news/default/1">News</a></li>
-        <li {% if this.page.id == 'community' %} class="active" {% endif %}><a href="/community">Community</a></li>
         <div class="only-on-mobile" style="width: 100%">
           <li {% if this.page.id == 'showcase' %} class="active" {% endif %}><a href="/showcase">Showcase</a></li>
         </div>
+        <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news/default/1">News</a></li>
+        <li {% if this.page.id == 'community' %} class="active" {% endif %}><a href="/community">Community</a></li>
+        <li {% if selected == 'more' %} class="active" {% endif %}><a href="/contact">About</a></li>
         <li><a href="https://godotengine.org/asset-library/asset">Assets</a></li>
       </ul>
 


### PR DESCRIPTION
The "About" link is less important than other links in there, so this PR moves it deeper to the right (and mobile-only direct "Showcase" link is brought towards the top in turn). Assets is still right-most, though, because it catches the eye better like that, being on the border.

![image](https://user-images.githubusercontent.com/11782833/179522121-212ed8ec-742b-4c09-8baf-6500b2061f54.png)
