### PR TITLE
Change documentation URLs on Features page to point to stable branch

### DIFF
--- a/themes/godotengine/pages/features.htm
+++ b/themes/godotengine/pages/features.htm
@@ -220,7 +220,7 @@ is_hidden = 0
       <li><strong>Export to mobile platforms:</strong> iOS and Android.</li>
       <li>
         <strong>Consoles:</strong> Nintendo Switch, PlayStation 4, Xbox One via third-party providers
-        <a href="https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html">(read more).</a>
+        <a href="https://docs.godotengine.org/en/stable/tutorials/platform/consoles.html">(read more).</a>
       </li>
       <li><strong>Export to the web</strong> using HTML5 and WebAssembly.</li>
       <li><strong>One-click deploy &amp; export</strong> to most platforms. Easily create custom builds as well.</li>

--- a/themes/godotengine/pages/features.htm
+++ b/themes/godotengine/pages/features.htm
@@ -163,14 +163,14 @@ is_hidden = 0
         </li>
         <li>
           <strong>Full C++ support</strong> without needing to recompile the engine using
-          <a href="https://docs.godotengine.org/en/latest/tutorials/scripting/gdnative/what_is_gdnative.html">GDNative</a>.
+          <a href="https://docs.godotengine.org/en/stable/tutorials/scripting/gdnative/what_is_gdnative.html">GDNative</a>.
         </li>
         <li>
           <strong><a href="https://docs.godotengine.org/en/stable/getting_started/scripting/visual_script/index.html">Visual scripting</a></strong>
           using blocks and connections.
         </li>
         <li>
-          <strong><a href="https://docs.godotengine.org/en/latest/tutorials/scripting/gdnative/what_is_gdnative.html#supported-languages">Additional languages</a></strong>
+          <strong><a href="https://docs.godotengine.org/en/stable/tutorials/scripting/gdnative/what_is_gdnative.html#supported-languages">Additional languages</a></strong>
           with community-provided support for Rust, Nim, D and other languages.
         </li>
         <li><strong>Built-in editor</strong> with syntax highlighting, real-time parser and code completion.</li>

--- a/themes/godotengine/pages/governance.htm
+++ b/themes/godotengine/pages/governance.htm
@@ -178,7 +178,7 @@ is_hidden = 0
       cases based on problems they are having with their current projects. This
       allows maintainers and contributors to have a much more "down to earth"
       understanding of user's requirements. This philosophy is best explained in
-      the <a href="https://docs.godotengine.org/en/latest/community/contributing/best_practices_for_engine_contributors.html"
+      the <a href="https://docs.godotengine.org/en/stable/community/contributing/best_practices_for_engine_contributors.html"
       >engine contributor guidelines</a>.
     </li>
     <li>

--- a/themes/godotengine/pages/license.htm
+++ b/themes/godotengine/pages/license.htm
@@ -38,7 +38,7 @@ is_hidden = 0
     acceptable way to satisfy the license terms.
   </p>
   <p>
-    See <a href="https://docs.godotengine.org/en/latest/about/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
+    See <a href="https://docs.godotengine.org/en/stable/about/complying_with_licenses.html">Complying with Licenses</a> in the documentation for more information.
   </p>
 
   <h3 class="title">License text</h3>


### PR DESCRIPTION
Currently, links to gdnative documentation on the features page link to `latest` documentation, which is missing pages for gdnative.

This PR changes those links to the `stable` documentation, which does have the gdnative page present.

There is another link on this page which points to `latest` documentation (https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html), but this link is alive and valid.

*Bugsquad edit: This closes https://github.com/godotengine/godot-website/issues/448.*