### PR TITLE
Scheduled task security.txt reminder

### DIFF
--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -1,0 +1,19 @@
+name: Yearly update security.txt
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 11 *"
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  create-issue:
+    name: Create issue
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Create issue
+        run: |
+          gh issue create --repo '${{ github.repository }}' --title 'Update `security.txt` expiration date' --body 'This is the yearly reminder to update `.well-known/security.txt`'


### PR DESCRIPTION
Every year, on November 1st, create an issue in this repo to update the `security.txt` expiration date.

Automate #460