### PR TITLE
Replace hardcoded meta links with dynamic ones

### DIFF
--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -14,7 +14,7 @@ description = "head partial"
   {% if this.page.id == 'home' %}
   <meta property="og:title" name="twitter:title" content="Free and open source 2D and 3D game engine">
   <meta property="og:description" name="twitter:description" content="{{ this.page.description }}">
-  <meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
+  <meta property="og:image" name="twitter:image" content="{{ 'assets/og_image.png' | theme }}">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   <title>Godot Engine - Free and open source 2D and 3D game engine</title>
@@ -30,7 +30,7 @@ description = "head partial"
   <title>Godot Engine - {{ this.page.title }}</title>
   <meta property="og:title" name="twitter:title" content="{{ this.page.title }}">
   <meta property="og:description" name="twitter:description" content="{{ this.page.description }}">
-  <meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
+  <meta property="og:image" name="twitter:image" content="{{ 'assets/og_image.png' | theme }}">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   {% endif %}


### PR DESCRIPTION
I've noticed a couple of links were absolute, which is not a big deal since they point to the production server, but still... better to make them generated to match the codestyle.