### PR TITLE
Governance: Add Clay John to list of PLC members

### DIFF
--- a/themes/godotengine/pages/governance.htm
+++ b/themes/godotengine/pages/governance.htm
@@ -32,7 +32,7 @@ is_hidden = 0
     project's funding.
   </p>
 
-  <h3>The Project Leadership Committee</h3>
+  <h3 id="plc">The Project Leadership Committee</h3>
   <p>
     The Project Leadership Committee (PLC) is responsible for making all funding
     and institutional decisions for the Godot project. The PLC is made of the
@@ -56,6 +56,7 @@ is_hidden = 0
   <ul>
     <li>Ariel Manzur — <i>ariel@godotengine.org</i></li>
     <li>Bastiaan Olij — <i>bastiaan@godotengine.org</i></li>
+    <li>Clay John — <i>clay@godotengine.org</i></li>
     <li>George Marques — <i>george@godotengine.org</i></li>
     <li>Hein-Pieter van Braam-Stewart — <i>hp@godotengine.org</i></li>
     <li>Ilaria Cislaghi — <i>ilaria@godotengine.org</i></li>
@@ -64,7 +65,7 @@ is_hidden = 0
     <li>Rémi Verschelde — <i>remi@godotengine.org</i></li>
   </ul>
 
-  <h3>Advisors</h3>
+  <h3 id="advisors">Advisors</h3>
   <p>
     The PLC has enlisted the help of its most trusted and veteran contributors
     whom they call <em>the advisors</em>. The advisors are consulted on usage


### PR DESCRIPTION
He's been part of the PLC since January, but apparently we had
ommitted to update the list on the governance page.

CC @godotengine/plc 