### PR TITLE
Fix text overflow on Teams page on mobile

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -282,6 +282,7 @@ h4 {
 
 .container-text {
   width: 100%;
+  box-sizing: border-box;
   padding: 0 24px;
   max-width: 800px;
   margin: auto;


### PR DESCRIPTION
Addresses issue found by @Calinou  on #48 https://github.com/godotengine/godot-website/pull/416#issuecomment-1204553258

Fixes mobile text overflowing
<img width="498" alt="Screen Shot 2022-08-07 at 7 40 46 PM" src="https://user-images.githubusercontent.com/9118169/183327859-a5629d78-9429-4054-93e6-69991509de45.png">

