### PR TITLE
adjusts article image sizing to be the same width as content

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -65,10 +65,6 @@ categoryPage = "article"
     margin-bottom: 16px;
   }
 
-  article img:first-child, article video:first-child {
-    max-width: 85%;
-  }
-
   article h1 {
     margin-top: 64px;
   }

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -48,6 +48,14 @@ categoryPage = "article"
     box-shadow: 0px 3px 2px 0px rgba(0, 0, 0, 0.15);
   }
 
+  figure {
+    margin: 0;
+  }
+
+  figure img {
+    margin: 0;
+  }
+
   article img, article video {
     max-width: 100%;
     height: auto;
@@ -101,7 +109,7 @@ categoryPage = "article"
   <article class="flex padded">
     <div class="content content-article">
       {# Lightbox elements and classes are added to all images via JavaScript. #}
-      <figure style="text-align: center">
+      <figure>
         <img
           src="{{ post.featured_images[0].path }}"
           title="{{ post.featured_images[0].title }}"


### PR DESCRIPTION
# Summary
Slight adjustments to the hero image on articles to allow them to flow to the full width of the content

<img width="844" alt="Screen Shot 2022-10-18 at 8 26 31 PM" src="https://user-images.githubusercontent.com/9118169/196590756-b2594aa5-e4f5-4c37-89c0-0db8fd9de556.png">
<img width="452" alt="Screen Shot 2022-10-18 at 8 26 45 PM" src="https://user-images.githubusercontent.com/9118169/196590769-866d5653-62d7-4d23-9803-b63189fbaac5.png">
<img width="1431" alt="Screen Shot 2022-10-18 at 8 26 54 PM" src="https://user-images.githubusercontent.com/9118169/196590774-768f6cf7-8571-46dc-85fa-c470a490210b.png">
