### PR TITLE
Update the Godot Forums contact hyperlink

### DIFF
--- a/themes/godotengine/pages/contact.htm
+++ b/themes/godotengine/pages/contact.htm
@@ -48,7 +48,7 @@ is_hidden = 0
     Note that <a href="https://godotforums.org/">Godot Forums</a> accounts are
     managed by a third party. Therefore, account removal requests for the Godot Forums
     must be directed to its administrators, not to us:
-    <a href="https://godotforums.org/contact/">Godot Forums Contact</a>
+    <a href="https://godotforums.org/p/1-contact">Godot Forums Contact</a>
   </p>
 
   <h3 class="title">General inquiries</h3>


### PR DESCRIPTION
The current hyperlink in the "Account removal" section of the contact page - "https://godotforums.org/contact/" leads to an error page. The updated URL is "https://godotforums.org/p/1-contact".