### PR TITLE
Update `security.txt` expiration date

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,5 +1,5 @@
 Contact: mailto:security@godotengine.org
-Expires: 2022-09-14T23:59:00.000Z
+Expires: 2023-11-20T23:59:00.000Z
 Preferred-Languages: en
 Canonical: https://godotengine.org/.well-known/security.txt
 Policy: https://github.com/godotengine/.github/blob/master/SECURITY.md


### PR DESCRIPTION
The date is set to be less than a year into the future as recommended per the specification.