### PR TITLE
Make the sponsors block more attractive looking

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -46,6 +46,10 @@
   --codeblock-background-color: #282b2e;
   --codeblock-color: #e0e2e4;
 
+  --sponsor-background-color: #dcdcdc;
+  --sponsor-platinum-background-color: #cfdbe4;
+  --sponsor-gold-background-color: #e0dfd4;
+
   --platform-code-background-color: #e5ebf1;
 
   --digital-store-background-color: #2d4c74;
@@ -116,6 +120,10 @@
     --code-background-color: #333639;
     --codeblock-background-color: #333639;
     --codeblock-color: hsla(0, 0%, 100%, 0.9);
+
+    --sponsor-background-color: #ffffff;
+    --sponsor-platinum-background-color: #e2ebfa;
+    --sponsor-gold-background-color: #efece2;
 
     --platform-code-background-color: #282b2e;
 

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -54,28 +54,46 @@ postPage = "{{ :slug }}"
     color: var(--dark-color-text-title);
   }
 
+  #sponsors .flex {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
   #sponsors .sponsor {
-    overflow: auto;
+    background-color: var(--sponsor-background-color);
+    border: 14px solid var(--sponsor-background-color);
+    border-radius: 8px 8px;
     display: flex;
     align-items: center;
-    height: 70px;
+    height: 80px;
     box-sizing: border-box;
     margin-bottom: 8px;
     margin-left: 8px;
+    overflow: auto;
+    opacity: 0.85;
+    transition: opacity 0.2s;
   }
 
-  #sponsors .platinum .sponsor {
-    height: 100px;
+  #sponsors .sponsor:hover {
+    filter: brightness(105%);
+    opacity: 1.0;
   }
 
   #sponsors img {
+    mix-blend-mode: multiply;
     width: inherit;
     height: 100%;
   }
 
-  #sponsors .flex {
-    justify-content: center;
-    flex-wrap: wrap;
+  #sponsors .gold .sponsor {
+    background-color: var(--sponsor-gold-background-color);
+    border-color: var(--sponsor-gold-background-color);
+  }
+
+  #sponsors .platinum .sponsor {
+    background-color: var(--sponsor-platinum-background-color);
+    border-color: var(--sponsor-platinum-background-color);
+    height: 100px;
   }
 
   .feature, #highlight {
@@ -424,10 +442,10 @@ Make sure to update this gradient when the home background image is changed.
     <h2 class="text-center">Sponsored by</h2>
 
     <div class="platinum flex">
-      <a class="sponsor card base-padding" href="https://www.gamblify.com/" target="_blank" rel="noopener">
+      <a class="sponsor card" href="https://www.gamblify.com/" target="_blank" rel="noopener">
         <img src="{{ 'assets/home/sponsors/gamblify.png' | theme }}" width="312" height="66" alt="Gamblify" loading="lazy">
       </a>
-      <a class="sponsor card base-padding" href="http://spiffcode.com/" target="_blank" rel="noopener">
+      <a class="sponsor card" href="http://spiffcode.com/" target="_blank" rel="noopener">
         <img src="{{ 'assets/home/sponsors/spiffcode.png' | theme }}" width="291" height="66" alt="Spiffcode" loading="lazy">
       </a>
     </div>


### PR DESCRIPTION
Currently the sponsors block is [rather ugly looking](https://user-images.githubusercontent.com/11782833/184226292-cd0ce25d-0323-4808-a8e7-9d9cee31f55d.png). We're limited by the logos, which only fit the light mode, and don't have a transparent background. I've tried to incorporate these limitations into the look so it feels better and looks more attractive. I've also added a bit of dimming and a sponsor-level color tint that makes the logos themselves colorized a bit.

I think it looks solid now, despite the limitations.

**Dark mode**

https://user-images.githubusercontent.com/11782833/184225790-72778d61-05fd-4400-80bd-95cee794b49c.mp4


**Light mode**

https://user-images.githubusercontent.com/11782833/184225821-557fbd3d-9c3e-4304-ad2d-4034d0837092.mp4

