### PR TITLE
Update address for matrix room

### DIFF
--- a/themes/godotengine/pages/community.htm
+++ b/themes/godotengine/pages/community.htm
@@ -332,7 +332,7 @@ is_hidden = 0
         Old-fashioned but reliable chat platform. Significantly less active than Discord. <span style="font-family: monospace; opacity: 0.7;">#godotengine@libera.chat</span>
       </p>
     </a>
-    <a href="https://matrix.to/#/#godotengine:matrix.org" class="card base-padding">
+    <a href="https://matrix.to/#/#godot:feneas.org" class="card base-padding">
       <h3>Matrix</h3>
       <p>Libre decentralized chat with advanced features, IRC compatible.</p>
     </a>


### PR DESCRIPTION
I want to make clear that the current link is not broken as it redirects to the correct room.