### PR TITLE
Adjust patron link box

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -458,6 +458,14 @@ nav > ul ul {
   display: none;
 }
 
+a.patronImgLink {
+  display: inline-block;
+}
+
+a.patronImgLink > img {
+  display: block;
+}
+
 a.patreonLink {
   text-decoration: none;
   height: 64px !important;


### PR DESCRIPTION
This adjust box from link inside button "_Become a patron_" in donate page.

All screen sizes was tested and worked.

## Original Behavior
![original-link-box](https://user-images.githubusercontent.com/72468926/206723810-5a8cf4f1-7cc8-446c-8506-2923076b7af8.gif)
![original-link-box](https://user-images.githubusercontent.com/72468926/206723834-873e6ea8-cc2c-4c54-ad53-d5261fffdd81.png)

## Adjusted Behavior
![adjusted-link-box](https://user-images.githubusercontent.com/72468926/206723869-b6f78b58-4657-4cee-8bd2-4d5a2c360244.gif)
![adjusted-link-box](https://user-images.githubusercontent.com/72468926/206723893-84822f9f-3c58-49c3-bb3c-c463b2688a2b.png)
