### PR TITLE
Make styling of news tags more consistent

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -776,10 +776,20 @@ p.small {
 
 .tag {
   display: inline-block;
-  border-radius: 1000px;
   background-color: var(--card-background-color);
+  border-radius: 1000px;
+  box-shadow: var(--base-shadow);
+  filter: saturate(0.35);
+  font-family: "Montserrat", sans-serif;
+  font-size: 16px;
   padding: 0.25rem 0.75rem;
   margin: 0.1rem;
+  opacity: 0.8;
+}
+
+.tag.active {
+  filter: saturate(1);
+  opacity: 1;
 }
 
 .card {

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -78,6 +78,10 @@ categoryPage = "article"
     margin-bottom: 64px;
   }
 
+  .tag.active {
+    filter: saturate(0.75);
+  }
+
   @media screen and (min-width: 900px) {
     article .content {
       width: 70%;
@@ -135,7 +139,7 @@ categoryPage = "article"
 
         <div class="tags">
           {% for category in post.categories %}
-            <a href="/news/{{ category.slug }}/{{ blogPosts.posts.currentPage }}" title="{{ category.description }}"><div class="tag">{{ category.name }}</div></a>
+            <a href="/news/{{ category.slug }}/{{ blogPosts.posts.currentPage }}" title="{{ category.description }}"><div class="tag active">{{ category.name }}</div></a>
           {% endfor %}
         </div>
       </div>

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -73,14 +73,12 @@ description = "News layout"
     <a
       href="/news/default/{{ blogPosts.posts.currentPage }}"
       title="Show all categories"
-      {% if blogCategories.currentCategorySlug == "default" or blogCategories.currentCategorySlug == "" %} style="font-weight: bold" {% endif %}
-    ><div class="tag">All</div></a>
+    ><div class="tag tag--default {% if blogCategories.currentCategorySlug == "default" or blogCategories.currentCategorySlug == "" %} active {% endif %}">All</div></a>
     {% for category in blogCategories.categories %}
       <a
         href="/news/{{ category.slug }}/{{ blogPosts.posts.currentPage }}"
         title="{{ category.description }}"
-        {% if category.slug == blogCategories.currentCategorySlug %} style="font-weight: bold" {% endif %}
-      ><div class="tag">{{ category.name }}</div></a>
+      ><div class="tag tag--{{ category.slug }} {% if category.slug == blogCategories.currentCategorySlug %} active {% endif %}">{{ category.name }}</div></a>
     {% endfor %}
   </div>
 

--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -38,7 +38,7 @@ description = "head partial"
   <link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
   <link rel="icon" href="{{ 'assets/favicon.png' | theme }}" sizes="any">
   <link rel="icon" href="{{ 'assets/favicon.svg' | theme }}" type="image/svg+xml">
-  <link rel="stylesheet" href="{{ 'assets/css/main.css?11' | theme }}">
+  <link rel="stylesheet" href="{{ 'assets/css/main.css?12' | theme }}">
   <link rel="stylesheet" href="{{ 'assets/css/tobii.min.css?1' | theme }}">
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-Bold.woff2?1' | theme }}" crossorigin>
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-ExtraBold.woff2?1' | theme }}" crossorigin>


### PR DESCRIPTION
I've always found the styling that we have for tags/categories to be inconsistent with the rest of our design. So here's an attempt to make it a bit more fitting:

**Article list**
[Before](https://user-images.githubusercontent.com/11782833/202274830-dc151ed4-24de-41a0-96d9-af489dfcc78b.png) | [After](https://user-images.githubusercontent.com/11782833/202274846-1e962201-c798-403f-93e8-52d75548da5a.png)

**Individual article**
[Before](https://user-images.githubusercontent.com/11782833/202274861-5919924a-2738-48c1-be91-c12dfd34e848.png) | [After](https://user-images.githubusercontent.com/11782833/202274875-ae7de2d2-0a72-4a76-8c86-7d2171073948.png)

This makes use of the Monserrat font that we use for titles and such. Initially I wanted to go with the default font and all-caps tags, but this is a good alternative if we don't like using all-caps for usability reasons. This also removes a lot of accent on inactive items on the article list page. Accent is also slightly reduced on the individual article page, so it's not being too distracting. Extra box shadow, using pre-existing styling, makes the buttons pop a bit more, which I find beneficial (e.g. it breaks up the article page better).
