### PR TITLE
Teams: Add Production team

### DIFF
--- a/themes/godotengine/pages/teams.htm
+++ b/themes/godotengine/pages/teams.htm
@@ -438,6 +438,21 @@ is_hidden = 0
 </div>
 
 <div class="teams-team-section">
+  <h4 class="title" id="production">Production • <a href="https://chat.godotengine.org/channel/devel">#devel</a></h4>
+
+  <p>
+    <em>The production team helps coordinate the engine development with the various teams.</em>
+  </p>
+
+  <p>
+    <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
+      Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>), Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
+      Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>), Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>),
+      Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+  </p>
+</div>
+
+<div class="teams-team-section">
   <h4 class="title" id="translation">Translation • <a href="https://chat.godotengine.org/channel/translation">#translation</a></h4>
 
   <p>


### PR DESCRIPTION
It's been operating for a while but was not part of the main draft for
the Teams page, and we weren't sure initially if it should be included
since it uses a private channel for communication.

But it would be good for contributors to know who to reach out to for
production questions, and they can use the devel channel for this.