### PR TITLE
Separate the text and the image of the home page's highlight section

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -252,10 +252,6 @@ a.btn,
   margin-top: 0px;
 }
 
-.base-color-text {
-  color: var(--base-color-text);
-}
-
 h1 {
   font-size: 42px;
 }

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -2,7 +2,7 @@ description = "home layout"
 
 [blogPosts]
 pageNumber = "{{ :page }}"
-postsPerPage = 4
+postsPerPage = 7
 noPostsMessage = "No posts found"
 sortOrder = "published_at desc"
 categoryPage = "home"
@@ -101,9 +101,43 @@ postPage = "{{ :slug }}"
   }
 
   #highlight {
-    min-height: 250px;
     background-size: cover;
     background-position: center;
+    background-color: var(--base-color);
+    border-radius: 4px 0 0 4px;
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+  }
+
+  #highlight .highlight-cover {
+    border-radius: 4px 0 0 0;
+    background-position: center;
+    height: 100%;
+    min-height: 250px;
+  }
+
+  #highlight .highlight-details {
+    border-radius: 0 0 0 4px;
+  }
+
+  #highlight .highlight-title {
+    text-decoration: underline;
+    text-decoration-color: var(--link-underline-color);
+    text-decoration-thickness: 0.125rem;
+  }
+
+  #news .news-list {
+    padding: 0 20px;
+  }
+
+  #news .news-shortitem {
+    color: var(--base-color-text);
+    padding: 2px 2px;
+  }
+
+  #news .news-shortitem:hover {
+    color: var(--base-color-text-hl);
   }
 
   .feature-link {
@@ -137,14 +171,6 @@ postPage = "{{ :slug }}"
     aspect-ratio: 3/2;
     object-fit: cover;
     object-position: top center;
-  }
-
-  #highlight .dark {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: var(--transparent-cover-darker);
   }
 
   .feature {
@@ -189,6 +215,15 @@ postPage = "{{ :slug }}"
 
     .features-grid {
       grid-template-columns: 1fr;
+    }
+
+    #highlight .highlight-cover {
+      background-size: auto 100%;
+      border-radius: 4px 4px 0 0;
+    }
+
+    #highlight .highlight-details {
+      border-radius: 0;
     }
   }
 </style>
@@ -236,27 +271,36 @@ Make sure to update this gradient when the home background image is changed.
 </section>
 
 <section id="news_and_highlights" class="container padded">
-  <div class="flex eqsize responsive card">
+  <div class="flex eqsize responsive card" style="border-radius: 4px;">
 
-    <a id="highlight" style="background-image: url({{ posts[0].featured_images[0].path }}); background-color: white" href="{{ 'article' | page({ slug: posts[0].slug }) }}">
-      <div class="dark base-padding">
-        <h4 class="no-margin">{{ posts[0].title }}</h4>
-        <p class="hide-on-mobile">{{ str_limit(posts[0].excerpt, 200) | raw }}</p>
+    <a id="highlight" href="{{ 'article' | page({ slug: posts[0].slug }) }}">
+      <div
+        class="highlight-cover"
+        style="background-image: url({{ posts[0].featured_images[0].path }});"
+        title="{{ posts[0].featured_images[0].title }}"
+        alt="{{ posts[0].featured_images[0].title }} {{ posts[0].featured_images[0].description }}"
+      ></div>
+      <div class="highlight-details dark base-padding">
+        <h4 class="highlight-title no-margin">{{ posts[0].title }}</h4>
+        <p class="highlight-summary hide-on-mobile">{{ str_limit(posts[0].excerpt, 200) | raw }}</p>
       </div>
     </a>
 
     <div id="news">
-      <h3 class="base-padding no-margin-bottom">News</h3>
-      <hr class="">
-      {% for post in posts %}
-      {% if post != posts[0] %}
-      <a class="base-padding flex base-color-text" href="{{ 'article'|page({ slug: post.slug }) }}">
-        <strong>{{ post.title }}</strong>
-      </a>
-      <hr>
-      {% endif %}
-      {% endfor %}
-      <div class="text-center base-padding"><a href="/news/default/1" class="btn flat no-margin">More</a></div>
+      <h3 class="base-padding no-margin-bottom" style="text-align: center;">News</h3>
+      <div class="news-list">
+        {% for post in posts %}
+        {% if post != posts[0] %}
+        <a class="news-shortitem" href="{{ 'article'|page({ slug: post.slug }) }}">
+          <strong>· {{ post.title }}</strong>
+        </a>
+        <hr>
+        {% endif %}
+        {% endfor %}
+      </div>
+      <div class="base-padding" style="text-align: right;">
+        <a href="/news/default/1" class="btn flat no-margin">More</a>
+      </div>
     </div>
 
   </div>


### PR DESCRIPTION
As @coppolaemilio noted, it'd be better if the text didn't cover the image (we did similar changes to the feature cards below). We also can show more news in there, so it looks a bit more substantial. So here's the changes that achieve that.

[Desktop Before](https://user-images.githubusercontent.com/11782833/184265472-94c779c7-93c8-4218-af78-b9134017cbcd.png)
[Desktop After](https://user-images.githubusercontent.com/11782833/184265454-e30805e7-d01f-436b-b3b4-ba22dd1f5fb5.png)
[In Light mode](https://user-images.githubusercontent.com/11782833/184265639-7c99f98b-c8a7-42b8-a1bc-256542ac8d4f.png)


[Mobile Before](https://user-images.githubusercontent.com/11782833/184265554-eea131fa-5332-4ea5-8a88-9faa8eed4e6f.png)
[Mobile After](https://user-images.githubusercontent.com/11782833/184265530-0c439d13-7f8f-4141-b0da-255f40985c8c.png)

Comparison in action:

https://user-images.githubusercontent.com/11782833/184265660-979198a7-a5cb-4b31-b6aa-8a9082981140.mp4

