### PR TITLE
Showcase: Primal Light is releasing on Switch

### DIFF
--- a/themes/godotengine/pages/showcase.htm
+++ b/themes/godotengine/pages/showcase.htm
@@ -127,7 +127,7 @@ is_hidden = 0
       partial "showcase/list-item"
       title="Primal Light"
       author="Fat Gem"
-      platforms="windows, macos, linux"
+      platforms="windows, macos, linux, switch"
       slug="primal-light"
       image="primal-light.png"
       placeholder="linear-gradient(90deg, #24190a 5%, #24190a 15%, #25190a 28%, #25190a 83%)"

--- a/themes/godotengine/pages/showcase/primal-light.htm
+++ b/themes/godotengine/pages/showcase/primal-light.htm
@@ -9,11 +9,11 @@ is_hidden = 0
 {% put author %} Fat Gem {% endput %}
 {% put author_url %} https://twitter.com/primallightgame {% endput %}
 {% put release_date %} July 2020 {% endput %}
-{% put platforms %} windows, macos, linux {% endput %}
+{% put platforms %} windows, macos, linux, switch {% endput %}
 
 {% put description %}
 <p>
-  Primal Light is a linear 2D action platformer for Windows, Mac, and Linux.
+  Primal Light is a linear 2D action platformer for Windows, Mac, Linux, and Nintendo Switch.
   Inhabit Krog, a mysterious blue creature in a red loincloth, as he traverses a
   labyrinth of ladders, levers, traps, and monsters. Explore the nooks and
   crannies of a bizarre and evocative world as you hack and slash your way to


### PR DESCRIPTION
It will be released on 2022.11.24.

I was notified of it by porting/publisher [No Gravity Games](https://nogravitygames.com/) and there website indeed confirms the upcoming release.