### PR TITLE
Make i18n extraction more stable, generate metadata

### DIFF
--- a/plugins/godotengine/i18n/classes/TranslationExtractor.php
+++ b/plugins/godotengine/i18n/classes/TranslationExtractor.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace GodotEngine\I18n\Classes;
+
+use Log;
+use Cms\Classes\Page;
+use Cms\Classes\Layout;
+use Cms\Classes\Partial;
+use \Gettext\Translations;
+use GodotEngine\I18n\Classes\TwigMarkupScanner;
+
+class TranslationExtractor
+{
+    /**
+     * @var string The default domain name for extracted messages (used only internally).
+     */
+    private static $defaultDomain = 'default';
+
+    /**
+     * Normalizes the file path for the given object.
+     */
+    private static function makeRelativePath($object)
+    {
+        return $object->theme->getDirName() . '/' . $object->getObjectTypeDirName() . '/' . $object->getFileName();
+    }
+
+    /**
+     * Extracts translation messages and their codes and generates PO files.
+     *
+     * @return array A collection of translatable messages.
+     */
+    public static function extractMessages()
+    {
+        Log::info('Starting message extraction.');
+
+        $scanner = new TwigMarkupScanner(
+            Translations::create(self::$defaultDomain)
+        );
+        $scanner->setDefaultDomain(self::$defaultDomain);
+
+        Log::info('Scanning Layout files.');
+        foreach (Layout::all() as $layout) {
+            $tree = $layout->getTwigNodeTree();
+            $scanner->scanAST($tree, self::makeRelativePath($layout));
+        }
+
+        Log::info('Scanning Page files.');
+        foreach (Page::all() as $page) {
+            $tree = $page->getTwigNodeTree();
+            $scanner->scanAST($tree, self::makeRelativePath($page));
+        }
+
+        Log::info('Scanning Partial files.');
+        foreach (Partial::all() as $partial) {
+            $tree = $partial->getTwigNodeTree();
+            $scanner->scanAST($tree, self::makeRelativePath($partial));
+        }
+
+        Log::info('Preparing extracted messages.');
+        $translations = $scanner->getTranslations()[self::$defaultDomain];
+
+        return $translations;
+    }
+}

--- a/plugins/godotengine/i18n/controllers/Manage.php
+++ b/plugins/godotengine/i18n/controllers/Manage.php
@@ -6,6 +6,7 @@ use Redirect;
 use Backend\Classes\Controller;
 use System\Classes\SettingsManager;
 use GodotEngine\I18n\Classes\TranslationManager;
+use GodotEngine\I18n\Classes\TranslationExtractor;
 
 class Manage extends Controller
 {
@@ -29,6 +30,8 @@ class Manage extends Controller
      */
     public function index()
     {
+        $this->pageTitle = 'Godot I18n';
+
         $this->vars['defaultLocale'] = TranslationManager::getDefaultLocale();
         $this->vars['cmsLocales'] = TranslationManager::getCMSLocales();
         $this->vars['poValid'] = TranslationManager::isSetupValid();
@@ -40,7 +43,7 @@ class Manage extends Controller
      */
     public function onSetup()
     {
-        $messages = TranslationManager::extractMessages();
+        $messages = TranslationExtractor::extractMessages();
         TranslationManager::generateBaseFile($messages);
 
         Flash::success('First-time setup complete!');
@@ -64,9 +67,9 @@ class Manage extends Controller
      */
     public function onExtractMessages()
     {
-        $messages = TranslationManager::extractMessages();
+        $messages = TranslationExtractor::extractMessages();
         TranslationManager::generateBaseFile($messages);
-        TranslationManager::mergeLocaleFiles();
+        TranslationManager::updateLocaleFiles();
 
         Flash::success('Messages successfully extracted!');
         return Redirect::refresh();

--- a/plugins/godotengine/i18n/controllers/manage/index.htm
+++ b/plugins/godotengine/i18n/controllers/manage/index.htm
@@ -1,7 +1,7 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
         <li><a href="<?= Backend::url('system/settings') ?>">Settings</a></li>
-        <li>Godot I18n</li>
+        <li><?= e(trans($this->pageTitle)) ?></li>
     </ul>
 <?php Block::endPut() ?>
 

--- a/plugins/godotengine/utility/controllers/Utilities.php
+++ b/plugins/godotengine/utility/controllers/Utilities.php
@@ -25,7 +25,7 @@ class Utilities extends Controller
      */
     public function index()
     {
-
+        $this->pageTitle = 'Godot Utilities';
     }
 
     /**

--- a/plugins/godotengine/utility/controllers/utilities/index.htm
+++ b/plugins/godotengine/utility/controllers/utilities/index.htm
@@ -1,7 +1,7 @@
 <?php Block::put('breadcrumb') ?>
     <ul>
         <li><a href="<?= Backend::url('system/settings') ?>">Settings</a></li>
-        <li>Godot Utilities</li>
+        <li><?= e(trans($this->pageTitle)) ?></li>
     </ul>
 <?php Block::endPut() ?>
 

--- a/themes/godotengine/i18n/po/messages.es.po
+++ b/themes/godotengine/i18n/po/messages.es.po
@@ -1,9 +1,287 @@
+# Spanish translation of the Godot Engine class reference.
+# Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.
+# Copyright (c) 2014-2022 Godot Engine contributors (cf. https://github.com/godotengine/godot/blob/master/AUTHORS.md).
+# This file is distributed under the same license as the Godot source code.
+#
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=utf-8\n"
+"Project-Id-Version: Godot Engine official website\n"
+"Report-Msgid-Bugs-To: https://github.com/godotengine/godot-website\n"
 "Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8-bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == "
+"0) ? 1 : 2);\n"
 "X-Domain: default\n"
 
 #: godotengine/layouts/home.htm:246
 msgid "The game engine you've been waiting&nbsp;for."
+msgstr ""
+
+#: godotengine/layouts/home.htm:247
+msgid ""
+"The Godot Engine is a free, all-in-one, cross-platform game engine that "
+"makes it easy for you to create 2D and 3D games."
+msgstr ""
+
+#: godotengine/layouts/home.htm:251 godotengine/partials/footer.htm:18
+#: godotengine/partials/header.htm:33
+msgid "Download"
+msgstr ""
+
+#: godotengine/layouts/home.htm:253 godotengine/layouts/home.htm:440
+#: godotengine/layouts/home.htm:449 godotengine/layouts/home.htm:458
+#: godotengine/layouts/home.htm:473
+msgid "Learn more"
+msgstr ""
+
+#: godotengine/layouts/home.htm:263
+msgid "Latest news"
+msgstr ""
+
+#: godotengine/layouts/home.htm:300
+msgid "More News"
+msgstr ""
+
+#: godotengine/layouts/home.htm:308
+msgid "A different way to make games"
+msgstr ""
+
+#: godotengine/layouts/home.htm:322
+msgid "Innovative design"
+msgstr ""
+
+#: godotengine/layouts/home.htm:324
+msgid ""
+"Godot's Node and Scene system gives you both power and flexibility to create "
+"anything."
+msgstr ""
+
+#: godotengine/layouts/home.htm:341
+msgid "Use the right language for the job"
+msgstr ""
+
+#: godotengine/layouts/home.htm:343
+msgid ""
+"Keep your code modular with an object-oriented API using Godot's own "
+"GDScript, C#, C++, or bring your own using GDNative."
+msgstr ""
+
+#: godotengine/layouts/home.htm:359
+msgid "Dedicated 2D engine"
+msgstr ""
+
+#: godotengine/layouts/home.htm:361
+msgid ""
+"Make crisp and performant 2D games with Godot's dedicated 2D rendering "
+"engine with real 2D pixel coordinates and 2D nodes."
+msgstr ""
+
+#: godotengine/layouts/home.htm:378
+msgid "Simple and powerful 3D"
+msgstr ""
+
+#: godotengine/layouts/home.htm:380
+msgid ""
+"Godot's 3D nodes give you everything you need to build, animate, and render "
+"your 3D worlds and characters."
+msgstr ""
+
+#: godotengine/layouts/home.htm:397
+msgid "Release on all platforms"
+msgstr ""
+
+#: godotengine/layouts/home.htm:399
+msgid ""
+"Deploy your game on desktop, mobile, and the web in seconds. Godot even "
+"supports consoles through third party publishers."
+msgstr ""
+
+#: godotengine/layouts/home.htm:416
+msgid "Open Source"
+msgstr ""
+
+#: godotengine/layouts/home.htm:418
+msgid ""
+"Truly open development: anyone who contributes to Godot benefits equally "
+"from others' contributions."
+msgstr ""
+
+#: godotengine/layouts/home.htm:427
+msgid "Get involved"
+msgstr ""
+
+#: godotengine/layouts/home.htm:429
+msgid ""
+"Join the community and help create a game engine that belongs to everybody."
+msgstr ""
+
+#: godotengine/layouts/home.htm:436
+msgid "Code"
+msgstr ""
+
+#: godotengine/layouts/home.htm:438
+msgid ""
+"If you know how to code, you can help by fixing bugs and working with engine "
+"contributors towards the implementation of new features."
+msgstr ""
+
+#: godotengine/layouts/home.htm:445
+msgid "Document"
+msgstr ""
+
+#: godotengine/layouts/home.htm:447
+msgid ""
+"Documentation quality is essential in a game engine; help make it better by "
+"updating the API reference, writing new guides or submitting corrections."
+msgstr ""
+
+#: godotengine/layouts/home.htm:454
+msgid "Report"
+msgstr ""
+
+#: godotengine/layouts/home.htm:456
+msgid ""
+"Found a problem with the engine? Don't forget to report it so that "
+"developers can track it down."
+msgstr ""
+
+#: godotengine/layouts/home.htm:467 godotengine/partials/footer.htm:34
+#: godotengine/partials/header.htm:37
+msgid "Donate"
+msgstr ""
+
+#: godotengine/layouts/home.htm:470
+msgid ""
+"You don't need to be an engine developer to help Godot. Consider donating to "
+"speed up development and make Godot&nbsp Engine even more awesome!"
+msgstr ""
+
+#: godotengine/layouts/home.htm:479
+msgid "Sponsored by"
+msgstr ""
+
+#: godotengine/partials/footer.htm:9
+msgid "and"
+msgstr ""
+
+#: godotengine/partials/footer.htm:9
+msgid "contributors"
+msgstr ""
+
+#: godotengine/partials/footer.htm:10
+msgid "Godot is a member of the"
+msgstr ""
+
+#: godotengine/partials/footer.htm:11
+msgid "Kindly hosted by"
+msgstr ""
+
+#: godotengine/partials/footer.htm:12
+msgid "Website source code on GitHub"
+msgstr ""
+
+#: godotengine/partials/footer.htm:17
+msgid "Get Godot"
+msgstr ""
+
+#: godotengine/partials/footer.htm:19
+msgid "Web Editor"
+msgstr ""
+
+#: godotengine/partials/footer.htm:21
+msgid "Public Relations"
+msgstr ""
+
+#: godotengine/partials/footer.htm:22 godotengine/partials/header.htm:26
+msgid "News"
+msgstr ""
+
+#: godotengine/partials/footer.htm:23
+msgid "Communities and Events"
+msgstr ""
+
+#: godotengine/partials/footer.htm:24
+msgid "Press Kit"
+msgstr ""
+
+#: godotengine/partials/footer.htm:27
+msgid "About Godot"
+msgstr ""
+
+#: godotengine/partials/footer.htm:28 godotengine/partials/header.htm:22
+msgid "Features"
+msgstr ""
+
+#: godotengine/partials/footer.htm:29 godotengine/partials/header.htm:24
+msgid "Showcase"
+msgstr ""
+
+#: godotengine/partials/footer.htm:30
+msgid "Education"
+msgstr ""
+
+#: godotengine/partials/footer.htm:31
+msgid "License"
+msgstr ""
+
+#: godotengine/partials/footer.htm:32
+msgid "Code of Conduct"
+msgstr ""
+
+#: godotengine/partials/footer.htm:33
+msgid "Privacy Policy"
+msgstr ""
+
+#: godotengine/partials/footer.htm:37
+msgid "Project Team"
+msgstr ""
+
+#: godotengine/partials/footer.htm:38
+msgid "Governance"
+msgstr ""
+
+#: godotengine/partials/footer.htm:39
+msgid "Teams"
+msgstr ""
+
+#: godotengine/partials/footer.htm:41
+msgid "Extra Resources"
+msgstr ""
+
+#: godotengine/partials/footer.htm:42
+msgid "Asset Library"
+msgstr ""
+
+#: godotengine/partials/footer.htm:43
+msgid "Documentation"
+msgstr ""
+
+#: godotengine/partials/footer.htm:44
+msgid "Code Repository"
+msgstr ""
+
+#: godotengine/partials/footer.htm:48
+msgid "Contact us"
+msgstr ""
+
+#: godotengine/partials/header.htm:27
+msgid "Community"
+msgstr ""
+
+#: godotengine/partials/header.htm:28
+msgid "About"
+msgstr ""
+
+#: godotengine/partials/header.htm:29
+msgid "Assets"
+msgstr ""
+
+#: godotengine/partials/header.htm:34
+msgid "Learn"
+msgstr ""
+
+#: godotengine/partials/header.htm:35
+msgid "Contribute"
 msgstr ""

--- a/themes/godotengine/i18n/po/messages.po
+++ b/themes/godotengine/i18n/po/messages.po
@@ -1,8 +1,0 @@
-msgid ""
-msgstr ""
-"Content-Type: text/plain; charset=utf-8\n"
-"X-Domain: default\n"
-
-#: godotengine/layouts/home.htm:246
-msgid "The game engine you've been waiting&nbsp;for."
-msgstr ""

--- a/themes/godotengine/i18n/po/messages.pot
+++ b/themes/godotengine/i18n/po/messages.pot
@@ -1,18 +1,15 @@
-# Russian translation of the Godot Engine class reference.
+# LANGUAGE translation of the Godot Engine class reference.
 # Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.
 # Copyright (c) 2014-2022 Godot Engine contributors (cf. https://github.com/godotengine/godot/blob/master/AUTHORS.md).
 # This file is distributed under the same license as the Godot source code.
 #
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8-bit\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"MIME-Version: 1.0\n"
 "Project-Id-Version: Godot Engine official website\n"
 "Report-Msgid-Bugs-To: https://github.com/godotengine/godot-website\n"
-"Language: ru\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8-bit\n"
-"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % "
-"10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
 "X-Domain: default\n"
 
 #: godotengine/layouts/home.htm:246
@@ -20,18 +17,19 @@ msgid "The game engine you've been waiting&nbsp;for."
 msgstr ""
 
 #: godotengine/layouts/home.htm:247
-msgid ""
-"The Godot Engine is a free, all-in-one, cross-platform game engine that "
-"makes it easy for you to create 2D and 3D games."
+msgid "The Godot Engine is a free, all-in-one, cross-platform game engine that makes it easy for you to create 2D and 3D games."
 msgstr ""
 
-#: godotengine/layouts/home.htm:251 godotengine/partials/footer.htm:18
+#: godotengine/layouts/home.htm:251
+#: godotengine/partials/footer.htm:18
 #: godotengine/partials/header.htm:33
 msgid "Download"
 msgstr ""
 
-#: godotengine/layouts/home.htm:253 godotengine/layouts/home.htm:440
-#: godotengine/layouts/home.htm:449 godotengine/layouts/home.htm:458
+#: godotengine/layouts/home.htm:253
+#: godotengine/layouts/home.htm:440
+#: godotengine/layouts/home.htm:449
+#: godotengine/layouts/home.htm:458
 #: godotengine/layouts/home.htm:473
 msgid "Learn more"
 msgstr ""
@@ -53,9 +51,7 @@ msgid "Innovative design"
 msgstr ""
 
 #: godotengine/layouts/home.htm:324
-msgid ""
-"Godot's Node and Scene system gives you both power and flexibility to create "
-"anything."
+msgid "Godot's Node and Scene system gives you both power and flexibility to create anything."
 msgstr ""
 
 #: godotengine/layouts/home.htm:341
@@ -63,9 +59,7 @@ msgid "Use the right language for the job"
 msgstr ""
 
 #: godotengine/layouts/home.htm:343
-msgid ""
-"Keep your code modular with an object-oriented API using Godot's own "
-"GDScript, C#, C++, or bring your own using GDNative."
+msgid "Keep your code modular with an object-oriented API using Godot's own GDScript, C#, C++, or bring your own using GDNative."
 msgstr ""
 
 #: godotengine/layouts/home.htm:359
@@ -73,9 +67,7 @@ msgid "Dedicated 2D engine"
 msgstr ""
 
 #: godotengine/layouts/home.htm:361
-msgid ""
-"Make crisp and performant 2D games with Godot's dedicated 2D rendering "
-"engine with real 2D pixel coordinates and 2D nodes."
+msgid "Make crisp and performant 2D games with Godot's dedicated 2D rendering engine with real 2D pixel coordinates and 2D nodes."
 msgstr ""
 
 #: godotengine/layouts/home.htm:378
@@ -83,9 +75,7 @@ msgid "Simple and powerful 3D"
 msgstr ""
 
 #: godotengine/layouts/home.htm:380
-msgid ""
-"Godot's 3D nodes give you everything you need to build, animate, and render "
-"your 3D worlds and characters."
+msgid "Godot's 3D nodes give you everything you need to build, animate, and render your 3D worlds and characters."
 msgstr ""
 
 #: godotengine/layouts/home.htm:397
@@ -93,9 +83,7 @@ msgid "Release on all platforms"
 msgstr ""
 
 #: godotengine/layouts/home.htm:399
-msgid ""
-"Deploy your game on desktop, mobile, and the web in seconds. Godot even "
-"supports consoles through third party publishers."
+msgid "Deploy your game on desktop, mobile, and the web in seconds. Godot even supports consoles through third party publishers."
 msgstr ""
 
 #: godotengine/layouts/home.htm:416
@@ -103,9 +91,7 @@ msgid "Open Source"
 msgstr ""
 
 #: godotengine/layouts/home.htm:418
-msgid ""
-"Truly open development: anyone who contributes to Godot benefits equally "
-"from others' contributions."
+msgid "Truly open development: anyone who contributes to Godot benefits equally from others' contributions."
 msgstr ""
 
 #: godotengine/layouts/home.htm:427
@@ -113,8 +99,7 @@ msgid "Get involved"
 msgstr ""
 
 #: godotengine/layouts/home.htm:429
-msgid ""
-"Join the community and help create a game engine that belongs to everybody."
+msgid "Join the community and help create a game engine that belongs to everybody."
 msgstr ""
 
 #: godotengine/layouts/home.htm:436
@@ -122,9 +107,7 @@ msgid "Code"
 msgstr ""
 
 #: godotengine/layouts/home.htm:438
-msgid ""
-"If you know how to code, you can help by fixing bugs and working with engine "
-"contributors towards the implementation of new features."
+msgid "If you know how to code, you can help by fixing bugs and working with engine contributors towards the implementation of new features."
 msgstr ""
 
 #: godotengine/layouts/home.htm:445
@@ -132,9 +115,7 @@ msgid "Document"
 msgstr ""
 
 #: godotengine/layouts/home.htm:447
-msgid ""
-"Documentation quality is essential in a game engine; help make it better by "
-"updating the API reference, writing new guides or submitting corrections."
+msgid "Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections."
 msgstr ""
 
 #: godotengine/layouts/home.htm:454
@@ -142,20 +123,17 @@ msgid "Report"
 msgstr ""
 
 #: godotengine/layouts/home.htm:456
-msgid ""
-"Found a problem with the engine? Don't forget to report it so that "
-"developers can track it down."
+msgid "Found a problem with the engine? Don't forget to report it so that developers can track it down."
 msgstr ""
 
-#: godotengine/layouts/home.htm:467 godotengine/partials/footer.htm:34
+#: godotengine/layouts/home.htm:467
+#: godotengine/partials/footer.htm:34
 #: godotengine/partials/header.htm:37
 msgid "Donate"
 msgstr ""
 
 #: godotengine/layouts/home.htm:470
-msgid ""
-"You don't need to be an engine developer to help Godot. Consider donating to "
-"speed up development and make Godot&nbsp Engine even more awesome!"
+msgid "You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot&nbsp Engine even more awesome!"
 msgstr ""
 
 #: godotengine/layouts/home.htm:479
@@ -194,7 +172,8 @@ msgstr ""
 msgid "Public Relations"
 msgstr ""
 
-#: godotengine/partials/footer.htm:22 godotengine/partials/header.htm:26
+#: godotengine/partials/footer.htm:22
+#: godotengine/partials/header.htm:26
 msgid "News"
 msgstr ""
 
@@ -210,11 +189,13 @@ msgstr ""
 msgid "About Godot"
 msgstr ""
 
-#: godotengine/partials/footer.htm:28 godotengine/partials/header.htm:22
+#: godotengine/partials/footer.htm:28
+#: godotengine/partials/header.htm:22
 msgid "Features"
 msgstr ""
 
-#: godotengine/partials/footer.htm:29 godotengine/partials/header.htm:24
+#: godotengine/partials/footer.htm:29
+#: godotengine/partials/header.htm:24
 msgid "Showcase"
 msgstr ""
 

--- a/themes/godotengine/layouts/home.htm
+++ b/themes/godotengine/layouts/home.htm
@@ -254,13 +254,13 @@ Make sure to update this gradient when the home background image is changed.
   <div class="wrapper">
     <div class="copy container">
       <h1>{{ TR('The game engine you\'ve been waiting&nbsp;for.') }}</h1>
-      <p>The Godot Engine is a free, all-in-one, cross-platform game engine that makes it easy for you to create 2D and 3D games.</p>
+      <p>{{ TR('The Godot Engine is a free, all-in-one, cross-platform game engine that makes it easy for you to create 2D and 3D games.') }}</p>
 
       <div class="main-download">
         <a href="/download" class="btn btn-download">
-          <div class="download-title">Download</div><div class="download-hint">{% include('version') with {'key': 'identifier'} %}</div>
+          <div class="download-title">{{ TR('Download') }}</div><div class="download-hint">{% include('version') with {'key': 'identifier'} %}</div>
         </a>
-        <a href="/features" class="btn btn-flat btn-flat-white btn-hero-learn-more">Learn more</a>
+        <a href="/features" class="btn btn-flat btn-flat-white btn-hero-learn-more">{{ TR('Learn more') }}</a>
       </div>
     </div>
   </div>
@@ -270,7 +270,7 @@ Make sure to update this gradient when the home background image is changed.
 </section>
 
 <section class="container padded">
-  <h2>Latest news</h2>
+  <h2>{{ TR('Latest news') }}</h2>
   <div class="flex eqsize responsive" style="gap: 30px;">
 
     <a href="{{ 'article'|page({ slug: posts[0].slug }) }}" style="text-decoration: none">
@@ -307,7 +307,7 @@ Make sure to update this gradient when the home background image is changed.
           {% endif %}
         {% endfor %}
         <div class="button-container">
-          <a href="/news/default/1" class="btn no-margin">More News</a>
+          <a href="/news/default/1" class="btn no-margin">{{ TR('More News') }}</a>
         </div>
       </div>
     </div>
@@ -315,7 +315,7 @@ Make sure to update this gradient when the home background image is changed.
 </section>
 
 <section id="features" class="container padded">
-  <h2>A different way to make games</h2>
+  <h2>{{ TR('A different way to make games') }}</h2>
 
   <div class="features-grid">
     <a class="feature-link" href="/features#design" data-barba-prevent>
@@ -329,10 +329,9 @@ Make sure to update this gradient when the home background image is changed.
           loading="lazy"
         >
         <div class="body">
-          <h4>Innovative design</h4>
+          <h4>{{ TR('Innovative design') }}</h4>
           <p>
-            Godot's Node and Scene system gives you both power and flexibility
-            to create anything.
+            {{ TR("Godot's Node and Scene system gives you both power and flexibility to create anything.") }}
           </p>
         </div>
       </div>
@@ -349,10 +348,9 @@ Make sure to update this gradient when the home background image is changed.
           loading="lazy"
         >
         <div class="body">
-          <h4>Use the right language for the job</h4>
+          <h4>{{ TR('Use the right language for the job') }}</h4>
           <p>
-            Keep your code modular with an object-oriented API using Godot's own
-            GDScript, C#, C++, or bring your own using GDNative.
+            {{ TR("Keep your code modular with an object-oriented API using Godot's own GDScript, C#, C++, or bring your own using GDNative.") }}
           </p>
         </div>
       </div>
@@ -368,10 +366,9 @@ Make sure to update this gradient when the home background image is changed.
           loading="lazy"
         >
         <div class="body">
-          <h4>Dedicated 2D engine</h4>
+          <h4>{{ TR('Dedicated 2D engine') }}</h4>
           <p>
-            Make crisp and performant 2D games with Godot's dedicated 2D
-            rendering engine with real 2D pixel coordinates and 2D nodes.
+            {{ TR("Make crisp and performant 2D games with Godot's dedicated 2D rendering engine with real 2D pixel coordinates and 2D nodes.") }}
           </p>
         </div>
       </div>
@@ -388,10 +385,9 @@ Make sure to update this gradient when the home background image is changed.
           loading="lazy"
         >
         <div class="body">
-          <h4>Simple and powerful 3D</h4>
+          <h4>{{ TR('Simple and powerful 3D') }}</h4>
           <p>
-            Godot's 3D nodes give you everything you need to build, animate,
-            and render your 3D worlds and characters.
+            {{ TR("Godot's 3D nodes give you everything you need to build, animate, and render your 3D worlds and characters.") }}
           </p>
         </div>
       </div>
@@ -408,10 +404,9 @@ Make sure to update this gradient when the home background image is changed.
           loading="lazy"
         >
         <div class="body">
-          <h4>Release on all platforms</h4>
+          <h4>{{ TR('Release on all platforms') }}</h4>
           <p>
-            Deploy your game on desktop, mobile, and the web in seconds. Godot
-            even supports consoles through third party publishers.
+            {{ TR('Deploy your game on desktop, mobile, and the web in seconds. Godot even supports consoles through third party publishers.') }}
           </p>
         </div>
       </div>
@@ -428,10 +423,9 @@ Make sure to update this gradient when the home background image is changed.
           loading="lazy"
         >
         <div class="body">
-          <h4>Open Source</h4>
+          <h4>{{ TR('Open Source') }}</h4>
           <p>
-            Truly open development: anyone who contributes to Godot benefits
-            equally from others’ contributions.
+            {{ TR("Truly open development: anyone who contributes to Godot benefits equally from others' contributions.") }}
           </p>
         </div>
       </div>
@@ -440,38 +434,38 @@ Make sure to update this gradient when the home background image is changed.
 </section>
 
 <section id="get_involved" class="container padded">
-  <h2>Get involved</h2>
+  <h2>{{ TR('Get involved') }}</h2>
   <p>
-    Join the community and help create a game engine that belongs to everybody.
+    {{ TR('Join the community and help create a game engine that belongs to everybody.') }}
   </p>
 
   <div class="flex eqsize responsive">
 
     <div class="text-center base-padding">
       <img src="{{ 'assets/home/code.svg' | theme }}" alt="" width="250" height="250" loading="lazy">
-      <h4>Code</h4>
+      <h4>{{ TR('Code') }}</h4>
       <p>
-        If you know how to code, you can help by fixing bugs and working with engine contributors towards the implementation of new features.
+        {{ TR('If you know how to code, you can help by fixing bugs and working with engine contributors towards the implementation of new features.') }}
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn btn-flat" target="_blank" rel="noopener">Learn more</a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code" class="btn btn-flat" target="_blank" rel="noopener">{{ TR('Learn more') }}</a>
     </div>
 
     <div class="text-center base-padding">
       <img src="{{ 'assets/home/document.svg' | theme }}" alt="" width="250" height="250" loading="lazy">
-      <h4>Document</h4>
+      <h4>{{ TR('Document') }}</h4>
       <p>
-        Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections.
+        {{ TR('Documentation quality is essential in a game engine; help make it better by updating the API reference, writing new guides or submitting corrections.') }}
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn btn-flat" target="_blank" rel="noopener">Learn more</a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation" class="btn btn-flat" target="_blank" rel="noopener">{{ TR('Learn more') }}</a>
     </div>
 
     <div class="text-center base-padding">
       <img src="{{ 'assets/home/report.svg' | theme }}" alt="" width="250" height="250" loading="lazy">
-      <h4>Report</h4>
+      <h4>{{ TR('Report') }}</h4>
       <p>
-        Found a problem with the engine? Don't forget to report it so that developers can track it down.
+        {{ TR("Found a problem with the engine? Don't forget to report it so that developers can track it down.") }}
       </p>
-      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn btn-flat" target="_blank" rel="noopener">Learn more</a>
+      <a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues" class="btn btn-flat" target="_blank" rel="noopener">{{ TR('Learn more') }}</a>
     </div>
 
   </div>
@@ -480,18 +474,19 @@ Make sure to update this gradient when the home background image is changed.
 <section id="donations" class="padded">
   <div class="container sm-full">
     <img id="sfc_graphic" src="{{ 'assets/home/sfc.svg' | theme }}" alt="Software Freedom Conservancy logo" width="1" height="1" class="img-auto-size"  loading="lazy">
-    <h3 class="text-center">Donate</h3>
-    <p class="small auto-margin">
-      You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot&nbsp;Engine even more awesome!
+    <h3 class="text-center">{{ TR('Donate') }}</h3>
+    <p class
+    ="small auto-margin">
+      {{ TR("You don't need to be an engine developer to help Godot. Consider donating to speed up development and make Godot&nbsp Engine even more awesome!") }}
     </p>
 
-    <a href="/donate" class="btn btn-flat btn-flat-white">Learn more</a>
+    <a href="/donate" class="btn btn-flat btn-flat-white">{{ TR('Learn more') }}</a>
   </div>
 </section>
 
 <section id="sponsors">
   <div class="container sm-full padded">
-    <h2 class="text-center">Sponsored by</h2>
+    <h2 class="text-center">{{ TR('Sponsored by') }}</h2>
 
     <div class="platinum flex">
       <a class="sponsor card" href="https://www.gamblify.com/" target="_blank" rel="noopener">

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -8,46 +8,46 @@ description = "footer partial"
   <div class="container flex">
     <div id="copyright">
       <p>
-        © 2007-{{ "now"|date("Y") }} Juan Linietsky, Ariel Manzur and <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank" rel="noopener">contributors</a><br>
-        Godot is a member of the <a href="https://sfconservancy.org/" target_="_blank" rel="noopener">Software Freedom Conservancy</a>.<br>
-        Kindly hosted by <a href="https://tuxfamily.org" target="_blank" rel="noopener">TuxFamily.org</a>.<br>
-        <a href="https://github.com/godotengine/godot-website" target="_blank" rel="noopener">Website source code on GitHub</a>.
+        © 2007-{{ "now"|date("Y") }} Juan Linietsky, Ariel Manzur {{ TR('and') }} <a href="https://github.com/godotengine/godot/blob/master/AUTHORS.md" target="_blank" rel="noopener">{{ TR('contributors') }}</a>.<br>
+        {{ TR('Godot is a member of the') }} <a href="https://sfconservancy.org/" target_="_blank" rel="noopener">Software Freedom Conservancy</a>.<br>
+        {{ TR('Kindly hosted by') }} <a href="https://tuxfamily.org" target="_blank" rel="noopener">TuxFamily.org</a>.<br>
+        <a href="https://github.com/godotengine/godot-website" target="_blank" rel="noopener">{{ TR('Website source code on GitHub') }}</a>.
       </p>
     </div>
     <div id="sitemap">
       <ul class="sitemap-group">
-        <li><strong>Get Godot</strong></li>
-        <li><a href="/download">Download</a></li>
-        <li><a href="https://editor.godotengine.org/releases/latest/">Web Editor</a></li>
+        <li><strong>{{ TR('Get Godot') }}</strong></li>
+        <li><a href="/download">{{ TR('Download') }}</a></li>
+        <li><a href="https://editor.godotengine.org/releases/latest/">{{ TR('Web Editor') }}</a></li>
         <li>&nbsp;</li>
-        <li><strong>Public Relations</strong></li>
-        <li><a href="/news/default/1">News</a></li>
-        <li><a href="/community">Communities and Events</a></li>
-        <li><a href="/press">Press Kit</a></li>
+        <li><strong>{{ TR('Public Relations') }}</strong></li>
+        <li><a href="/news/default/1">{{ TR('News') }}</a></li>
+        <li><a href="/community">{{ TR('Communities and Events') }}</a></li>
+        <li><a href="/press">{{ TR('Press Kit') }}</a></li>
       </ul>
       <ul class="sitemap-group">
-        <li><strong>About Godot</strong></li>
-        <li><a href="/features">Features</a></li>
-        <li><a href="/showcase">Showcase</a></li>
-        <li><a href="/education">Education</a></li>
-        <li><a href="/license">License</a></li>
-        <li><a href="/code-of-conduct">Code of Conduct</a></li>
-        <li><a href="/privacy-policy">Privacy Policy</a></li>
-        <li><a href="/donate">Donate</a></li>
+        <li><strong>{{ TR('About Godot') }}</strong></li>
+        <li><a href="/features">{{ TR('Features') }}</a></li>
+        <li><a href="/showcase">{{ TR('Showcase') }}</a></li>
+        <li><a href="/education">{{ TR('Education') }}</a></li>
+        <li><a href="/license">{{ TR('License') }}</a></li>
+        <li><a href="/code-of-conduct">{{ TR('Code of Conduct') }}</a></li>
+        <li><a href="/privacy-policy">{{ TR('Privacy Policy') }}</a></li>
+        <li><a href="/donate">{{ TR('Donate') }}</a></li>
       </ul>
       <ul class="sitemap-group">
-        <li><strong>Project Team</strong></li>
-        <li><a href="/governance">Governance</a></li>
-        <li><a href="/teams">Teams</a></li>
+        <li><strong>{{ TR('Project Team') }}</strong></li>
+        <li><a href="/governance">{{ TR('Governance') }}</a></li>
+        <li><a href="/teams">{{ TR('Teams') }}</a></li>
         <li>&nbsp;</li>
-        <li><strong>Extra Resources</strong></li>
-        <li><a href="/asset-library/asset">Asset Library</a></li>
-        <li><a href="https://docs.godotengine.org">Documentation</a></li>
-        <li><a href="https://github.com/godotengine">Code Repository</a></li>
+        <li><strong>{{ TR('Extra Resources') }}</strong></li>
+        <li><a href="/asset-library/asset">{{ TR('Asset Library') }}</a></li>
+        <li><a href="https://docs.godotengine.org">{{ TR('Documentation') }}</a></li>
+        <li><a href="https://github.com/godotengine">{{ TR('Code Repository') }}</a></li>
       </ul>
     </div>
     <div id="social" class="dark-desaturate">
-      <h4 class="text-right"><a href="/contact">Contact us</a></h4>
+      <h4 class="text-right"><a href="/contact">{{ TR('Contact us') }}</a></h4>
       <div class="flex justify-space-between">
         <a href="https://github.com/godotengine" target="_blank" rel="noopener">
           <img src="{{ 'assets/footer/github_logo.svg' | theme }}" width="32" height="32" alt="GitHub">
@@ -131,49 +131,45 @@ description = "footer partial"
           namespace: 'default',
           beforeEnter() {
             // Updating the hero on the home page
-            if (window.location.pathname === '/') {
+            // get the current html lang attribute
+            const htmlLang = document.documentElement.lang;
+            if (window.location.pathname === '/' || window.location.pathname === '/' + htmlLang || window.location.pathname === '/' + htmlLang + '/') {
               const authors = [
                 {
                   game: 'TailQuest: Defense',
-                  by: 'by Kivano Games',
+                  by: 'Kivano Games',
                   url: 'https://kivano.games/',
                   image: '/themes/godotengine/assets/home/hero/tail-quest.jpg',
                 },
                 {
                   game: 'Beat Invaders',
-                  by: 'by Raffaele Picca',
+                  by: 'Raffaele Picca',
                   url: 'https://www.raffaelepicca.com/',
                   image: '/themes/godotengine/assets/showcase/beat-invaders.jpg',
                 },
                 {
                   game: 'Ex Zodiac',
-                  by: 'by Ben Hickling',
+                  by: 'Ben Hickling',
                   url: 'https://store.steampowered.com/app/1249480/ExZodiac/',
                   image: '/themes/godotengine/assets/showcase/ex-zodiac.png',
                 },
                 {
                   game: 'Primal Light',
-                  by: 'by Fat Gem',
+                  by: 'Fat Gem',
                   url: 'https://store.steampowered.com/app/771420/Primal_Light/',
                   image: '/themes/godotengine/assets/home/hero/primal-light.jpg',
                 },
                 {
                   game: 'Resolutiion',
-                  by: 'by Monolith of Minds',
+                  by: 'Monolith of Minds',
                   url: 'https://store.steampowered.com/app/975150/Resolutiion/',
                   image: '/themes/godotengine/assets/home/hero/resolutiion.jpg',
                 },
                 {
                   game: 'Dome Keeper',
-                  by: 'by Bippinbits',
+                  by: 'Bippinbits',
                   url: 'https://bippinbits.com/',
                   image: '/themes/godotengine/assets/showcase/dome-keeper.jpg',
-                },
-                {
-                  game: 'Fist of the Forgotten',
-                  by: 'Lone Wulf Studio',
-                  url: 'https://fistoftheforgotten.com/',
-                  image: '/themes/godotengine/assets/showcase/fist-of-the-forgotten.jpg',
                 },
               ];
 
@@ -181,7 +177,7 @@ description = "footer partial"
               document.querySelector('.hero .background-image').style.backgroundImage = `url(${author.image})`;
               document.querySelector('.hero .credits a').href = author.url;
               document.querySelector('.hero .credits a span.game').innerText = author.game;
-              document.querySelector('.hero .credits a span.by').innerText = author.by;
+              document.querySelector('.hero .credits a span.by').innerText = ' - ' + author.by;
 
               // Parallax effect: On page scroll move background-position up.
               // This effect is disabled if user opted to have reduced motion in browser/OS settings.

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -22,22 +22,22 @@ description = "header partial"
 
     <nav id="nav">
       <ul class="left">
-        <li {% if selected == 'features' %} class="active" {% endif %}><a href="/features">Features</a></li>
+        <li {% if selected == 'features' %} class="active" {% endif %}><a href="/features">{{ TR('Features') }}</a></li>
         <div class="only-on-mobile" style="width: 100%">
-          <li {% if this.page.id == 'showcase' %} class="active" {% endif %}><a href="/showcase">Showcase</a></li>
+          <li {% if this.page.id == 'showcase' %} class="active" {% endif %}><a href="/showcase">{{ TR('Showcase') }}</a></li>
         </div>
-        <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news/default/1">News</a></li>
-        <li {% if this.page.id == 'community' %} class="active" {% endif %}><a href="/community">Community</a></li>
-        <li {% if selected == 'more' %} class="active" {% endif %}><a href="/contact">About</a></li>
-        <li><a href="https://godotengine.org/asset-library/asset">Assets</a></li>
+        <li {% if selected == 'news' %} class="active" {% endif %}><a href="/news/default/1">{{ TR('News') }}</a></li>
+        <li {% if this.page.id == 'community' %} class="active" {% endif %}><a href="/community">{{ TR('Community') }}</a></li>
+        <li {% if selected == 'more' %} class="active" {% endif %}><a href="/contact">{{ TR('About') }}</a></li>
+        <li><a href="https://godotengine.org/asset-library/asset">{{ TR('Assets') }}</a></li>
       </ul>
 
       <ul class="right">
-        <li {% if selected == 'download' %} class="active" {% endif %}><a href="/download">Download</a></li>
-        <li><a href="https://docs.godotengine.org">Learn</a></li>
-        <li><a href="https://docs.godotengine.org/en/stable/community/contributing/index.html">Contribute</a></li>
+        <li {% if selected == 'download' %} class="active" {% endif %}><a href="/download">{{ TR('Download') }}</a></li>
+        <li><a href="https://docs.godotengine.org">{{ TR('Learn') }}</a></li>
+        <li><a href="https://docs.godotengine.org/en/stable/community/contributing/index.html">{{ TR('Contribute') }}</a></li>
         {# We add the control character at the end to force the heart to render as text and not as an emoji. #}
-        <li class="fund {% if this.page.id == 'donate' %} active {% endif %}"><a href="/donate">❤&#xFE0E; Donate</a></li>
+        <li class="fund {% if this.page.id == 'donate' %} active {% endif %}"><a href="/donate">❤&#xFE0E; {{ TR('Donate') }}</a></li>
       </ul>
     </nav>
   </div>

--- a/themes/godotengine/theme.yaml
+++ b/themes/godotengine/theme.yaml
@@ -1,7 +1,7 @@
 name: godotengine
 description: "Godot's custom theme"
 author: "Godot Engine"
-homepage: ""
+homepage: "https://godotengine.org/"
 code: gde
 translate:
   es: i18n/es.yaml


### PR DESCRIPTION
This is a companion for https://github.com/godotengine/godot-website/pull/491 that improves the translation systems.

* `messages.po` is now `messages.pot`, to act as a proper PO template.
* All PO and POT files now generate additional headers and copyright notes, following those that can be found in the main repo.
* The order for added strings is now deterministic, following the first source references order (filename and line).
* Translation markup for home, as well as header and footer, from #491 is included, so that the language files are property regenerated.
* Also includes Emi's fix for the hero image when navigating to a localized home page.
* Some code refactoring for clarity and separation of concerns.
* Backend pages of our plugins now have page titles, which were previously not set correctly.