### PR TITLE
Removing the name attribute from the OG image meta.

### DIFF
--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -14,7 +14,7 @@ description = "head partial"
   {% if this.page.id == 'home' %}
   <meta property="og:title" name="twitter:title" content="Free and open source 2D and 3D game engine">
   <meta property="og:description" name="twitter:description" content="{{ this.page.description }}">
-  <meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
+  <meta property="og:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   <title>Godot Engine - Free and open source 2D and 3D game engine</title>
@@ -24,13 +24,13 @@ description = "head partial"
   <meta property="og:title" name="twitter:title" content="{{ post.title }}">
   <meta property="og:description" name="twitter:description" content="{{ post.summary }}">
   <meta property="og:type" content="article">
-  <meta property="og:image" name="twitter:image" content="{{ post.featured_images[0].path }}">
+  <meta property="og:image" content="{{ post.featured_images[0].path }}">
   <meta name="twitter:card" content="summary_large_image">
   {% else %}
   <title>Godot Engine - {{ this.page.title }}</title>
   <meta property="og:title" name="twitter:title" content="{{ this.page.title }}">
   <meta property="og:description" name="twitter:description" content="{{ this.page.description }}">
-  <meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
+  <meta property="og:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   {% endif %}


### PR DESCRIPTION
The og image is not being indexed by sites like Reddit. By removing the `name="twitter:image"` it should get the preview image properly.

I'm not sure if we will also need to specify the `<meta property="og:image:type" content="image/jpeg" />` one, but I think we should try with this one first and see if it works. There isn't a way to test this locally, so we need to give it a go as-is. 