### PR TITLE
Update designs for text-heavy pages

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -53,6 +53,8 @@
   --teams-odd-color: rgba(160, 160, 160, 0.15);
   --teams-even-color: rgba(160, 160, 160, 0.05);
   --teams-subteams-color: rgba(255, 255, 255, 0.4);
+
+  --table-divider-color: rgba(0, 0, 0, 0.1);
 }
 
 .nav-logo.dark-logo {
@@ -122,6 +124,8 @@
     --teams-odd-color: rgba(120, 120, 120, 0.15);
     --teams-even-color: rgba(120, 120, 120, 0.05);
     --teams-subteams-color: rgba(0, 0, 0, 0.2);
+
+    --table-divider-color: rgba(255, 255, 255, 0.1);
   }
 
   /* Use logo with white text for dark navbar. */
@@ -274,6 +278,27 @@ h4 {
   max-width: 1200px;
   margin: auto;
   overflow: visible;
+}
+
+.container-text {
+  width: 100%;
+  padding: 0 24px;
+  max-width: 800px;
+  margin: auto;
+  overflow: visible;
+}
+
+.container-text h2 {
+  margin-top: 80px;
+}
+
+.container-text h3 {
+  margin-top: 60px;
+}
+
+.container-text h4 {
+  margin-top: 40px;
+  margin-bottom: 20px;
 }
 
 .flex {
@@ -1067,7 +1092,9 @@ pre > code {
 .teams-team-section {
   background-color: var(--teams-odd-color);
   padding: 20px 16px;
+  margin: 40px 0;
 }
+
 .teams-team-section:nth-of-type(2n) {
   background-color: var(--teams-even-color);
 }
@@ -1085,18 +1112,44 @@ pre > code {
   padding: 4px 10px;
   margin-top: 30px;
   width: 100%;
+  table-layout: fixed;
+}
+
+.teams-subteams th {
+  padding: 16px;
+  border-right: 1px dashed var(--table-divider-color);
+}
+
+.teams-subteams td {
+  padding: 16px 0 16px 12px;
+}
+
+.teams-subteams th,
+.teams-subteams td {
+  border-bottom: 1px dashed var(--table-divider-color);
+  border-collapse: collapse;
+}
+
+.teams-subteams tr:last-of-type td,
+.teams-subteams tr:last-of-type th {
+  border-bottom: 0;
 }
 
 .teams-subteam-name {
-  font-weight: 600;
-  padding: 6px 18px 6px 0;
   text-align: left;
-  width: 15%;
+  width: 25%;
 }
 
 .teams-subteam-leader:before {
   content: "⭐ ";
 }
+
 .teams-subteam-leader {
   font-weight: 700;
+}
+
+.teams-subteam-leader,
+.teams-subteam-members {
+  font-size: 16px;
+  line-height: 1.6;
 }

--- a/themes/godotengine/pages/code-of-conduct.htm
+++ b/themes/godotengine/pages/code-of-conduct.htm
@@ -7,104 +7,106 @@ is_hidden = 0
 {##}
 {% put title %} Code of Conduct {% endput %}
 
-<p>
-  The Godot project is an international community open to everyone without discrimination. We want this community to be a safe and welcoming place for both newcomers and current members. Everyone should feel comfortable and accepted regardless of their personal background and affiliation to the Godot project.
-</p>
+<div class="container-text">
+  <p>
+    The Godot project is an international community open to everyone without discrimination. We want this community to be a safe and welcoming place for both newcomers and current members. Everyone should feel comfortable and accepted regardless of their personal background and affiliation to the Godot project.
+  </p>
 
-<h3 class="title" id="philosophy">Philosophy</h3>
+  <h3 class="title" id="philosophy">Philosophy</h3>
 
-<p>
-  In the Godot community, participants from all over the world come together to create a Free and Open Source game engine. This is made possible by the support, hard work, and enthusiasm of thousands of people who collaborate towards the common goal of creating great technology and games. Cooperation at such a scale requires common guidelines to ensure a positive and inspiring atmosphere in the community.
-</p>
+  <p>
+    In the Godot community, participants from all over the world come together to create a Free and Open Source game engine. This is made possible by the support, hard work, and enthusiasm of thousands of people who collaborate towards the common goal of creating great technology and games. Cooperation at such a scale requires common guidelines to ensure a positive and inspiring atmosphere in the community.
+  </p>
 
-<p>
-  This is why we have this Code of Conduct: it explains the type of community we want to have. The rules below are not applied to all interactions with a simple matching algorithm. Human interactions happen in context and are complex. Perceived violations are evaluated by real humans who will try to interpret the interactions and the rules with kindness. Accordingly, there is no need to hypothesize on how these rules would affect normal interactions. Be reasonable, the <a href="#coc-team">Code of Conduct team</a> surely will be as well.
-</p>
+  <p>
+    This is why we have this Code of Conduct: it explains the type of community we want to have. The rules below are not applied to all interactions with a simple matching algorithm. Human interactions happen in context and are complex. Perceived violations are evaluated by real humans who will try to interpret the interactions and the rules with kindness. Accordingly, there is no need to hypothesize on how these rules would affect normal interactions. Be reasonable, the <a href="#coc-team">Code of Conduct team</a> surely will be as well.
+  </p>
 
-<h3 class="title" id="application">Application</h3>
+  <h3 class="title" id="application">Application</h3>
 
-<p>
-  This Code of Conduct applies to all users and contributors who engage with the Godot project and its community platforms, both online and at Godot-related events.
-</p>
+  <p>
+    This Code of Conduct applies to all users and contributors who engage with the Godot project and its community platforms, both online and at Godot-related events.
+  </p>
 
-<h3 class="title" id="expectations">Expectations</h3>
+  <h3 class="title" id="expectations">Expectations</h3>
 
-<ul>
-  <li>Politeness is expected at all times. Be kind and courteous.</li>
-  <li>Always assume positive intent from others. Be aware that differences in culture and English proficiency make written communication more difficult than face-to-face communication and that your interpretation of messages may not be the one the author intended. Conversely, if someone asks you to rephrase something you said, be ready to do so without feeling judged.</li>
-  <li>Feedback is always welcome but keep your criticism constructive. We encourage you to open discussions, proposals, issues, and bug reports. Use the community platforms to discuss improvements, not to vent out frustration. Similarly, when other users offer you feedback please accept it gracefully.</li>
-</ul>
+  <ul>
+    <li>Politeness is expected at all times. Be kind and courteous.</li>
+    <li>Always assume positive intent from others. Be aware that differences in culture and English proficiency make written communication more difficult than face-to-face communication and that your interpretation of messages may not be the one the author intended. Conversely, if someone asks you to rephrase something you said, be ready to do so without feeling judged.</li>
+    <li>Feedback is always welcome but keep your criticism constructive. We encourage you to open discussions, proposals, issues, and bug reports. Use the community platforms to discuss improvements, not to vent out frustration. Similarly, when other users offer you feedback please accept it gracefully.</li>
+  </ul>
 
-<h3 class="title" id="restricted-conduct">Restricted conduct</h3>
+  <h3 class="title" id="restricted-conduct">Restricted conduct</h3>
 
-<p>
-  Participating in restricted conduct will lead to a warning from community moderators and/or the Code of Conduct team and may lead to exclusion from the community in the form of a ban from one or all platforms.
-</p>
+  <p>
+    Participating in restricted conduct will lead to a warning from community moderators and/or the Code of Conduct team and may lead to exclusion from the community in the form of a ban from one or all platforms.
+  </p>
 
-<ul>
-  <li>The Godot project is committed to providing a friendly and safe environment for everyone, regardless of level of experience, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, language proficiency, age, political orientation, nationality, religion, or other similar characteristics. We do not tolerate harassment or discrimination of participants in any form.</li>
-  <li>In particular, we strive to be welcoming to all industry minorities and to ensure that they can take a more active role in the community and the project. Targeted harassment of minorities is unacceptable.</li>
-  <li>As a community developed project, we strive for consensus among contributors before moving forward with a proposed feature. If there is not enough support for your ideas, please don't continue insisting or trying to force others into supporting your point. Features are not accepted through a voting process, so piling onto a contentious feature proposal is not acceptable.</li>
-  <li>Aggressive or offensive behavior is not acceptable.</li>
-  <li>You will be excluded from participating in the community if you insult, demean, harass, intentionally make others uncomfortable by any means, or participate in any other hateful conduct, either publicly or privately.</li>
-  <li>Likewise, any spamming, trolling, flaming, baiting, or other attention-stealing behavior is not welcome and will result in exclusion from the community.</li>
-  <li>Any form of retaliation against a participant who contacts the Code of Conduct team is completely unacceptable, regardless of the outcome of the complaint. Any such behavior will result in exclusion from the community.</li>
-  <li>For certainty, any conduct which could reasonably be considered inappropriate in a professional setting is not acceptable.</li>
-</ul>
+  <ul>
+    <li>The Godot project is committed to providing a friendly and safe environment for everyone, regardless of level of experience, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, language proficiency, age, political orientation, nationality, religion, or other similar characteristics. We do not tolerate harassment or discrimination of participants in any form.</li>
+    <li>In particular, we strive to be welcoming to all industry minorities and to ensure that they can take a more active role in the community and the project. Targeted harassment of minorities is unacceptable.</li>
+    <li>As a community developed project, we strive for consensus among contributors before moving forward with a proposed feature. If there is not enough support for your ideas, please don't continue insisting or trying to force others into supporting your point. Features are not accepted through a voting process, so piling onto a contentious feature proposal is not acceptable.</li>
+    <li>Aggressive or offensive behavior is not acceptable.</li>
+    <li>You will be excluded from participating in the community if you insult, demean, harass, intentionally make others uncomfortable by any means, or participate in any other hateful conduct, either publicly or privately.</li>
+    <li>Likewise, any spamming, trolling, flaming, baiting, or other attention-stealing behavior is not welcome and will result in exclusion from the community.</li>
+    <li>Any form of retaliation against a participant who contacts the Code of Conduct team is completely unacceptable, regardless of the outcome of the complaint. Any such behavior will result in exclusion from the community.</li>
+    <li>For certainty, any conduct which could reasonably be considered inappropriate in a professional setting is not acceptable.</li>
+  </ul>
 
-<h3 class="title" id="reporting-breach">Reporting a breach</h3>
+  <h3 class="title" id="reporting-breach">Reporting a breach</h3>
 
-<p>
-  If you witness or are involved in an interaction with another community member that you think may violate this Code of Conduct, please contact Godot's <a href="mailto:conduct@godotengine.org">Code of Conduct team</a>.
-</p>
+  <p>
+    If you witness or are involved in an interaction with another community member that you think may violate this Code of Conduct, please contact Godot's <a href="mailto:conduct@godotengine.org">Code of Conduct team</a>.
+  </p>
 
-<p>
-  The Godot team recognizes that it can be difficult to come forward in cases of a violation of the Code of Conduct. To make it easier to report violations, we provide a single point of contact via email at: <a href="mailto:conduct@godotengine.org">conduct@godotengine.org</a>. If you are more comfortable reaching out to a single person, you are also welcome to contact one or more members of the team using their personal emails <a href="#coc-team">listed below</a>, or via direct messaging on community platforms where they are present.
-</p>
+  <p>
+    The Godot team recognizes that it can be difficult to come forward in cases of a violation of the Code of Conduct. To make it easier to report violations, we provide a single point of contact via email at: <a href="mailto:conduct@godotengine.org">conduct@godotengine.org</a>. If you are more comfortable reaching out to a single person, you are also welcome to contact one or more members of the team using their personal emails <a href="#coc-team">listed below</a>, or via direct messaging on community platforms where they are present.
+  </p>
 
-<h3 class="title" id="coc-team">Code of Conduct team</h3>
+  <h3 class="title" id="coc-team">Code of Conduct team</h3>
 
-<ul>
-  <li>
-    George Marques, george@godotengine.org (he/him)
-    <ul>
-      <li>GitHub / Contributors Chat / Discord / Reddit / Twitter: <em>vnen</em></li>
-      <li>Languages: English, Portuguese</li>
-    </ul>
-  </li>
-  <li>
-    Hein-Pieter van Braam-Stewart, hp@godotengine.org (he/him)
-    <ul>
-      <li>GitHub: <em>hpvb</em> – Contributors Chat: <em>hp</em> – Discord / Reddit: <em>TMM</em></li>
-      <li>Languages: English, Dutch</li>
-    </ul>
-  </li>
-  <li>
-    Ilaria Cislaghi, ilaria@godotengine.org (she/her)
-    <ul>
-      <li>GitHub / Contributors Chat / Discord / Twitter: <em>QbieShay</em></li>
-      <li>Languages: English, Italian</li>
-    </ul>
-  </li>
-  <li>
-    Julian Murgia, julian@godotengine.org (he/him)
-    <ul>
-      <li>GitHub / Contributors Chat / Discord/ Reddit: <em>StraToN</em> – Twitter: <em>TheStraToN</em></li>
-      <li>Languages: English, French</li>
-    </ul>
-  </li>
-  <li>
-    Lara Herzog, lara@godotengine.org (she/her)
-    <ul>
-      <li>GitHub / Discord: <em>cuddlefishie</em> – Contributors Chat: <em>cuddlefish</em> – Twitter: <em>cuddlefishiiie</em></li>
-      <li>Languages: English, German</li>
-    </ul>
-  </li>
-  <li>
-    Rémi Verschelde, remi@godotengine.org (he/him)
-    <ul>
-      <li>GitHub / Reddit: <em>akien-mga</em> – Contributors Chat / Discord / Twitter: <em>Akien</em></li>
-      <li>Languages: English, French, German</li>
-    </ul>
-  </li>
-</ul>
+  <ul>
+    <li>
+      George Marques, george@godotengine.org (he/him)
+      <ul>
+        <li>GitHub / Contributors Chat / Discord / Reddit / Twitter: <em>vnen</em></li>
+        <li>Languages: English, Portuguese</li>
+      </ul>
+    </li>
+    <li>
+      Hein-Pieter van Braam-Stewart, hp@godotengine.org (he/him)
+      <ul>
+        <li>GitHub: <em>hpvb</em> – Contributors Chat: <em>hp</em> – Discord / Reddit: <em>TMM</em></li>
+        <li>Languages: English, Dutch</li>
+      </ul>
+    </li>
+    <li>
+      Ilaria Cislaghi, ilaria@godotengine.org (she/her)
+      <ul>
+        <li>GitHub / Contributors Chat / Discord / Twitter: <em>QbieShay</em></li>
+        <li>Languages: English, Italian</li>
+      </ul>
+    </li>
+    <li>
+      Julian Murgia, julian@godotengine.org (he/him)
+      <ul>
+        <li>GitHub / Contributors Chat / Discord/ Reddit: <em>StraToN</em> – Twitter: <em>TheStraToN</em></li>
+        <li>Languages: English, French</li>
+      </ul>
+    </li>
+    <li>
+      Lara Herzog, lara@godotengine.org (she/her)
+      <ul>
+        <li>GitHub / Discord: <em>cuddlefishie</em> – Contributors Chat: <em>cuddlefish</em> – Twitter: <em>cuddlefishiiie</em></li>
+        <li>Languages: English, German</li>
+      </ul>
+    </li>
+    <li>
+      Rémi Verschelde, remi@godotengine.org (he/him)
+      <ul>
+        <li>GitHub / Reddit: <em>akien-mga</em> – Contributors Chat / Discord / Twitter: <em>Akien</em></li>
+        <li>Languages: English, French, German</li>
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/themes/godotengine/pages/contact.htm
+++ b/themes/godotengine/pages/contact.htm
@@ -7,7 +7,7 @@ is_hidden = 0
 {##}
 {% put title %} Contact us {% endput %}
 
-<div class="container">
+<div class="container-text">
 
   <h3 class="title">Support</h3>
   <p>

--- a/themes/godotengine/pages/governance.htm
+++ b/themes/godotengine/pages/governance.htm
@@ -7,8 +7,7 @@ is_hidden = 0
 {##}
 {% put title %} Governance model {% endput %}
 
-<div class="container">
-
+<div class="container-text">
   <h3>Legal status</h3>
   <p>
     On its own, Godot has no legal status. Godot exists as a member project of

--- a/themes/godotengine/pages/license.htm
+++ b/themes/godotengine/pages/license.htm
@@ -7,81 +7,83 @@ is_hidden = 0
 {##}
 {% put title %} License {% endput %}
 
-<h3 class="title">The engine</h3>
-<p>
-  Godot&nbsp;Engine is <a href="https://en.wikipedia.org/wiki/Free_and_open_source_software">free and open source software</a>
-  released under the permissive <a href="https://github.com/godotengine/godot/blob/master/LICENSE.txt">MIT license</a> (also named Expat license).
-</p>
-<p>This license grants users a number of freedoms:</p>
-<ul>
-  <li>You are free to use Godot&nbsp;Engine, for any purpose</li>
-  <li>You can study how Godot&nbsp;Engine works and change it</li>
-  <li>You can distribute unmodified and changed versions of Godot&nbsp;Engine, even commercially and under a different license (including proprietary)</li>
-</ul>
-<p>
-  The only restriction to that third freedom is that you need to distribute the copyright notice and license statement of Godot&nbsp;Engine whenever you redistribute it.
-  So your derivative product may have a different license, but should still state in its documentation that it derives from the MIT licensed Godot&nbsp;Engine (see below).
-</p>
+<div class="container-text">
+  <h3 class="title">The engine</h3>
+  <p>
+    Godot&nbsp;Engine is <a href="https://en.wikipedia.org/wiki/Free_and_open_source_software">free and open source software</a>
+    released under the permissive <a href="https://github.com/godotengine/godot/blob/master/LICENSE.txt">MIT license</a> (also named Expat license).
+  </p>
+  <p>This license grants users a number of freedoms:</p>
+  <ul>
+    <li>You are free to use Godot&nbsp;Engine, for any purpose</li>
+    <li>You can study how Godot&nbsp;Engine works and change it</li>
+    <li>You can distribute unmodified and changed versions of Godot&nbsp;Engine, even commercially and under a different license (including proprietary)</li>
+  </ul>
+  <p>
+    The only restriction to that third freedom is that you need to distribute the copyright notice and license statement of Godot&nbsp;Engine whenever you redistribute it.
+    So your derivative product may have a different license, but should still state in its documentation that it derives from the MIT licensed Godot&nbsp;Engine (see below).
+  </p>
 
-<h3 class="title">Your game</h3>
-<p>
-  Godot&nbsp;Engine's license terms and copyright do not apply to the content you create with it; you are free to license your games how you see best fit,
-  and will be their sole copyright owner(s).
-</p>
-<p>
-  Note however that the Godot&nbsp;Engine binary that you would distribute with your game is a copy of the "Software" as defined in the license,
-  and you are therefore required to include the copyright notice and license statement somewhere in your documentation.
-</p>
-<p>
-  The Godot&nbsp;Engine developers consider that a link to this page (<a href="/license">godotengine.org/license</a>) in your game documentation or credits would be an
-  acceptable way to satisfy the license terms.
-</p>
-<p>
-  See <a href="https://docs.godotengine.org/en/latest/about/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
-</p>
+  <h3 class="title">Your game</h3>
+  <p>
+    Godot&nbsp;Engine's license terms and copyright do not apply to the content you create with it; you are free to license your games how you see best fit,
+    and will be their sole copyright owner(s).
+  </p>
+  <p>
+    Note however that the Godot&nbsp;Engine binary that you would distribute with your game is a copy of the "Software" as defined in the license,
+    and you are therefore required to include the copyright notice and license statement somewhere in your documentation.
+  </p>
+  <p>
+    The Godot&nbsp;Engine developers consider that a link to this page (<a href="/license">godotengine.org/license</a>) in your game documentation or credits would be an
+    acceptable way to satisfy the license terms.
+  </p>
+  <p>
+    See <a href="https://docs.godotengine.org/en/latest/about/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
+  </p>
 
-<h3 class="title">License text</h3>
-<p>
-  A plain text version of the license is available from Godot&nbsp;Engine's GitHub repository: <a href="https://github.com/godotengine/godot/blob/master/LICENSE.txt">LICENSE.txt</a>.<br />
-  A list of contributors is also available: <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md">AUTHORS.md</a>.
-</p>
+  <h3 class="title">License text</h3>
+  <p>
+    A plain text version of the license is available from Godot&nbsp;Engine's GitHub repository: <a href="https://github.com/godotengine/godot/blob/master/LICENSE.txt">LICENSE.txt</a>.<br />
+    A list of contributors is also available: <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md">AUTHORS.md</a>.
+  </p>
 
-<pre>
-Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.
-Copyright (c) 2014-2022 Godot Engine contributors.
+  <pre>
+  Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.
+  Copyright (c) 2014-2022 Godot Engine contributors.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
 
--- Godot Engine &lt;https://godotengine.org&gt;
-</pre>
+  -- Godot Engine &lt;https://godotengine.org&gt;
+  </pre>
 
-<h3 class="title">Third-party components</h3>
-<p>
-  Godot&nbsp;Engine uses several third-party libraries and code snippets, which are distributed under their own license and copyright statements.
-  All such components are compatible with the terms of Godot&nbsp;Engine's MIT license.
-  You can refer to <a href="https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt">this list</a>
-  for a comprehensive overview of all third-party components used in Godot&nbsp;Engine and their respective licenses.
-</p>
+  <h3 class="title">Third-party components</h3>
+  <p>
+    Godot&nbsp;Engine uses several third-party libraries and code snippets, which are distributed under their own license and copyright statements.
+    All such components are compatible with the terms of Godot&nbsp;Engine's MIT license.
+    You can refer to <a href="https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt">this list</a>
+    for a comprehensive overview of all third-party components used in Godot&nbsp;Engine and their respective licenses.
+  </p>
 
-<h3 class="title">Disclaimer</h3>
-<p>
-  The above explanations of Godot&nbsp;Engine's license terms and their implications for its users do not constitute legal advice.
-  They reflect the Godot&nbsp;Engine team's understanding of their own license terms and that of their third-party components;
-  in case of doubt, please refer to your lawyer.
-</p>
+  <h3 class="title">Disclaimer</h3>
+  <p>
+    The above explanations of Godot&nbsp;Engine's license terms and their implications for its users do not constitute legal advice.
+    They reflect the Godot&nbsp;Engine team's understanding of their own license terms and that of their third-party components;
+    in case of doubt, please refer to your lawyer.
+  </p>
+</div>

--- a/themes/godotengine/pages/privacy-policy.htm
+++ b/themes/godotengine/pages/privacy-policy.htm
@@ -7,7 +7,7 @@ is_hidden = 0
 {##}
 {% put title %} Privacy policy {% endput %}
 
-<div class="container">
+<div class="container-text">
 
   <h3 class="title">Scope of This Notice</h3>
 

--- a/themes/godotengine/pages/teams.htm
+++ b/themes/godotengine/pages/teams.htm
@@ -7,435 +7,436 @@ is_hidden = 0
 {##}
 {% put title %} Godot&nbsp;Engine teams {% endput %}
 
-<p>
-  This pages provides an overview of the various teams working on Godot&nbsp;Engine. If you want to know who works on what, who to get in contact with on a topic,
-    which people should review a particular Pull Request or similar - this is a good first stop.
-</p>
-
-<p>
-  Engine teams are listed by engine area, with a few keywords describing what belongs to that area and a link to the teams chat channel,
-    followed by a list of the members of that team (names and GitHub handles). For some larger areas, subteams exist for parts of that area.<br>
-  Names in bold with a ⭐ emoji are the main contributors in charge of a given area, who typically lead the team work and can merge Pull Requests in their area of expertise.
-</p>
-
-<p>
-  If you want to get in touch, use the link to each team's chat channel on the Godot&nbsp;Engine Contributors chat after the team's names (see <a href="/community">Community</a>).<br>
-  For general development discussions which may not fit a specific team channel, use the general purpose <a href="https://chat.godotengine.org/channel/devel">#devel</a> channel.<br>
-  For general enquiries, private or security related matters, have a look at the <a href="/contact">Contact</a> page.
-</p>
-
-
-<h2 class="title" id="general">General areas</h2>
-
-<p>
-  Categorizing the engine development in discrete teams is not easy! This section includes some broad areas which have an influence on all engine subsystems,
-    and where many contributors are active without necessarily being responsible for all the features that their team encompasses.<br>
-  Some more specialized teams are then listed in the <a href="#systems">Systems</a> section.
-</p>
-
-<div class="teams-team-section">
-  <h4 class="title" id="core">Core • <a href="https://chat.godotengine.org/channel/core">#core</a></h4>
-
+<div class="container-text">
   <p>
-    <em>Low-level Core API: Object, Variant, templates, base nodes like Node, Viewport, etc.
-      (everything under <a href="https://github.com/godotengine/godot/tree/master/core"><code>core</code></a> and
-      <a href="https://github.com/godotengine/godot/tree/master/scene/main"><code>scene/main</code></a>).</em>
+    This pages provides an overview of the various teams working on Godot&nbsp;Engine. If you want to know who works on what, who to get in contact with on a topic,
+      which people should review a particular Pull Request or similar - this is a good first stop.
   </p>
 
   <p>
-    <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>, George Marques (<a href="https://github.com/vnen">@vnen</a>),
-      Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>), Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)<br>
+    Engine teams are listed by engine area, with a few keywords describing what belongs to that area and a link to the teams chat channel,
+      followed by a list of the members of that team (names and GitHub handles). For some larger areas, subteams exist for parts of that area.<br>
+    Names in bold with a ⭐ emoji are the main contributors in charge of a given area, who typically lead the team work and can merge Pull Requests in their area of expertise.
   </p>
 
-  <table class="teams-subteams">
+  <p>
+    If you want to get in touch, use the link to each team's chat channel on the Godot&nbsp;Engine Contributors chat after the team's names (see <a href="/community">Community</a>).<br>
+    For general development discussions which may not fit a specific team channel, use the general purpose <a href="https://chat.godotengine.org/channel/devel">#devel</a> channel.<br>
+    For general enquiries, private or security related matters, have a look at the <a href="/contact">Contact</a> page.
+  </p>
+
+
+  <h2 class="title" id="general">General areas</h2>
+
+  <p>
+    Categorizing the engine development in discrete teams is not easy! This section includes some broad areas which have an influence on all engine subsystems,
+      and where many contributors are active without necessarily being responsible for all the features that their team encompasses.<br>
+    Some more specialized teams are then listed in the <a href="#systems">Systems</a> section.
+  </p>
+
+  <div class="teams-team-section">
+    <h4 class="title" id="core">Core • <a href="https://chat.godotengine.org/channel/core">#core</a></h4>
+
+    <p>
+      <em>Low-level Core API: Object, Variant, templates, base nodes like Node, Viewport, etc.
+        (everything under <a href="https://github.com/godotengine/godot/tree/master/core"><code>core</code></a> and
+        <a href="https://github.com/godotengine/godot/tree/master/scene/main"><code>scene/main</code></a>).</em>
+    </p>
+
+    <p>
+      <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>, George Marques (<a href="https://github.com/vnen">@vnen</a>),
+        Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>), Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)<br>
+    </p>
+
+    <table class="teams-subteams">
+      <tr>
+        <th class="teams-subteam-name">Data Structures</th>
+        <td class="teams-subteam-members">
+          Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>), <a href="https://github.com/lawnjelly">@lawnjelly</a>
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">Threading</th>
+        <td class="teams-subteam-members">
+          Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">Input</th>
+        <td class="teams-subteam-members">
+          Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>), Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
+            Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>),
+            Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="teams-team-section">
+    <h4 class="title" id="gui-nodes">GUI Nodes • <a href="https://chat.godotengine.org/channel/gui">#gui</a></h4>
+
+    <p>
+      <em>Everything that inherits Control (everything under <a href="https://github.com/godotengine/godot/tree/master/scene/gui"><code>scene/gui</code></a>)
+        and can be used to build Graphical User Interfaces (both game UI and editor tools).</em>
+    <p>
+
+    <p>
+       Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>),
+        Gilles Roudière (<a href="https://github.com/groud">@groud</a>), Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>),
+        Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>), Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>),
+        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    </p>
+
+    <table class="teams-subteams">
+      <tr>
+        <th class="teams-subteam-name">Text</th>
+        <td class="teams-subteam-members">
+          Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>), Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="teams-team-section">
+    <h4 class="title" id="editor">Editor • <a href="https://chat.godotengine.org/channel/editor">#editor</a></h4>
+
+    <p>
+      <em>All things related to the editor, both tools and usability (<a href="https://github.com/godotengine/godot/tree/master/editor"><code>editor</code></a>).</em>
+    </p>
+
+    <p>
+      Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>), Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
+        Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>), Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
+        Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>), Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>),
+        Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>), Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    </p>
+
+    <table class="teams-subteams">
+      <tr>
+        <th class="teams-subteam-name">2D</th>
+        <td class="teams-subteam-members">
+          Gilles Roudière (<a href="https://github.com/groud">@groud</a>), Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),
+            Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">3D</th>
+        <td class="teams-subteam-members">
+          Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">Debugger</th>
+        <td class="teams-subteam-members">
+          Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>), George Marques (<a href="https://github.com/vnen">@vnen</a>)
+        </td>
+      </tr>
     <tr>
-      <th class="teams-subteam-name">Data Structures:</th>
-      <td class="teams-subteam-members">
-        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>), <a href="https://github.com/lawnjelly">@lawnjelly</a>
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">Threading:</th>
-      <td class="teams-subteam-members">
-        Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">Input:</th>
-      <td class="teams-subteam-members">
-        Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>), Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-          Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>),
-          Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
-      </td>
-    </tr>
-  </table>
-</div>
+        <th class="teams-subteam-name">Script editor</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>)</span>,
+            Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)
+        </td>
+      </tr>
+    </table>
+  </div>
 
-<div class="teams-team-section">
-  <h4 class="title" id="gui-nodes">GUI Nodes • <a href="https://chat.godotengine.org/channel/gui">#gui</a></h4>
+  <div class="teams-team-section">
+    <h4 class="title" id="scripting">Scripting • <a href="https://chat.godotengine.org/channel/scripting">#scripting</a></h4>
+
+    <p>
+      <em>Umbrella team for all the scripting languages usable with Godot. Encompasses some shared core components (Object, ClassDB, MethodBind, ScriptLanguage, etc.)
+        and language specific implementations in dedicated subteams.</em>
+    </p>
+
+    <p>
+      George Marques (<a href="https://github.com/vnen">@vnen</a>), Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>),
+        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
+    </p>
+
+    <table class="teams-subteams">
+      <tr>
+        <th class="teams-subteam-name">GDExtension (<a href="https://chat.godotengine.org/channel/gdextension">#gdextension</a>)</th>
+        <td class="teams-subteam-members">
+          Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>),
+          Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>), George Marques (<a href="https://github.com/vnen">@vnen</a>),
+          Gilles Roudière (<a href="https://github.com/groud">@groud</a>), Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>), Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">GDScript (<a href="https://chat.godotengine.org/channel/gdscript">#gdscript</a>)</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">Mono / C#</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)</span>,
+          Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>), Raul Santos (<a href="https://github.com/raulsntos">@raulsntos</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">VisualScript</th>
+        <td class="teams-subteam-members">
+          K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>)
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="teams-team-section">
+    <h4 class="title" id="buildsystem">Buildsystem • <a href="https://chat.godotengine.org/channel/buildsystem">#buildsystem</a></h4>
+
+    <p>
+      <em>Tools and scripts that we use to compile and maintain Godot, both for development purpose (SCons, CI) and releases (official build containers).</em>
+    </p>
+
+    <p>
+      <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
+        Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>), Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
+        Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>), Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
+        Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)
+    </p>
+  </div>
+
+  <div class="teams-team-section">
+    <h4 class="title" id="platforms">Platforms • <a href="https://chat.godotengine.org/channel/platforms">#platforms</a></h4>
+
+    <p>
+      <em>Platform specific layers that reside in <a href="https://github.com/godotengine/godot/tree/master/platform"><code>platform</code></a>, with shared components
+        (Unix, Win32, Apple, etc.) in <a href="https://github.com/godotengine/godot/tree/master/drivers"><code>drivers</code></a>.</em>
+    </p>
+
+    <p>
+      <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>,
+      <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+    </p>
+
+    <table class="teams-subteams">
+      <tr>
+        <th class="teams-subteam-name">Android (<a href="https://chat.godotengine.org/channel/android">#android</a>)</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)</span>
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">HTML5</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">iOS</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>, Sergey Minakov (<a href="https://github.com/naithar">@naithar</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">Linux / BSD</th>
+        <td class="teams-subteam-members">
+           Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
+            Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>),Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">macOS</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">UWP</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">Windows</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>, Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <h2 class="title" id="systems">Systems</h2>
 
   <p>
-    <em>Everything that inherits Control (everything under <a href="https://github.com/godotengine/godot/tree/master/scene/gui"><code>scene/gui</code></a>)
-      and can be used to build Graphical User Interfaces (both game UI and editor tools).</em>
-  <p>
-
-  <p>
-    Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>), Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-      Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>), Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),
-      Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>), Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>),
-      Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    Specialized subsystems with their dedicated teams and communication channels.
   </p>
 
-  <table class="teams-subteams">
-    <tr>
-      <th class="teams-subteam-name">Text:</th>
-      <td class="teams-subteam-members">
-        Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>), Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)
-      </td>
-    </tr>
-  </table>
-</div>
+  <div class="teams-team-section">
+    <h4 class="title" id="animation">Animation • <a href="https://chat.godotengine.org/channel/animation">#animation</a></h4>
 
-<div class="teams-team-section">
-  <h4 class="title" id="editor">Editor • <a href="https://chat.godotengine.org/channel/editor">#editor</a></h4>
+    <p>
+      <em>Nodes and features for 2D and 3D animation and IK workflows.</em>
+    </p>
 
-  <p>
-    <em>All things related to the editor, both tools and usability (<a href="https://github.com/godotengine/godot/tree/master/editor"><code>editor</code></a>).</em>
-  </p>
+    <p>
+      <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
+        K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>), <a href="https://github.com/lyuma">@lyuma</a>,
+        Silc 'Tokage' Renew (<a href="https://github.com/TokageItLab">@TokageItLab</a>), <a href="https://github.com/SaracenOne">SaracenOne</a>
+    </p>
+  </div>
 
-  <p>
-    Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>), Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-      Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>), Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-      Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>), Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>),
-      Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>), Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
-  </p>
+  <div class="teams-team-section">
+    <h4 class="title" id="audio">Audio • <a href="https://chat.godotengine.org/channel/audio">#audio</a></h4>
 
-  <table class="teams-subteams">
-    <tr>
-      <th class="teams-subteam-name">2D:</th>
-      <td class="teams-subteam-members">
-        Gilles Roudière (<a href="https://github.com/groud">@groud</a>), Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),
-          Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">3D:</th>
-      <td class="teams-subteam-members">
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">Debugger:</th>
-      <td class="teams-subteam-members">
-        Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>), George Marques (<a href="https://github.com/vnen">@vnen</a>)
-      </td>
-    </tr>
-  <tr>
-      <th class="teams-subteam-name">Script editor:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>)</span>,
-          Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)
-      </td>
-    </tr>
-  </table>
-</div>
+    <p>
+      <em>All audio-related features, from low-level AudioServer and drivers to high-level nodes and effects.</em>
+    </p>
 
-<div class="teams-team-section">
-  <h4 class="title" id="scripting">Scripting • <a href="https://chat.godotengine.org/channel/scripting">#scripting</a></h4>
+    <p>
+      Ellen Poe (<a href="https://github.com/ellenhp">@ellenhp</a>), Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
+    </p>
+  </div>
 
-  <p>
-    <em>Umbrella team for all the scripting languages usable with Godot. Encompasses some shared core components (Object, ClassDB, MethodBind, ScriptLanguage, etc.)
-      and language specific implementations in dedicated subteams.</em>
-  </p>
+  <div class="teams-team-section">
+    <h4 class="title" id="import">Import • <a href="https://chat.godotengine.org/channel/asset-pipeline">#asset-pipeline</a></h4>
 
-  <p>
-    George Marques (<a href="https://github.com/vnen">@vnen</a>), Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>),
-      Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
-  </p>
+    <p>
+      <em>Asset import pipeline for 2D (textures) and 3D (scenes, models, animations, etc.).</em>
+    </p>
 
-  <table class="teams-subteams">
-    <tr>
-      <th class="teams-subteam-name">GDExtension (<a href="https://chat.godotengine.org/channel/gdextension">#gdextension</a>):</th>
-      <td class="teams-subteam-members">
-        Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>), Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
-        George Marques (<a href="https://github.com/vnen">@vnen</a>), Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>), Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">GDScript (<a href="https://chat.godotengine.org/channel/gdscript">#gdscript</a>):</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">Mono / C#:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)</span>,
-        Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>), Raul Santos (<a href="https://github.com/raulsntos">@raulsntos</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">VisualScript:</th>
-      <td class="teams-subteam-members">
-        K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>)
-      </td>
-    </tr>
-  </table>
-</div>
+    <p>
+      <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
+        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>),
+        K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>), <a href="https://github.com/lyuma">@lyuma</a>,
+        Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
+    </p>
+  </div>
 
-<div class="teams-team-section">
-  <h4 class="title" id="buildsystem">Buildsystem • <a href="https://chat.godotengine.org/channel/buildsystem">#buildsystem</a></h4>
+  <div class="teams-team-section">
+    <h4 class="title" id="networking">Networking • <a href="https://chat.godotengine.org/channel/networking">#networking</a></h4>
 
-  <p>
-    <em>Tools and scripts that we use to compile and maintain Godot, both for development purpose (SCons, CI) and releases (official build containers).</em>
-  </p>
+    <p>
+      <em>Networked multiplayer, RPCs and replication, HTTP/TCP/UDP/DNS, WebSockets, ENet, encryption.</em>
+    </p>
 
-  <p>
-    <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
-      Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>), Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
-      Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>), Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-      Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)
-  </p>
-</div>
+    <p>
+      <span class="teams-subteam-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>,
+        Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)
+    </p>
+  </div>
 
-<div class="teams-team-section">
-  <h4 class="title" id="platforms">Platforms • <a href="https://chat.godotengine.org/channel/platforms">#platforms</a></h4>
+  <div class="teams-team-section">
+    <h4 class="title" id="physics">Physics • <a href="https://chat.godotengine.org/channel/physics">#physics</a></h4>
 
-  <p>
-    <em>Platform specific layers that reside in <a href="https://github.com/godotengine/godot/tree/master/platform"><code>platform</code></a>, with shared components
-      (Unix, Win32, Apple, etc.) in <a href="https://github.com/godotengine/godot/tree/master/drivers"><code>drivers</code></a>.</em>
-  </p>
+    <p>
+      <em>Physics servers and their implementation in 2D and 3D.</em>
+    </p>
 
-  <p>
-    <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>,
-    <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
-  </p>
+    <p>
+      Andrea Catania (<a href="https://github.com/AndreaCatania">@AndreaCatania</a>), Fabrice Cipolla (<a href="https://github.com/fabriceci">@fabriceci</a>),
+        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>), <a href="https://github.com/lawnjelly">@lawnjelly</a>,
+        Ricardo Buring (<a href="https://github.com/rburing">@rburing</a>)
+    </p>
+  </div>
 
-  <table class="teams-subteams">
-    <tr>
-      <th class="teams-subteam-name">Android (<a href="https://chat.godotengine.org/channel/android">#android</a>):</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)</span>
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">HTML5:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">iOS:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>, Sergey Minakov (<a href="https://github.com/naithar">@naithar</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">Linux / BSD:</th>
-      <td class="teams-subteam-members">
-        Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>), Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>),
-          Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">macOS:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">UWP:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">Windows:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>, Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)
-      </td>
-    </tr>
-  </table>
-</div>
+  <div class="teams-team-section">
+    <h4 class="title" id="rendering">Rendering • <a href="https://chat.godotengine.org/channel/rendering">#rendering</a></h4>
 
-<h2 class="title" id="systems">Systems</h2>
+    <p>
+      <em>Rendering server and RenderingDevice implementations (Vulkan, OpenGL), as well as the actual rendering techniques implemented using those graphics APIs.</em>
+    </p>
 
-<p>
-  Specialized subsystems with their dedicated teams and communication channels.
-</p>
+    <p>
+      <span class="teams-subteam-leader">Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>,
+        Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>), Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
+        <a href="https://github.com/lawnjelly">@lawnjelly</a>, Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>),
+        Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>), Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
+    </p>
 
-<div class="teams-team-section">
-  <h4 class="title" id="animation">Animation • <a href="https://chat.godotengine.org/channel/animation">#animation</a></h4>
+    <table class="teams-subteams">
+      <tr>
+        <th class="teams-subteam-name">Shaders</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)</span>,
+            Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)
+        </td>
+      </tr>
+      <tr>
+        <th class="teams-subteam-name">Tech Art</th>
+        <td class="teams-subteam-members">
+          Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>), Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
+            Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="teams-team-section">
+    <h4 class="title" id="xr">XR • <a href="https://chat.godotengine.org/channel/xr">#xr</a></h4>
+
+    <p>
+      <em>Augmented (AR) and virtual reality (VR).</em>
+    </p>
+
+    <p>
+      <span class="teams-subteam-leader">Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>)</span>, Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)
+    </p>
+
+    <table class="teams-subteams">
+      <tr>
+        <th class="teams-subteam-name">WebXR</th>
+        <td class="teams-subteam-members">
+          <span class="teams-subteam-leader">David Snopek (<a href="https://github.com/dsnopek">@dsnopek</a>)</span>
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <h2 class="title" id="community">Community</h2>
 
   <p>
-    <em>Nodes and features for 2D and 3D animation and IK workflows.</em>
+    The following teams do not impact the engine code directly, but take care of all other important parts of the Godot ecosystem such
+      as the documentation, demos, website, etc.
   </p>
 
-  <p>
-    <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
-      K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>), <a href="https://github.com/lyuma">@lyuma</a>,
-      Silc 'Tokage' Renew (<a href="https://github.com/TokageItLab">@TokageItLab</a>), <a href="https://github.com/SaracenOne">SaracenOne</a>
-  </p>
-</div>
+  <div class="teams-team-section">
+    <h4 class="title" id="communication">Communication • <a href="https://chat.godotengine.org/channel/communication">#communication</a></h4>
 
-<div class="teams-team-section">
-  <h4 class="title" id="audio">Audio • <a href="https://chat.godotengine.org/channel/audio">#audio</a></h4>
+    <p>
+      <em>Coordination and collaboration around the official communication of the Godot project (blog, videos, website, social media, etc.).<br>
+      This team was newly created and we're still finding our bearings.</em>
+    </p>
 
-  <p>
-    <em>All audio-related features, from low-level AudioServer and drivers to high-level nodes and effects.</em>
-  </p>
+    <p>
+      Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>), Emilio Copolla (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>),
+        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
+        Raffaele Picca (<a href="https://github.com/RPicster">@RPicster</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
+        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    </p>
+  </div>
 
-  <p>
-    Ellen Poe (<a href="https://github.com/ellenhp">@ellenhp</a>), Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
-  </p>
-</div>
+  <div class="teams-team-section">
+    <h4 class="title" id="demos">Demos • <a href="https://chat.godotengine.org/channel/demo-content">#demo-content</a></h4>
 
-<div class="teams-team-section">
-  <h4 class="title" id="import">Import • <a href="https://chat.godotengine.org/channel/asset-pipeline">#asset-pipeline</a></h4>
+    <p>
+      <em>Maintainance and creation of official demo projects in <a href="https://github.com/godotengine/godot-demo-projects">godot-demo-projects</a>.</em>
+    </p>
 
-  <p>
-    <em>Asset import pipeline for 2D (textures) and 3D (scenes, models, animations, etc.).</em>
-  </p>
+    <p>
+      <span class="teams-subteam-leader">Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>)</span>,
+        <span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+    </p>
+  </div>
 
-  <p>
-    <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
-      Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>),
-      K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>), <a href="https://github.com/lyuma">@lyuma</a>,
-      Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
-  </p>
-</div>
+  <div class="teams-team-section">
+    <h4 class="title" id="documentation">Documentation • <a href="https://chat.godotengine.org/channel/documentation">#documentation</a></h4>
 
-<div class="teams-team-section">
-  <h4 class="title" id="networking">Networking • <a href="https://chat.godotengine.org/channel/networking">#networking</a></h4>
+    <p>
+      <em>Maintainance and writing of the official documentation at <a href="https://github.com/godotengine/godot-docs">godot-docs</a>.</em>
+    </p>
 
-  <p>
-    <em>Networked multiplayer, RPCs and replication, HTTP/TCP/UDP/DNS, WebSockets, ENet, encryption.</em>
-  </p>
-
-  <p>
-    <span class="teams-subteam-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>,
-      Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)
-  </p>
-</div>
-
-<div class="teams-team-section">
-  <h4 class="title" id="physics">Physics • <a href="https://chat.godotengine.org/channel/physics">#physics</a></h4>
-
-  <p>
-    <em>Physics servers and their implementation in 2D and 3D.</em>
-  </p>
-
-  <p>
-    Andrea Catania (<a href="https://github.com/AndreaCatania">@AndreaCatania</a>), Fabrice Cipolla (<a href="https://github.com/fabriceci">@fabriceci</a>),
-      Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>), <a href="https://github.com/lawnjelly">@lawnjelly</a>,
-      Ricardo Buring (<a href="https://github.com/rburing">@rburing</a>)
-  </p>
-</div>
-
-<div class="teams-team-section">
-  <h4 class="title" id="rendering">Rendering • <a href="https://chat.godotengine.org/channel/rendering">#rendering</a></h4>
-
-  <p>
-    <em>Rendering server and RenderingDevice implementations (Vulkan, OpenGL), as well as the actual rendering techniques implemented using those graphics APIs.</em>
-  </p>
-
-  <p>
-    <span class="teams-subteam-leader">Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>,
-      Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>), Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-      <a href="https://github.com/lawnjelly">@lawnjelly</a>, Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>),
-      Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>), Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
-  </p>
-
-  <table class="teams-subteams">
-    <tr>
-      <th class="teams-subteam-name">Shaders:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)</span>,
-          Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)
-      </td>
-    </tr>
-    <tr>
-      <th class="teams-subteam-name">Tech Art:</th>
-      <td class="teams-subteam-members">
-        Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>), Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
-          Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)
-      </td>
-    </tr>
-  </table>
-</div>
-
-<div class="teams-team-section">
-  <h4 class="title" id="xr">XR • <a href="https://chat.godotengine.org/channel/xr">#xr</a></h4>
-
-  <p>
-    <em>Augmented (AR) and virtual reality (VR).</em>
-  </p>
-
-  <p>
-    <span class="teams-subteam-leader">Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>)</span>, Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)
-  </p>
-
-  <table class="teams-subteams">
-    <tr>
-      <th class="teams-subteam-name">WebXR:</th>
-      <td class="teams-subteam-members">
-        <span class="teams-subteam-leader">David Snopek (<a href="https://github.com/dsnopek">@dsnopek</a>)</span>
-      </td>
-    </tr>
-  </table>
-</div>
-
-<h2 class="title" id="community">Community</h2>
-
-<p>
-  The following teams do not impact the engine code directly, but take care of all other important parts of the Godot ecosystem such
-    as the documentation, demos, website, etc.
-</p>
-
-<div class="teams-team-section">
-  <h4 class="title" id="communication">Communication • <a href="https://chat.godotengine.org/channel/communication">#communication</a></h4>
-
-  <p>
-    <em>Coordination and collaboration around the official communication of the Godot project (blog, videos, website, social media, etc.).<br>
-    This team was newly created and we're still finding our bearings.</em>
-  </p>
-
-  <p>
-    Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>), Emilio Copolla (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>),
-      Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
-      Raffaele Picca (<a href="https://github.com/RPicster">@RPicster</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
-      Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
-  </p>
-</div>
-
-<div class="teams-team-section">
-  <h4 class="title" id="demos">Demos • <a href="https://chat.godotengine.org/channel/demo-content">#demo-content</a></h4>
-
-  <p>
-    <em>Maintainance and creation of official demo projects in <a href="https://github.com/godotengine/godot-demo-projects">godot-demo-projects</a>.</em>
-  </p>
-
-  <p>
-    <span class="teams-subteam-leader">Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>)</span>,
-      <span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
-  </p>
-</div>
-
-<div class="teams-team-section">
-  <h4 class="title" id="documentation">Documentation • <a href="https://chat.godotengine.org/channel/documentation">#documentation</a></h4>
-
-  <p>
-    <em>Maintainance and writing of the official documentation at <a href="https://github.com/godotengine/godot-docs">godot-docs</a>.</em>
-  </p>
-
-  <p>
-    Chris Bradfield (<a href="https://github.com/cbscribe">@cbscribe</a>), Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
-      Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Matthew (<a href="https://github.com/skyace65">@skyace65</a>),
-      Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
-      Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
-  </p>
-</div>
+    <p>
+      Chris Bradfield (<a href="https://github.com/cbscribe">@cbscribe</a>), Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
+        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Matthew (<a href="https://github.com/skyace65">@skyace65</a>),
+        Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
+        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    </p>
+  </div>
 
 <div class="teams-team-section">
   <h4 class="title" id="production">Production • <a href="https://chat.godotengine.org/channel/devel">#devel</a></h4>
@@ -452,34 +453,35 @@ is_hidden = 0
   </p>
 </div>
 
-<div class="teams-team-section">
-  <h4 class="title" id="translation">Translation • <a href="https://chat.godotengine.org/channel/translation">#translation</a></h4>
+  <div class="teams-team-section">
+    <h4 class="title" id="translation">Translation • <a href="https://chat.godotengine.org/channel/translation">#translation</a></h4>
 
-  <p>
-    <em>Internationalization and localization team - building the infrastructure to make it possible to translate Godot and its documentation.</em>
-  </p>
+    <p>
+      <em>Internationalization and localization team - building the infrastructure to make it possible to translate Godot and its documentation.</em>
+    </p>
 
-  <p>
-    <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
-    <span class="teams-subteam-leader">Haoyu Qiu (<a href="https://github.com/timothyqiu">@timothyqiu</a>)</span>,
-      Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)
-  </p>
+    <p>
+      <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
+      <span class="teams-subteam-leader">Haoyu Qiu (<a href="https://github.com/timothyqiu">@timothyqiu</a>)</span>,
+        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)
+    </p>
 
-  <p>
-    If you work on Godot translations and contributors for your language have a dedicated communication channel for coordination, let us know so we can link it here.
-  </p>
-</div>
+    <p>
+      If you work on Godot translations and contributors for your language have a dedicated communication channel for coordination, let us know so we can link it here.
+    </p>
+  </div>
 
-<div class="teams-team-section">
-  <h4 class="title" id="website">Website • <a href="https://chat.godotengine.org/channel/website">#website</a></h4>
+  <div class="teams-team-section">
+    <h4 class="title" id="website">Website • <a href="https://chat.godotengine.org/channel/website">#website</a></h4>
 
-  <p>
-    <em>Maintenance of the official Godot website and other hosted resources (Q&amp;A, asset library).</em>
-  </p>
+    <p>
+      <em>Maintenance of the official Godot website and other hosted resources (Q&amp;A, asset library).</em>
+    </p>
 
-  <p>
-    <span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>,
-      Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
-      Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
-  </p>
+    <p>
+      <span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>,
+        Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
+        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    </p>
+  </div>
 </div>


### PR DESCRIPTION
Tightens up the layout and styles of the text heavy about/* pages

## Makes the following changes:
- creates new `.container-text` style to constrain text to a readable max-width
- creates subtle borders around table rows
- removes colons on table headers
- creates better header spacing for long text
 
<img width="1243" alt="Screen Shot 2022-07-22 at 11 09 08 AM" src="https://user-images.githubusercontent.com/9118169/180469430-12ee804d-a6c7-4f1f-a566-8100d01d7e5a.png">

<img width="1242" alt="Screen Shot 2022-07-22 at 11 09 21 AM" src="https://user-images.githubusercontent.com/9118169/180469436-42864451-315a-4bba-af0a-13118caa6117.png">

<img width="1239" alt="Screen Shot 2022-07-22 at 11 09 00 AM" src="https://user-images.githubusercontent.com/9118169/180469424-1e3d57af-11ea-4f7b-9edc-588b6a1eb3c5.png">

