### PR TITLE
Fix a typo in name on Teams page

### DIFF
--- a/themes/godotengine/pages/teams.htm
+++ b/themes/godotengine/pages/teams.htm
@@ -403,7 +403,7 @@ is_hidden = 0
     </p>
 
     <p>
-      Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>), Emilio Copolla (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>),
+      Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>), Emilio Coppola (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>),
         Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>), Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
         Raffaele Picca (<a href="https://github.com/RPicster">@RPicster</a>), Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
         Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)


### PR DESCRIPTION
It should be Coppola instead of Copolla