### PR TITLE
Fix the parallax effect animation frame binding

### DIFF
--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -189,20 +189,20 @@ description = "footer partial"
                 const parallaxMinWidth = 768;
                 const parallaxSpeed = 0.4;
 
-                const parallaxTick = (offsetY) => {
+                const parallaxTick = () => {
                   if (window.innerWidth > parallaxMinWidth) {
-                    parallaxImage.style.transform = `translateY(${offsetY * parallaxSpeed}px)`;
+                    parallaxImage.style.transform = `translateY(${window.pageYOffset * parallaxSpeed}px)`;
                   } else {
                     parallaxImage.style.transform = 'none';
                   }
                 }
 
                 window.addEventListener("scroll", () => {
-                  requestAnimationFrame(parallaxTick(window.pageYOffset))
+                  window.requestAnimationFrame(parallaxTick)
                 });
 
                 window.addEventListener("resize", () => {
-                  requestAnimationFrame(parallaxTick(window.pageYOffset))
+                  window.requestAnimationFrame(parallaxTick)
                 });
               }
             }


### PR DESCRIPTION
Seems like https://github.com/godotengine/godot-website/pull/485 contained a mistake. `requestAnimationFrame` takes a function as an argument, and instead the function was just called directly with its result being passed to `requestAnimationFrame` with no useful effect. It also spammed the console.

Not sure if the desired performance was achieved in the end, as it didn't actually run on animation frames. But it did run on the handled events themselves, so visually there was no difference for most users. I did notice a hitch on the first scroll though, a few times. Might be related.

Either way, this should be better now. It still works, doesn't spew errors, and hopefully removes any visual lagginess from less powered/lower refresh rate devices.