### PR TITLE
Make the Teams page mobile-friendly

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -1158,8 +1158,11 @@ pre > code {
   margin-top: 2rem;
 }
 
+/* The teams page */
+
 .teams-team-section {
   background-color: var(--teams-odd-color);
+  box-shadow: var(--base-shadow);
   padding: 20px 16px;
   margin: 40px 0;
 }
@@ -1172,55 +1175,113 @@ pre > code {
 }
 
 .teams-team-section > h4 {
+  font-size: 24px;
   margin-top: 0;
+}
+
+.teams-team-section em {
+  font-size: 94%;
+}
+
+.teams-team-section > p {
+  margin-top: 1.5em;
+  margin-bottom: 0.25em;
+}
+
+.teams-team-leader:before {
+  content: "⭐\00a0"; /* This is a non-breakable space. */
+}
+
+.teams-team-leader {
+  color: var(--base-color-text-hl);
+  font-weight: 700;
 }
 
 .teams-subteams {
   background-color: var(--teams-subteams-color);
   border-left: 6px solid var(--accent-color);
+  border-radius: 2px;
   padding: 4px 10px;
   margin-top: 30px;
-  width: 100%;
-  table-layout: fixed;
-}
-
-.teams-subteams th {
-  padding: 16px;
-  border-right: 1px dashed var(--table-divider-color);
-}
-
-.teams-subteams td {
-  padding: 16px 0 16px 12px;
-}
-
-.teams-subteams th,
-.teams-subteams td {
-  border-bottom: 1px dashed var(--table-divider-color);
-  border-collapse: collapse;
-}
-
-.teams-subteams tr:last-of-type td,
-.teams-subteams tr:last-of-type th {
-  border-bottom: 0;
+  display: grid;
+  grid-template-columns: 25% 75%;
 }
 
 .teams-subteam-name {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  font-size: 18px;
   text-align: left;
-  width: 25%;
+  padding: 16px 16px 16px 10px;
+  vertical-align: top;
 }
 
-.teams-subteam-leader:before {
-  content: "⭐ ";
+.teams-subteam-members {
+  padding: 16px 0 16px 12px;
 }
 
-.teams-subteam-leader {
-  font-weight: 700;
+.teams-subteam-name,
+.teams-subteam-members {
+  border-bottom: 2px dashed var(--table-divider-color);
+}
+.teams-subteam-name:last-of-type,
+.teams-subteam-members:last-of-type {
+  border-bottom: 0;
 }
 
-.teams-subteam-leader,
+.teams-subteams .teams-team-leader,
 .teams-subteam-members {
   font-size: 16px;
   line-height: 1.6;
+}
+
+.teams-team-members > span:after,
+.teams-subteam-members > span:after {
+  content: ", ";
+}
+
+.teams-team-members > span:last-child:after,
+.teams-subteam-members > span:last-child:after {
+  content: "";
+}
+
+@media (max-width: 768px) {
+  .teams-team-section {
+    margin-left: -18px;
+    margin-right: -18px;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .teams-subteams {
+    padding: 4px;
+    grid-template-columns: 1fr;
+  }
+
+  .teams-subteam-name {
+    border-bottom: 0;
+  }
+
+  .teams-team-members,
+  .teams-subteam-members {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .teams-team-members > span:after,
+  .teams-subteam-members > span:after {
+    content: "";
+  }
+  .teams-team-members > span:not(.teams-team-leader):before,
+  .teams-subteam-members > span:not(.teams-team-leader):before {
+    content: "· ";
+    font-size: 18px;
+    font-weight: 700;
+  }
+
+  .teams-team-leader {
+    margin-left: -6px;
+  }
 }
 
 .rounded {

--- a/themes/godotengine/pages/teams.htm
+++ b/themes/godotengine/pages/teams.htm
@@ -34,8 +34,8 @@ is_hidden = 0
     Some more specialized teams are then listed in the <a href="#systems">Systems</a> section.
   </p>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="core">Core • <a href="https://chat.godotengine.org/channel/core">#core</a></h4>
+  <div class="teams-team-section" id="core">
+    <h4 class="title">Core • <a href="https://chat.godotengine.org/channel/core">#core</a></h4>
 
     <p>
       <em>Low-level Core API: Object, Variant, templates, base nodes like Node, Viewport, etc.
@@ -43,241 +43,218 @@ is_hidden = 0
         <a href="https://github.com/godotengine/godot/tree/master/scene/main"><code>scene/main</code></a>).</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
-        George Marques (<a href="https://github.com/vnen">@vnen</a>),
-        Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>),
-        Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
+      <span>George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+      <span>Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>)</span>
+      <span>Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)</span>
     </p>
 
-    <table class="teams-subteams">
-      <tr>
-        <th class="teams-subteam-name">Data Structures</th>
-        <td class="teams-subteam-members">
-          Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>),
-            <a href="https://github.com/lawnjelly">@lawnjelly</a>
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">Threading</th>
-        <td class="teams-subteam-members">
-          Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">Input</th>
-        <td class="teams-subteam-members">
-          Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>),
-            Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-            Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>),
-            Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
-        </td>
-      </tr>
-    </table>
+    <div class="teams-subteams">
+      <span class="teams-subteam-name">Data Structures</span>
+      <div class="teams-subteam-members">
+        <span>Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
+        <span><a href="https://github.com/lawnjelly">@lawnjelly</a></span>
+      </div>
+
+      <span class="teams-subteam-name">Threading</span>
+      <div class="teams-subteam-members">
+        <span>Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">Input</span>
+      <div class="teams-subteam-members">
+        <span>Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>)</span>
+        <span>Gilles Roudière (<a href="https://github.com/groud">@groud</a>)</span>
+        <span>Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>)</span>
+        <span>Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      </div>
+    </div>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="gui-nodes">GUI Nodes • <a href="https://chat.godotengine.org/channel/gui">#gui</a></h4>
+  <div class="teams-team-section" id="gui-nodes">
+    <h4 class="title">GUI Nodes • <a href="https://chat.godotengine.org/channel/gui">#gui</a></h4>
 
     <p>
       <em>Everything that inherits Control (everything under <a href="https://github.com/godotengine/godot/tree/master/scene/gui"><code>scene/gui</code></a>)
         and can be used to build Graphical User Interfaces (both game UI and editor tools).</em>
-    <p>
-
-    <p>
-      Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>),
-        Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-        Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>),
-        Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),
-        Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>),
-        Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>),
-        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
     </p>
 
-    <table class="teams-subteams">
-      <tr>
-        <th class="teams-subteam-name">Text</th>
-        <td class="teams-subteam-members">
-          Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>),
-            Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)
-        </td>
-      </tr>
-    </table>
+    <p class="teams-team-members">
+      <span>Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>)</span>
+      <span>Gilles Roudière (<a href="https://github.com/groud">@groud</a>)</span>
+      <span>Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>)</span>
+      <span>Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)</span>
+      <span>Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+      <span>Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>)</span>
+      <span>Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)</span>
+    </p>
+
+    <div class="teams-subteams">
+      <span class="teams-subteam-name">Text</span>
+      <div class="teams-subteam-members">
+        <span>Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>)</span>
+        <span>Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+      </div>
+    </div>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="editor">Editor • <a href="https://chat.godotengine.org/channel/editor">#editor</a></h4>
+  <div class="teams-team-section" id="editor">
+    <h4 class="title">Editor • <a href="https://chat.godotengine.org/channel/editor">#editor</a></h4>
 
     <p>
       <em>All things related to the editor, both tools and usability (<a href="https://github.com/godotengine/godot/tree/master/editor"><code>editor</code></a>).</em>
     </p>
 
-    <p>
-      Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>),
-        Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-        Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>),
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-        Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),
-        Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>),
-        Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>),
-        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    <p class="teams-team-members">
+      <span>Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>)</span>
+      <span>Gilles Roudière (<a href="https://github.com/groud">@groud</a>)</span>
+      <span>Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span>Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)</span>
+      <span>Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>)</span>
+      <span>Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>)</span>
+      <span>Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)</span>
     </p>
 
-    <table class="teams-subteams">
-      <tr>
-        <th class="teams-subteam-name">2D</th>
-        <td class="teams-subteam-members">
-          Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-            Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),
-            Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>)
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">3D</th>
-        <td class="teams-subteam-members">
-          Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-            Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>)
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">Debugger</th>
-        <td class="teams-subteam-members">
-          Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
-            George Marques (<a href="https://github.com/vnen">@vnen</a>)
-        </td>
-      </tr>
-    <tr>
-        <th class="teams-subteam-name">Script editor</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>)</span>,
-            Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)
-        </td>
-      </tr>
-    </table>
+    <div class="teams-subteams">
+      <span class="teams-subteam-name">2D</span>
+      <div class="teams-subteam-members">
+        <span>Gilles Roudière (<a href="https://github.com/groud">@groud</a>)</span>
+        <span>Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)</span>
+        <span>Tomasz Chabora (<a href="https://github.com/KoBeWi">@KoBeWi</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">3D</span>
+      <div class="teams-subteam-members">
+        <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+        <span>Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">Debugger</span>
+      <div class="teams-subteam-members">
+        <span>Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
+        <span>George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">Script editor</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>)</span>
+        <span>Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)</span>
+      </div>
+    </div>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="scripting">Scripting • <a href="https://chat.godotengine.org/channel/scripting">#scripting</a></h4>
+  <div class="teams-team-section" id="scripting">
+    <h4 class="title">Scripting • <a href="https://chat.godotengine.org/channel/scripting">#scripting</a></h4>
 
     <p>
       <em>Umbrella team for all the scripting languages usable with Godot. Encompasses some shared core components (Object, ClassDB, MethodBind, ScriptLanguage, etc.)
         and language specific implementations in dedicated subteams.</em>
     </p>
 
-    <p>
-      George Marques (<a href="https://github.com/vnen">@vnen</a>),
-        Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>),
-        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
+    <p class="teams-team-members">
+      <span>George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+      <span>Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)</span>
+      <span>Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
     </p>
 
-    <table class="teams-subteams">
-      <tr>
-        <th class="teams-subteam-name">GDExtension (<a href="https://chat.godotengine.org/channel/gdextension">#gdextension</a>)</th>
-        <td class="teams-subteam-members">
-          Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>),
-            Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
-            George Marques (<a href="https://github.com/vnen">@vnen</a>),
-            Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
-            Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>),
-            Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">GDScript (<a href="https://chat.godotengine.org/channel/gdscript">#gdscript</a>)</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">C#</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)</span>,
-            Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>),
-            Raul Santos (<a href="https://github.com/raulsntos">@raulsntos</a>)
-        </td>
-      </tr>
-    </table>
+    <div class="teams-subteams">
+      <span class="teams-subteam-name">GDExtension (<a href="https://chat.godotengine.org/channel/gdextension">#gdextension</a>)</span>
+      <div class="teams-subteam-members">
+        <span>Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>)</span>
+        <span>Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
+        <span>George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+        <span>Gilles Roudière (<a href="https://github.com/groud">@groud</a>)</span>
+        <span>Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
+        <span>Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">GDScript (<a href="https://chat.godotengine.org/channel/gdscript">#gdscript</a>)</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">C#</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)</span>
+        <span>Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>)</span>
+        <span>Raul Santos (<a href="https://github.com/raulsntos">@raulsntos</a>)</span>
+      </div>
+    </div>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="buildsystem">Buildsystem • <a href="https://chat.godotengine.org/channel/buildsystem">#buildsystem</a></h4>
+  <div class="teams-team-section" id="buildsystem">
+    <h4 class="title">Buildsystem • <a href="https://chat.godotengine.org/channel/buildsystem">#buildsystem</a></h4>
 
     <p>
       <em>Tools and scripts that we use to compile and maintain Godot, both for development purpose (SCons, CI) and releases (official build containers).</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
-        Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>),
-        Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
-        Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>),
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-        Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      <span>Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>)</span>
+      <span>Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
+      <span>Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span>Ignacio Roldán Etcheverry (<a href="https://github.com/neikeq">@neikeq</a>)</span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="platforms">Platforms • <a href="https://chat.godotengine.org/channel/platforms">#platforms</a></h4>
+  <div class="teams-team-section" id="platforms">
+    <h4 class="title">Platforms • <a href="https://chat.godotengine.org/channel/platforms">#platforms</a></h4>
 
     <p>
       <em>Platform specific layers that reside in <a href="https://github.com/godotengine/godot/tree/master/platform"><code>platform</code></a>, with shared components
         (Unix, Win32, Apple, etc.) in <a href="https://github.com/godotengine/godot/tree/master/drivers"><code>drivers</code></a>.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>,
-        <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+      <span class="teams-team-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
     </p>
 
-    <table class="teams-subteams">
-      <tr>
-        <th class="teams-subteam-name">Android (<a href="https://chat.godotengine.org/channel/android">#android</a>)</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)</span>
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">HTML5</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">iOS</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>,
-            Sergey Minakov (<a href="https://github.com/naithar">@naithar</a>)
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">Linux / BSD</th>
-        <td class="teams-subteam-members">
-          Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
-            Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>),
-            Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>),
-            Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">macOS</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">UWP</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">Windows</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>,
-            Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)
-        </td>
-      </tr>
-    </table>
+    <div class="teams-subteams">
+      <span class="teams-subteam-name">Android (<a href="https://chat.godotengine.org/channel/android">#android</a>)</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">HTML5</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">iOS</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+        <span>Sergey Minakov (<a href="https://github.com/naithar">@naithar</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">Linux / BSD</span>
+      <div class="teams-subteam-members">
+        <span>Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
+        <span>Hein-Pieter van Braam (<a href="https://github.com/hpvb">@hpvb</a>)</span>
+        <span>Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+        <span>Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">macOS</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">UWP</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">Windows</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+        <span>Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>
+      </div>
+    </div>
   </div>
 
   <h2 class="title" id="systems">Systems</h2>
@@ -286,138 +263,133 @@ is_hidden = 0
     Specialized subsystems with their dedicated teams and communication channels.
   </p>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="animation">Animation • <a href="https://chat.godotengine.org/channel/animation">#animation</a></h4>
+  <div class="teams-team-section" id="animation">
+    <h4 class="title">Animation • <a href="https://chat.godotengine.org/channel/animation">#animation</a></h4>
 
     <p>
       <em>Nodes and features for 2D and 3D animation and IK workflows.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
-        K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>),
-        <a href="https://github.com/lyuma">@lyuma</a>,
-        Silc 'Tokage' Renew (<a href="https://github.com/TokageItLab">@TokageItLab</a>),
-        <a href="https://github.com/SaracenOne">SaracenOne</a>
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
+      <span>K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>)</span>
+      <span><a href="https://github.com/lyuma">@lyuma</a></span>
+      <span>Silc 'Tokage' Renew (<a href="https://github.com/TokageItLab">@TokageItLab</a>)</span>
+      <span><a href="https://github.com/SaracenOne">SaracenOne</a></span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="audio">Audio • <a href="https://chat.godotengine.org/channel/audio">#audio</a></h4>
+  <div class="teams-team-section" id="audio">
+    <h4 class="title">Audio • <a href="https://chat.godotengine.org/channel/audio">#audio</a></h4>
 
     <p>
       <em>All audio-related features, from low-level AudioServer and drivers to high-level nodes and effects.</em>
     </p>
 
-    <p>
-      Ellen Poe (<a href="https://github.com/ellenhp">@ellenhp</a>),
-        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
+    <p class="teams-team-members">
+      <span>Ellen Poe (<a href="https://github.com/ellenhp">@ellenhp</a>)</span>
+      <span>Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="import">Import • <a href="https://chat.godotengine.org/channel/asset-pipeline">#asset-pipeline</a></h4>
+  <div class="teams-team-section" id="import">
+    <h4 class="title">Import • <a href="https://chat.godotengine.org/channel/asset-pipeline">#asset-pipeline</a></h4>
 
     <p>
       <em>Asset import pipeline for 2D (textures) and 3D (scenes, models, animations, etc.).</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-        Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>),
-        K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>),
-        <a href="https://github.com/lyuma">@lyuma</a>,
-        Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span>Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>)</span>
+      <span>K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>)</span>
+      <span><a href="https://github.com/lyuma">@lyuma</a></span>
+      <span>Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="networking">Networking • <a href="https://chat.godotengine.org/channel/networking">#networking</a></h4>
+  <div class="teams-team-section" id="networking">
+    <h4 class="title">Networking • <a href="https://chat.godotengine.org/channel/networking">#networking</a></h4>
 
     <p>
       <em>Networked multiplayer, RPCs and replication, HTTP/TCP/UDP/DNS, WebSockets, ENet, encryption.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>,
-        Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>
+      <span>Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="physics">Physics • <a href="https://chat.godotengine.org/channel/physics">#physics</a></h4>
+  <div class="teams-team-section" id="physics">
+    <h4 class="title">Physics • <a href="https://chat.godotengine.org/channel/physics">#physics</a></h4>
 
     <p>
       <em>Physics servers and their implementation in 2D and 3D.</em>
     </p>
 
-    <p>
-      Andrea Catania (<a href="https://github.com/AndreaCatania">@AndreaCatania</a>),
-        Fabrice Cipolla (<a href="https://github.com/fabriceci">@fabriceci</a>),
-        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>),
-        <a href="https://github.com/lawnjelly">@lawnjelly</a>,
-        Ricardo Buring (<a href="https://github.com/rburing">@rburing</a>)
+    <p class="teams-team-members">
+      <span>Andrea Catania (<a href="https://github.com/AndreaCatania">@AndreaCatania</a>)</span>
+      <span>Fabrice Cipolla (<a href="https://github.com/fabriceci">@fabriceci</a>)</span>
+      <span>Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
+      <span><a href="https://github.com/lawnjelly">@lawnjelly</a></span>
+      <span>Ricardo Buring (<a href="https://github.com/rburing">@rburing</a>)</span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="rendering">Rendering • <a href="https://chat.godotengine.org/channel/rendering">#rendering</a></h4>
+  <div class="teams-team-section" id="rendering">
+    <h4 class="title">Rendering • <a href="https://chat.godotengine.org/channel/rendering">#rendering</a></h4>
 
     <p>
       <em>Rendering server and RenderingDevice implementations (Vulkan, OpenGL), as well as the actual rendering techniques implemented using those graphics APIs.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>,
-        Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>),
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-        <a href="https://github.com/lawnjelly">@lawnjelly</a>,
-        Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>),
-        Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>),
-        Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>
+      <span>Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span><a href="https://github.com/lawnjelly">@lawnjelly</a></span>
+      <span>Pedro J. Estébanez (<a href="https://github.com/RandomShaper">RandomShaper</a>)</span>
+      <span>Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>)</span>
+      <span>Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
     </p>
 
-    <table class="teams-subteams">
-      <tr>
-        <th class="teams-subteam-name">Shaders</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)</span>,
-            Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)
-        </td>
-      </tr>
-      <tr>
-        <th class="teams-subteam-name">Tech Art</th>
-        <td class="teams-subteam-members">
-          Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
-            Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-            Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
-            Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)
-        </td>
-      </tr>
-    </table>
+    <div class="teams-subteams">
+      <span class="teams-subteam-name">Shaders</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)</span>
+        <span>Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>
+      </div>
+
+      <span class="teams-subteam-name">Tech Art</span>
+      <div class="teams-subteam-members">
+        <span>Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>
+        <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+        <span>Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>)</span>
+        <span>Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)</span>
+      </div>
+    </div>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="xr">XR • <a href="https://chat.godotengine.org/channel/xr">#xr</a></h4>
+  <div class="teams-team-section" id="xr">
+    <h4 class="title">XR • <a href="https://chat.godotengine.org/channel/xr">#xr</a></h4>
 
     <p>
       <em>Augmented (AR) and virtual reality (VR).</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>)</span>,
-        Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>)</span>
+      <span>Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)</span>
     </p>
 
-    <table class="teams-subteams">
-      <tr>
-        <th class="teams-subteam-name">WebXR</th>
-        <td class="teams-subteam-members">
-          <span class="teams-subteam-leader">David Snopek (<a href="https://github.com/dsnopek">@dsnopek</a>)</span>
-        </td>
-      </tr>
-    </table>
+    <div class="teams-subteams">
+      <span class="teams-subteam-name">WebXR</span>
+      <div class="teams-subteam-members">
+        <span class="teams-team-leader">David Snopek (<a href="https://github.com/dsnopek">@dsnopek</a>)</span>
+      </div>
+    </div>
   </div>
 
   <h2 class="title" id="community">Community</h2>
@@ -427,85 +399,85 @@ is_hidden = 0
       as the documentation, demos, website, etc.
   </p>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="communication">Communication • <a href="https://chat.godotengine.org/channel/communication">#communication</a></h4>
+  <div class="teams-team-section" id="communication">
+    <h4 class="title">Communication • <a href="https://chat.godotengine.org/channel/communication">#communication</a></h4>
 
     <p>
       <em>The communication team ensures that our platforms, from the website to our social media, are kept up to date with current information about the engine and showcase other projects from the community.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Emilio Coppola (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>)</span>,
-        Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-        Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
-        Raffaele Picca (<a href="https://github.com/RPicster">@RPicster</a>),
-        Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
-        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Emilio Coppola (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>)</span>
+      <span>Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span>Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>)</span>
+      <span>Raffaele Picca (<a href="https://github.com/RPicster">@RPicster</a>)</span>
+      <span>Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      <span>Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)</span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="demos">Demos • <a href="https://chat.godotengine.org/channel/demo-content">#demo-content</a></h4>
+  <div class="teams-team-section" id="demos">
+    <h4 class="title">Demos • <a href="https://chat.godotengine.org/channel/demo-content">#demo-content</a></h4>
 
     <p>
       <em>Maintenance and creation of official demo projects in <a href="https://github.com/godotengine/godot-demo-projects">godot-demo-projects</a>.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>)</span>,
-        <span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>)</span>
+      <span class="teams-team-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="documentation">Documentation • <a href="https://chat.godotengine.org/channel/documentation">#documentation</a></h4>
+  <div class="teams-team-section" id="documentation">
+    <h4 class="title">Documentation • <a href="https://chat.godotengine.org/channel/documentation">#documentation</a></h4>
 
     <p>
       <em>Maintainance and writing of the official documentation at <a href="https://github.com/godotengine/godot-docs">godot-docs</a>.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>,
-        Chris Bradfield (<a href="https://github.com/cbscribe">@cbscribe</a>),
-        Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-        Matthew (<a href="https://github.com/skyace65">@skyace65</a>),
-        Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
-        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>
+      <span>Chris Bradfield (<a href="https://github.com/cbscribe">@cbscribe</a>)</span>
+      <span>Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span>Matthew (<a href="https://github.com/skyace65">@skyace65</a>)</span>
+      <span>Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      <span>Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)</span>
     </p>
   </div>
 
-<div class="teams-team-section">
-  <h4 class="title" id="production">Production • <a href="https://chat.godotengine.org/channel/devel">#devel</a></h4>
+  <div class="teams-team-section" id="production">
+    <h4 class="title">Production • <a href="https://chat.godotengine.org/channel/devel">#devel</a></h4>
 
-  <p>
-    <em>The production team helps coordinate the engine development with the various teams.</em>
-  </p>
+    <p>
+      <em>The production team helps coordinate the engine development with the various teams.</em>
+    </p>
 
-  <p>
-    <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
-      Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
-      Emilio Coppola (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>),
-      Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>),
-      Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-      Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>),
-      Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>),
-      Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
-  </p>
-</div>
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      <span>Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>
+      <span>Emilio Coppola (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>)</span>
+      <span>Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span>Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>
+      <span>Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>
+      <span>Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)</span>
+    </p>
+  </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="translation">Translation • <a href="https://chat.godotengine.org/channel/translation">#translation</a></h4>
+  <div class="teams-team-section" id="translation">
+    <h4 class="title">Translation • <a href="https://chat.godotengine.org/channel/translation">#translation</a></h4>
 
     <p>
       <em>Internationalization and localization team - building the infrastructure to make it possible to translate Godot and its documentation.</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
-      <span class="teams-subteam-leader">Haoyu Qiu (<a href="https://github.com/timothyqiu">@timothyqiu</a>)</span>,
-        Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      <span class="teams-team-leader">Haoyu Qiu (<a href="https://github.com/timothyqiu">@timothyqiu</a>)</span>
+      <span>Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
     </p>
 
     <p>
@@ -513,18 +485,18 @@ is_hidden = 0
     </p>
   </div>
 
-  <div class="teams-team-section">
-    <h4 class="title" id="website">Website • <a href="https://chat.godotengine.org/channel/website">#website</a></h4>
+  <div class="teams-team-section" id="website">
+    <h4 class="title">Website • <a href="https://chat.godotengine.org/channel/website">#website</a></h4>
 
     <p>
       <em>Maintenance of the official Godot website and other hosted resources (Q&amp;A, asset library).</em>
     </p>
 
-    <p>
-      <span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>,
-        Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>),
-        Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
-        Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+    <p class="teams-team-members">
+      <span class="teams-team-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+      <span>Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>
+      <span>Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+      <span>Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)</span>
     </p>
   </div>
 </div>

--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -46,7 +46,7 @@ description = "head partial"
   <link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
   <link rel="icon" href="{{ 'assets/favicon.png' | theme }}" sizes="any">
   <link rel="icon" href="{{ 'assets/favicon.svg' | theme }}" type="image/svg+xml">
-  <link rel="stylesheet" href="{{ 'assets/css/main.css?15' | theme }}">
+  <link rel="stylesheet" href="{{ 'assets/css/main.css?16' | theme }}">
   <link rel="stylesheet" href="{{ 'assets/css/tobii.min.css?1' | theme }}">
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-Bold.woff2?1' | theme }}" crossorigin>
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-ExtraBold.woff2?1' | theme }}" crossorigin>


### PR DESCRIPTION
After merging https://github.com/godotengine/godot-website/pull/489 I noticed that there are a few issues with the styles on the Teams page. One thing led to another, and so I ended up making the layout more flexible and mobile friendly, as well as fixing a few mistakes and typos.

* Sections now have drop shadow for better visual separation.
* Team titles are a bit bigger, and inside of each section spacing is more... spacious.
* Some font colors have been slightly adjusted.
* Font size for main team leaders has been adjusted to match the font size of the paragraph.
* Star emoji is now sticky and won't be left on the previous line when wrapping.
* Tables have been replaced with a grid layout, dynamically changing from 2 to 1 column layout depending on the screen size.
* Sub-team titles now use Montserrat, with sizes and padding adjusted.
* Borders have been adjusted to better fit the overall design.
* Sections use mobile screen more efficiently.
* On mobile members are now displayed as a vertical list.
* Various layout bugs have been fixed.

Before: [chrome_2022-12-14_23-26-02](https://user-images.githubusercontent.com/11782833/207708996-0924733b-e6c4-41c9-99c9-bfee92c45c01.png)
After: [chrome_2022-12-14_23-26-06](https://user-images.githubusercontent.com/11782833/207709025-f967338e-78d5-4a4c-aeea-8618641c97ae.png)

Before: [chrome_2022-12-14_23-26-35](https://user-images.githubusercontent.com/11782833/207709041-0e3983f0-ad6e-4a0d-adea-d3fc575ba620.png)
After: [chrome_2022-12-14_23-26-39](https://user-images.githubusercontent.com/11782833/207709048-ee1f897d-92e1-4b5a-a84b-d81e053f110c.png)

Before: [chrome_2022-12-14_23-27-34](https://user-images.githubusercontent.com/11782833/207709058-f5188911-fd94-4295-8a3d-6de6270c66e4.png)
After: [chrome_2022-12-14_23-27-38](https://user-images.githubusercontent.com/11782833/207709063-50d62ae7-9338-4af2-97ad-77e8643d44e5.png)

Before: [chrome_2022-12-14_23-27-45](https://user-images.githubusercontent.com/11782833/207709078-0d39e74e-574c-40db-b50c-01abc5473200.png)
After: [chrome_2022-12-14_23-27-53](https://user-images.githubusercontent.com/11782833/207709088-e2cbcd5f-4cf9-4d6c-bfab-ab741f3c3e28.png)

Before: [chrome_2022-12-14_23-28-13](https://user-images.githubusercontent.com/11782833/207709113-556ef7e0-4fb3-4d17-8b59-13c9c14ad641.png)
After: [chrome_2022-12-14_23-43-45](https://user-images.githubusercontent.com/11782833/207709841-df28de6c-5bee-44e2-afc9-e77bec4709cd.png)

Before: [chrome_2022-12-14_23-28-57](https://user-images.githubusercontent.com/11782833/207709146-c2617098-db07-4f9e-9044-0a4f5bbbdf02.png)
After: [chrome_2022-12-14_23-29-03](https://user-images.githubusercontent.com/11782833/207709163-eb13b844-665f-43b7-9448-4b8837b85842.png)

Before: [chrome_2022-12-14_23-29-37](https://user-images.githubusercontent.com/11782833/207709179-8ccd7042-3b2f-425b-8de4-ecfbfe4d1c8b.png)
After: [chrome_2022-12-14_23-29-41](https://user-images.githubusercontent.com/11782833/207709189-a2fcde4c-f26b-4088-9430-5153ae67f656.png)

Before: [chrome_2022-12-14_23-30-49](https://user-images.githubusercontent.com/11782833/207709197-42d46a0e-bf93-4219-94d6-b4609aefd11a.png)
After: [chrome_2022-12-14_23-30-53](https://user-images.githubusercontent.com/11782833/207709209-b8cdf8c6-5201-41f2-bc04-2feec793d710.png)
