### PR TITLE
Fix City Game Studio trailer URL on showcase page

### DIFF
--- a/themes/godotengine/pages/showcase/city-game-studio.htm
+++ b/themes/godotengine/pages/showcase/city-game-studio.htm
@@ -69,6 +69,6 @@ is_hidden = 0
 
 {% put image %} city-game-studio.png {% endput image %}
 {% put placeholder %} linear-gradient(90deg, #d7dac1 14%, #d7dac1 27%, #7c7171 70%, #a69483 87%) {% endput %}
-{% put youtube_embed_code %} TODO {% endput %}
+{% put youtube_embed_code %} hcRDBdvtuVQ {% endput %}
 {% put link_steam %} https://store.steampowered.com/app/726840/City_Game_Studio_a_tycoon_about_game_dev/ {% endput %}
 {% put link_itch %} https://binogure.itch.io/city-game-studio {% endput %}


### PR DESCRIPTION
The video ID is TODO actually while the original trailer should be `hcRDBdvtuVQ`.

See the original trailer: https://www.youtube.com/watch?v=hcRDBdvtuVQ

Cheers