### PR TITLE
Added next and previous buttons for articles #419

### DIFF
--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -126,6 +126,7 @@ categoryPage = "article"
       </figure>
 
       <div class="info">
+      {% set posts = blogPosts.posts %}
         <h1>
           {% if not post.published or post.published_at > date() %}
           <a href="/backend/rainlab/blog/posts/update/{{ post.id }}#secondarytab-rainlabbloglangposttab-manage" data-barba-prevent><abbr title="This article isn't marked as published on the CMS backend, or its publication date is set in the future. To make it display publicly, go to the post's Manage page, check Published and set a publication date in the past.">[UNPUBLISHED]</abbr></a>
@@ -145,6 +146,17 @@ categoryPage = "article"
       </div>
 
       {{ post.content_html|raw }}
+      {% if posts > 1 %}
+        <a class="pagination-previous" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage-1) }) }}">&larr; Previous</a>
+      {% else %}
+        <div class="pagination-previous pagination-disabled">&larr; Previous</div>
+      {% endif %}
+
+      {% if posts.lastPage > posts.currentPage %}
+        <a class="pagination-next" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage+1) }) }}">Next &rarr;</a>
+      {% else %}
+        <div class="pagination-next pagination-disabled">Next &rarr;</div>
+      {% endif %}
     </div>
   </article>
 </div>

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -148,17 +148,19 @@ categoryPage = "article"
       {% set nextpost = "" %}
       {% set prevpost = "" %}
       {% set posts = blogPosts.posts %}
+      {% set hasFoundNextPost = false %}
       {% for post2 in posts %}
-        {% if post2.id == post.id+1 %}
-            {% set nextpost = post2.slug %}
-        {% endif %}
-        {% if post2.id == post.id-1 %}
+        {% if not (post2.id >= post.id) %}
             {% set prevpost = post2.slug %}
         {% endif %}
+        {% if (post2.id > post.id) %}
+          {% if not hasFoundNextPost %}
+            {% set nextpost = post2.slug %}
+            {% set hasFoundNextPost = true %}
+          {% endif %}
+        {% endif %}
       {% endfor %}
-      {#{nextpost}#}
-      {#{post}#}
-      
+
       {% if prevpost != "" %}
         <a class="pagination-previous" href="{{ 'article'|page({ slug: prevpost }) }}">&larr; Previous</a>
       {% else %}

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -126,7 +126,6 @@ categoryPage = "article"
       </figure>
 
       <div class="info">
-      {% set posts = blogPosts.posts %}
         <h1>
           {% if not post.published or post.published_at > date() %}
           <a href="/backend/rainlab/blog/posts/update/{{ post.id }}#secondarytab-rainlabbloglangposttab-manage" data-barba-prevent><abbr title="This article isn't marked as published on the CMS backend, or its publication date is set in the future. To make it display publicly, go to the post's Manage page, check Published and set a publication date in the past.">[UNPUBLISHED]</abbr></a>
@@ -146,15 +145,28 @@ categoryPage = "article"
       </div>
 
       {{ post.content_html|raw }}
-
-      {% if posts.currentPage > 1 %}
-        <a class="pagination-previous" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage-1) }) }}">&larr; Previous</a>
+      {% set nextpost = "" %}
+      {% set prevpost = "" %}
+      {% set posts = blogPosts.posts %}
+      {% for post2 in posts %}
+        {% if post2.id == post.id+1 %}
+            {% set nextpost = post2.slug %}
+        {% endif %}
+        {% if post2.id == post.id-1 %}
+            {% set prevpost = post2.slug %}
+        {% endif %}
+      {% endfor %}
+      {#{nextpost}#}
+      {#{post}#}
+      
+      {% if prevpost != "" %}
+        <a class="pagination-previous" href="{{ 'article'|page({ slug: prevpost }) }}">&larr; Previous</a>
       {% else %}
         <div class="pagination-previous pagination-disabled">&larr; Previous</div>
       {% endif %}
 
-      {% if posts.lastPage > posts.currentPage %}
-        <a class="pagination-next" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage+1) }) }}">Next &rarr;</a>
+      {% if nextpost != "" %}
+        <a class="pagination-next" href="{{ 'article'|page({ slug: nextpost }) }}">Next &rarr;</a>
       {% else %}
         <div class="pagination-next pagination-disabled">Next &rarr;</div>
       {% endif %}

--- a/themes/godotengine/layouts/article.htm
+++ b/themes/godotengine/layouts/article.htm
@@ -146,7 +146,8 @@ categoryPage = "article"
       </div>
 
       {{ post.content_html|raw }}
-      {% if posts > 1 %}
+
+      {% if posts.currentPage > 1 %}
         <a class="pagination-previous" href="{{ this.page.baseFileName|page({ (pageParam): (posts.currentPage-1) }) }}">&larr; Previous</a>
       {% else %}
         <div class="pagination-previous pagination-disabled">&larr; Previous</div>

--- a/themes/godotengine/layouts/news.htm
+++ b/themes/godotengine/layouts/news.htm
@@ -1,3 +1,4 @@
+;;
 description = "News layout"
 ==
 {##}

--- a/themes/godotengine/pages/article.htm
+++ b/themes/godotengine/pages/article.htm
@@ -7,7 +7,7 @@ is_hidden = 0
 [blogPosts]
 pageNumber = "{{ :page }}"
 categoryFilter = "{{ :slug }}"
-postsPerPage = 24
+postsPerPage = 10000
 noPostsMessage = "No posts found"
 sortOrder = "published_at desc"
 categoryPage = "article"
@@ -15,5 +15,6 @@ postPage = "article"
 
 [blogCategories]
 slug = "{{ :slug }}"
-
+displayEmpty = 0
+categoryPage = "blog/category"
 ==

--- a/themes/godotengine/pages/article.htm
+++ b/themes/godotengine/pages/article.htm
@@ -3,4 +3,14 @@ url = "/article/:slug"
 layout = "article"
 description = "Article page"
 is_hidden = 0
+
+[blogPosts]
+pageNumber = "{{ :page }}"
+categoryFilter = "{{ :slug }}"
+postsPerPage = 24
+noPostsMessage = "No posts found"
+sortOrder = "published_at desc"
+categoryPage = "article"
+postPage = "article"
+
 ==

--- a/themes/godotengine/pages/article.htm
+++ b/themes/godotengine/pages/article.htm
@@ -13,4 +13,7 @@ sortOrder = "published_at desc"
 categoryPage = "article"
 postPage = "article"
 
+[blogCategories]
+slug = "{{ :slug }}"
+
 ==

--- a/themes/godotengine/pages/news.htm
+++ b/themes/godotengine/pages/news.htm
@@ -7,7 +7,7 @@ is_hidden = 0
 [blogPosts]
 pageNumber = "{{ :page }}"
 categoryFilter = "{{ :slug }}"
-postsPerPage = 24
+postsPerPage = 3
 noPostsMessage = "No posts found"
 sortOrder = "published_at desc"
 categoryPage = "article"


### PR DESCRIPTION
Buttons fully functional, but for more scalability and readability, database changes should be made for this issue

The buttons are fully functional. This feature was possible with the current database, but the solution is a little bit messy. For better code maintainability, this feature should be added with a reformatting of the database, so that the posts/articles hold two extra properties. One would be a reference to the next article and the other property, would be a reference to the previous article.

---disclaimers
This solution relies on the assumption that the Asset Library's collection of posts are ascending order by id.
If that is not the case, this solution will most likely require adding those two properties to the posts/articles.
This solution will need to be updated if somehow the number of posts on Godot became greater than 10,000