### PR TITLE
Add link to Mastodon account in `<head>` to verify it

### DIFF
--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -42,4 +42,5 @@ description = "head partial"
   <link rel="stylesheet" href="{{ 'assets/css/tobii.min.css?1' | theme }}">
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-Bold.woff2?1' | theme }}" crossorigin>
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-ExtraBold.woff2?1' | theme }}" crossorigin>
+  <link rel="me" href="https://mastodon.gamedev.place/@godotengine">
 </head>


### PR DESCRIPTION
Verifies this account, which I confirm is maintained by myself (and @StraToN and since today @coppolaemilio):
https://mastodon.gamedev.place/@godotengine

I tested that this works:

![image](https://user-images.githubusercontent.com/4701338/202500494-65469ad0-990e-416e-8103-ae06bdc75162.png)

(So this change is actually already deployed on the live instance, just as untracked change. You'll have to `git checkout .` before `git pull`ing to sync once merged.)