### PR TITLE
Fix styling of buttons and separators, remove unused styles

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -260,6 +260,11 @@ h4 {
   font-size: 22px;
 }
 
+hr {
+  border: none;
+  border-top: 2px solid var(--base-color-text);
+}
+
 .intro-title {
   margin-top: 48px;
   margin-bottom: 48px;
@@ -708,39 +713,34 @@ p.small {
   text-decoration: none;
   font-weight: bold;
 }
-
 .btn:hover {
   box-shadow: var(--more-shadow);
 }
 
-.btn.flat {
+.btn.btn-flat {
   box-shadow: none;
   background-color: transparent;
   color: var(--link-color);
   margin: 16px 32px 16px 32px;
 }
-
-.btn.flat:hover {
+.btn.btn-flat:hover {
   background-color: hsla(0, 0%, 50%, 0.1);
 }
-
-.btn.flat.btn-white-text {
+.btn.btn-flat.btn-flat-white {
   color: hsla(0, 0%, 100%, 0.95);
 }
 
-.btn.download {
-  padding: 0px;
-  margin-top: 48px;
-}
-
-.btn.download > .main {
+.btn.btn-download {
   background-color: white;
+  padding: 0px;
+  text-align: center;
+}
+.btn.btn-download > .download-title {
   color: var(--dark-color);
   display: inline-block;
   padding: 16px 32px 16px 32px;
 }
-
-.btn.download > .opt {
+.btn.btn-download > .download-hint {
   background-color: var(--primary-color);
   color: var(--primary-color-text-title);
   display: inline-block;
@@ -798,14 +798,12 @@ p.small {
   border: 1px solid rgba(0, 0, 0, 0.2);
   box-sizing: border-box;
 }
-.card hr {
-  border-color: rgba(0, 0, 0, 0.05);
-}
-.card .footer {
-  background-color: var(--card-footer-color);
-}
 .card:hover {
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.2), 0 0 2px rgba(0, 0, 0, 0.1);
+}
+
+.card .footer {
+  background-color: var(--card-footer-color);
 }
 
 a.card {

--- a/themes/godotengine/layouts/download.htm
+++ b/themes/godotengine/layouts/download.htm
@@ -9,33 +9,20 @@ description = "Download layout"
 {% set stable_version_date = include('version', {'key': 'date'}) %}
 
 <style>
-  .btn.download {
+  .btn.btn-version-download {
+    background-color: var(--primary-color);
     color: white;
+    display: inline-flex;
+    flex-basis: content;
+    padding: 0px;
     margin-bottom: 8px;
   }
 
-  .btn.download a {
+  .btn.btn-version-download a {
     color: white;
     text-decoration: none;
-  }
-
-  .btn.split {
-    display: inline-flex;
-    flex-basis: content;
-  }
-
-  .btn.split > a {
     padding: 10px 20px;
     width: auto;
-  }
-
-  .btn.split > :first-child {
-    background-color: var(--primary-color);
-  }
-
-  .btn.split > :nth-child(2n) {
-    background-color: transparent;
-    color: var(--dark-color);
   }
 
   .digital-stores {
@@ -68,9 +55,9 @@ description = "Download layout"
 
   .digital-stores-name {
     color: var(--base-color-text-hl);
-    font-size: 13px;
+    font-family: "Montserrat", sans-serif;
+    font-size: 14px;
     font-weight: 600;
-    text-transform: uppercase;
     padding: 8px 16px;
   }
 
@@ -100,6 +87,10 @@ description = "Download layout"
 
   .version-overview img {
     filter: drop-shadow(var(--base-shadow));
+  }
+
+  .platform-details hr {
+    border-top-color: rgba(0, 0, 0, 0.15);
   }
 
   .platform-details pre {

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -39,10 +39,6 @@ postPage = "{{ :slug }}"
     margin-top: 48px;
   }
 
-  .main-download .btn.download {
-    margin-top: 0;
-  }
-
   #donations {
     background-color: var(--dark-color);
     color: var(--dark-color-text);
@@ -136,6 +132,10 @@ postPage = "{{ :slug }}"
 
   #news .news-list {
     padding: 0 20px;
+  }
+
+  #news .news-list hr {
+    border-top-color: rgba(0, 0, 0, 0.05);
   }
 
   #news .news-shortitem {
@@ -262,10 +262,10 @@ Make sure to update this gradient when the home background image is changed.
       </p>
 
       <div class="main-download">
-        <a href="/download" class="btn download">
-          <div class="main">Download</div><div class="opt">{% include('version') with {'key': 'identifier'} %}</div>
+        <a href="/download" class="btn btn-download">
+          <div class="download-title">Download</div><div class="download-hint">{% include('version') with {'key': 'identifier'} %}</div>
         </a>
-        <a href="/features" class="btn flat btn-white-text">Learn more</a>
+        <a href="/features" class="btn btn-flat btn-flat-white">Learn more</a>
       </div>
     </div>
 
@@ -305,7 +305,7 @@ Make sure to update this gradient when the home background image is changed.
         {% endfor %}
       </div>
       <div class="base-padding" style="text-align: right;">
-        <a href="/news/default/1" class="btn flat no-margin">More</a>
+        <a href="/news/default/1" class="btn btn-flat no-margin">More</a>
       </div>
     </div>
 
@@ -451,7 +451,7 @@ Make sure to update this gradient when the home background image is changed.
       <p>
         If you know how to code, you can help by fixing bugs and working with engine contributors towards the implementation of new features.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn flat" target="_blank" rel="noopener">Learn more</a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn btn-flat" target="_blank" rel="noopener">Learn more</a>
     </div>
 
     <div class="text-center base-padding">
@@ -460,7 +460,7 @@ Make sure to update this gradient when the home background image is changed.
       <p>
         Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn flat" target="_blank" rel="noopener">Learn more</a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn btn-flat" target="_blank" rel="noopener">Learn more</a>
     </div>
 
     <div class="text-center base-padding">
@@ -469,7 +469,7 @@ Make sure to update this gradient when the home background image is changed.
       <p>
         Found a problem with the engine? Don't forget to report it so that developers can track it down.
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn flat" target="_blank" rel="noopener">Learn more</a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn btn-flat" target="_blank" rel="noopener">Learn more</a>
     </div>
 
   </div>
@@ -483,7 +483,7 @@ Make sure to update this gradient when the home background image is changed.
       You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot&nbsp;Engine even more awesome!
     </p>
 
-    <a href="/donate" class="btn flat btn-white-text">Learn more</a>
+    <a href="/donate" class="btn btn-flat btn-flat-white">Learn more</a>
   </div>
 </section>
 

--- a/themes/godotengine/layouts/showcase-item.htm
+++ b/themes/godotengine/layouts/showcase-item.htm
@@ -89,61 +89,61 @@ description = "Showcase item layout"
       {% placeholder description %}
       <div class="flex responsive" style="justify-content: center; margin-top: 2rem">
         {% if placeholder('link_steam') %}
-        <a href="{% placeholder link_steam %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_steam %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on Steam
         </a>
         {% endif %}
 
         {% if placeholder('link_egs') %}
-        <a href="{% placeholder link_egs %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_egs %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on Epic Games Store
         </a>
         {% endif %}
 
         {% if placeholder('link_gog') %}
-        <a href="{% placeholder link_gog %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_gog %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on GOG
         </a>
         {% endif %}
 
         {% if placeholder('link_itch') %}
-        <a href="{% placeholder link_itch %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_itch %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on itch.io
         </a>
         {% endif %}
 
         {% if placeholder('link_humble') %}
-        <a href="{% placeholder link_humble %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_humble %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on Humble Store
         </a>
         {% endif %}
 
         {% if placeholder('link_play_store') %}
-        <a href="{% placeholder link_play_store %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_play_store %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on Google Play
         </a>
         {% endif %}
 
         {% if placeholder('link_app_store') %}
-        <a href="{% placeholder link_app_store %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_app_store %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on App Store
         </a>
         {% endif %}
 
         {% if placeholder('link_switch') %}
-        <a href="{% placeholder link_switch %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_switch %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on Switch
         </a>
         {% endif %}
 
         {% if placeholder('link_github') %}
-        <a href="{% placeholder link_github %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_github %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View on GitHub
         </a>
         {% endif %}
 
         {% if placeholder('link_custom') %}
-        <a href="{% placeholder link_custom %}" class="btn btn-default" style="margin: 0 0.5rem; white-space: nowrap">
+        <a href="{% placeholder link_custom %}" class="btn" style="margin: 0 0.5rem; white-space: nowrap">
           View
         </a>
         {% endif %}

--- a/themes/godotengine/pages/download/android.htm
+++ b/themes/godotengine/pages/download/android.htm
@@ -11,7 +11,7 @@ is_hidden = 0
 {##}
 {% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_android_editor.apk">
       Universal (ARM64 + ARMv7 + x86_64 + x86)
     </a>

--- a/themes/godotengine/pages/download/linux.htm
+++ b/themes/godotengine/pages/download/linux.htm
@@ -11,13 +11,13 @@ is_hidden = 0
 {##}
 {% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_x11.64.zip">
       64-bit (x86_64)
     </a>
   </div>
 
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_x11.32.zip">
       32-bit (x86)
     </a>
@@ -26,12 +26,12 @@ is_hidden = 0
 
 
 {% put mono_downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_x11_64.zip">
       64-bit (x86_64)
     </a>
   </div>
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_x11_32.zip">
       32-bit (x86)
     </a>

--- a/themes/godotengine/pages/download/osx.htm
+++ b/themes/godotengine/pages/download/osx.htm
@@ -11,7 +11,7 @@ is_hidden = 0
 {##}
 {% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_osx.universal.zip">
       Universal 64-bit (x86_64 + Apple Silicon)
     </a>
@@ -19,7 +19,7 @@ is_hidden = 0
 {% endput %}
 
 {% put mono_downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_osx.universal.zip">
       Universal 64-bit (x86_64 + Apple Silicon)
     </a>

--- a/themes/godotengine/pages/download/server.htm
+++ b/themes/godotengine/pages/download/server.htm
@@ -11,12 +11,12 @@ is_hidden = 0
 {##}
 {% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_linux_headless.64.zip">
       Headless (64-bit, x86_64)
     </a>
   </div>
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_linux_server.64.zip">
       Server (64-bit, x86_64)
     </a>
@@ -24,12 +24,12 @@ is_hidden = 0
 {% endput %}
 
 {% put mono_downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_linux_headless_64.zip">
       Headless (64-bit, x86_64)
     </a>
   </div>
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_linux_server_64.zip">
       Server (64-bit, x86_64)
     </a>

--- a/themes/godotengine/pages/download/windows.htm
+++ b/themes/godotengine/pages/download/windows.htm
@@ -11,12 +11,12 @@ is_hidden = 0
 {##}
 {% set stable_version = include('version', {'key': 'identifier'}) %}
 {% put downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_win64.exe.zip">
       64-bit (x86_64)
     </a>
   </div>
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/Godot_v{{stable_version}}-stable_win32.exe.zip">
       32-bit (x86)
     </a>
@@ -24,12 +24,12 @@ is_hidden = 0
 {% endput %}
 
 {% put mono_downloads %}
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_win64.zip">
       64-bit (x86_64)
     </a>
   </div>
-  <div class="btn split download">
+  <div class="btn btn-version-download">
     <a href="https://downloads.tuxfamily.org/godotengine/{{stable_version}}/mono/Godot_v{{stable_version}}-stable_mono_win32.zip">
       32-bit (x86)
     </a>

--- a/themes/godotengine/pages/features.htm
+++ b/themes/godotengine/pages/features.htm
@@ -35,6 +35,10 @@ is_hidden = 0
     padding-top: 32px;
     padding-bottom: 42px;
   }
+
+  #call-to-action .btn.btn-download {
+    margin-top: 32px;
+  }
 </style>
 
 <section id="design" style="margin-top: 24px">
@@ -280,11 +284,11 @@ is_hidden = 0
     <h2 class="text-center" style="color: white; width: 100%">Ready to start?</h2>
     <p class="text-center" style="color: white; margin-bottom: -0.5rem">Download Godot and try it out today!</p>
     <div class="text-center">
-      <a href="/download" class="btn download">
-        <div class="main">Download</div><div class="opt">{% include('version') with {'key': 'identifier'} %}</div>
+      <a href="/download" class="btn btn-download">
+        <div class="download-title">Download</div><div class="download-hint">{% include('version') with {'key': 'identifier'} %}</div>
       </a>
       <br>
-      <a href="https://docs.godotengine.org/en/stable/about/list_of_features.html" class="btn flat btn-white-text">Complete list of features</a>
+      <a href="https://docs.godotengine.org/en/stable/about/list_of_features.html" class="btn btn-flat btn-flat-white">Complete list of features</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixes a regression from https://github.com/godotengine/godot-website/pull/433, as well as does a general clean-up of styles associated with buttons.

- Removed a bunch of style definitions and class names which were not used anywhere, and renamed the rest to be less generic (e.g. added `btn-` prefixes across the board).
- Split the download button style into two, one for the main button on the home page and the Features page, and another for the Downloads page.
- Added proper default styling for `<hr>` tags, which were currently left to the browser to decide on the looks; most pages which rely on those separators should look the same as before, and the Downloads page should have them slightly more visible.
- Adjusted the text on digital store buttons to avoid uppercasing and to use Monserrat; after some time I realized those buttons really stand out in our current design.

Here's the downloads page for comparison:

[Before](https://user-images.githubusercontent.com/11782833/204100953-13026b08-5020-4b46-9066-88ca7c34cbb4.png) | [After](https://user-images.githubusercontent.com/11782833/204100969-2d5a825b-da32-4afc-b499-6859b6538368.png)

