### PR TITLE
fix news-highlight img

### DIFF
--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -113,6 +113,7 @@ postPage = "{{ :slug }}"
   #highlight .highlight-cover {
     border-radius: 4px 0 0 0;
     background-position: center;
+    background-size: cover;
     height: 100%;
     min-height: 250px;
   }
@@ -218,7 +219,6 @@ postPage = "{{ :slug }}"
     }
 
     #highlight .highlight-cover {
-      background-size: auto 100%;
       border-radius: 4px 4px 0 0;
     }
 


### PR DESCRIPTION
This will fix some placement issues with news images and should work with all kinds of viewport sizes.

### Before:
![chrome-capture-2022-8-26](https://user-images.githubusercontent.com/1307706/192257385-8493b4d4-8daf-4550-b1b4-9e4632adb2c9.png)

### After:
![chrome-capture-2022-8-26 (1)](https://user-images.githubusercontent.com/1307706/192257424-7c16651b-55a7-401a-9c86-c4a7b8e69d58.png)
