### PR TITLE
Add a locale picker widget to the footer

### DIFF
--- a/themes/godotengine/assets/css/main.css
+++ b/themes/godotengine/assets/css/main.css
@@ -43,6 +43,7 @@
   --button-background-color: #ffffff;
   --footer-color: rgb(175, 180, 220);
   --footer-background-color: #414d69;
+  --locale-background-color: #313849;
 
   --code-background-color: #dcdfe2;
   --codeblock-background-color: #282b2e;
@@ -114,6 +115,7 @@
     --button-background-color: #333639;
     --footer-color: hsla(0, 0%, 100%, 0.625);
     --footer-background-color: #333639;
+    --locale-background-color: #202325;
 
     --code-background-color: #333639;
     --codeblock-background-color: #333639;

--- a/themes/godotengine/i18n/po/messages.es.po
+++ b/themes/godotengine/i18n/po/messages.es.po
@@ -25,7 +25,7 @@ msgid ""
 "makes it easy for you to create 2D and 3D games."
 msgstr ""
 
-#: godotengine/layouts/home.htm:251 godotengine/partials/footer.htm:18
+#: godotengine/layouts/home.htm:251 godotengine/partials/footer.htm:19
 #: godotengine/partials/header.htm:33
 msgid "Download"
 msgstr ""
@@ -147,7 +147,7 @@ msgid ""
 "developers can track it down."
 msgstr ""
 
-#: godotengine/layouts/home.htm:467 godotengine/partials/footer.htm:34
+#: godotengine/layouts/home.htm:467 godotengine/partials/footer.htm:35
 #: godotengine/partials/header.htm:37
 msgid "Donate"
 msgstr ""
@@ -162,107 +162,107 @@ msgstr ""
 msgid "Sponsored by"
 msgstr ""
 
-#: godotengine/partials/footer.htm:9
+#: godotengine/partials/footer.htm:10
 msgid "and"
 msgstr ""
 
-#: godotengine/partials/footer.htm:9
+#: godotengine/partials/footer.htm:10
 msgid "contributors"
 msgstr ""
 
-#: godotengine/partials/footer.htm:10
+#: godotengine/partials/footer.htm:11
 msgid "Godot is a member of the"
 msgstr ""
 
-#: godotengine/partials/footer.htm:11
+#: godotengine/partials/footer.htm:12
 msgid "Kindly hosted by"
 msgstr ""
 
-#: godotengine/partials/footer.htm:12
+#: godotengine/partials/footer.htm:13
 msgid "Website source code on GitHub"
 msgstr ""
 
-#: godotengine/partials/footer.htm:17
+#: godotengine/partials/footer.htm:18
 msgid "Get Godot"
 msgstr ""
 
-#: godotengine/partials/footer.htm:19
+#: godotengine/partials/footer.htm:20
 msgid "Web Editor"
 msgstr ""
 
-#: godotengine/partials/footer.htm:21
+#: godotengine/partials/footer.htm:22
 msgid "Public Relations"
 msgstr ""
 
-#: godotengine/partials/footer.htm:22 godotengine/partials/header.htm:26
+#: godotengine/partials/footer.htm:23 godotengine/partials/header.htm:26
 msgid "News"
 msgstr ""
 
-#: godotengine/partials/footer.htm:23
+#: godotengine/partials/footer.htm:24
 msgid "Communities and Events"
 msgstr ""
 
-#: godotengine/partials/footer.htm:24
+#: godotengine/partials/footer.htm:25
 msgid "Press Kit"
 msgstr ""
 
-#: godotengine/partials/footer.htm:27
+#: godotengine/partials/footer.htm:28
 msgid "About Godot"
 msgstr ""
 
-#: godotengine/partials/footer.htm:28 godotengine/partials/header.htm:22
+#: godotengine/partials/footer.htm:29 godotengine/partials/header.htm:22
 msgid "Features"
 msgstr ""
 
-#: godotengine/partials/footer.htm:29 godotengine/partials/header.htm:24
+#: godotengine/partials/footer.htm:30 godotengine/partials/header.htm:24
 msgid "Showcase"
 msgstr ""
 
-#: godotengine/partials/footer.htm:30
+#: godotengine/partials/footer.htm:31
 msgid "Education"
 msgstr ""
 
-#: godotengine/partials/footer.htm:31
+#: godotengine/partials/footer.htm:32
 msgid "License"
 msgstr ""
 
-#: godotengine/partials/footer.htm:32
+#: godotengine/partials/footer.htm:33
 msgid "Code of Conduct"
 msgstr ""
 
-#: godotengine/partials/footer.htm:33
+#: godotengine/partials/footer.htm:34
 msgid "Privacy Policy"
 msgstr ""
 
-#: godotengine/partials/footer.htm:37
+#: godotengine/partials/footer.htm:38
 msgid "Project Team"
 msgstr ""
 
-#: godotengine/partials/footer.htm:38
+#: godotengine/partials/footer.htm:39
 msgid "Governance"
 msgstr ""
 
-#: godotengine/partials/footer.htm:39
+#: godotengine/partials/footer.htm:40
 msgid "Teams"
 msgstr ""
 
-#: godotengine/partials/footer.htm:41
+#: godotengine/partials/footer.htm:42
 msgid "Extra Resources"
 msgstr ""
 
-#: godotengine/partials/footer.htm:42
+#: godotengine/partials/footer.htm:43
 msgid "Asset Library"
 msgstr ""
 
-#: godotengine/partials/footer.htm:43
+#: godotengine/partials/footer.htm:44
 msgid "Documentation"
 msgstr ""
 
-#: godotengine/partials/footer.htm:44
+#: godotengine/partials/footer.htm:45
 msgid "Code Repository"
 msgstr ""
 
-#: godotengine/partials/footer.htm:48
+#: godotengine/partials/footer.htm:49
 msgid "Contact us"
 msgstr ""
 
@@ -284,4 +284,28 @@ msgstr ""
 
 #: godotengine/partials/header.htm:35
 msgid "Contribute"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:101
+msgid "Language"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:113
+msgid "English"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:119
+msgid "German"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:125
+msgid "Spanish"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:131
+msgid "French"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:137
+msgid "Russian"
 msgstr ""

--- a/themes/godotengine/i18n/po/messages.pot
+++ b/themes/godotengine/i18n/po/messages.pot
@@ -21,7 +21,7 @@ msgid "The Godot Engine is a free, all-in-one, cross-platform game engine that m
 msgstr ""
 
 #: godotengine/layouts/home.htm:251
-#: godotengine/partials/footer.htm:18
+#: godotengine/partials/footer.htm:19
 #: godotengine/partials/header.htm:33
 msgid "Download"
 msgstr ""
@@ -127,7 +127,7 @@ msgid "Found a problem with the engine? Don't forget to report it so that develo
 msgstr ""
 
 #: godotengine/layouts/home.htm:467
-#: godotengine/partials/footer.htm:34
+#: godotengine/partials/footer.htm:35
 #: godotengine/partials/header.htm:37
 msgid "Donate"
 msgstr ""
@@ -140,110 +140,110 @@ msgstr ""
 msgid "Sponsored by"
 msgstr ""
 
-#: godotengine/partials/footer.htm:9
+#: godotengine/partials/footer.htm:10
 msgid "and"
 msgstr ""
 
-#: godotengine/partials/footer.htm:9
+#: godotengine/partials/footer.htm:10
 msgid "contributors"
 msgstr ""
 
-#: godotengine/partials/footer.htm:10
+#: godotengine/partials/footer.htm:11
 msgid "Godot is a member of the"
 msgstr ""
 
-#: godotengine/partials/footer.htm:11
+#: godotengine/partials/footer.htm:12
 msgid "Kindly hosted by"
 msgstr ""
 
-#: godotengine/partials/footer.htm:12
+#: godotengine/partials/footer.htm:13
 msgid "Website source code on GitHub"
 msgstr ""
 
-#: godotengine/partials/footer.htm:17
+#: godotengine/partials/footer.htm:18
 msgid "Get Godot"
 msgstr ""
 
-#: godotengine/partials/footer.htm:19
+#: godotengine/partials/footer.htm:20
 msgid "Web Editor"
 msgstr ""
 
-#: godotengine/partials/footer.htm:21
+#: godotengine/partials/footer.htm:22
 msgid "Public Relations"
 msgstr ""
 
-#: godotengine/partials/footer.htm:22
+#: godotengine/partials/footer.htm:23
 #: godotengine/partials/header.htm:26
 msgid "News"
 msgstr ""
 
-#: godotengine/partials/footer.htm:23
+#: godotengine/partials/footer.htm:24
 msgid "Communities and Events"
 msgstr ""
 
-#: godotengine/partials/footer.htm:24
+#: godotengine/partials/footer.htm:25
 msgid "Press Kit"
 msgstr ""
 
-#: godotengine/partials/footer.htm:27
+#: godotengine/partials/footer.htm:28
 msgid "About Godot"
 msgstr ""
 
-#: godotengine/partials/footer.htm:28
+#: godotengine/partials/footer.htm:29
 #: godotengine/partials/header.htm:22
 msgid "Features"
 msgstr ""
 
-#: godotengine/partials/footer.htm:29
+#: godotengine/partials/footer.htm:30
 #: godotengine/partials/header.htm:24
 msgid "Showcase"
 msgstr ""
 
-#: godotengine/partials/footer.htm:30
+#: godotengine/partials/footer.htm:31
 msgid "Education"
 msgstr ""
 
-#: godotengine/partials/footer.htm:31
+#: godotengine/partials/footer.htm:32
 msgid "License"
 msgstr ""
 
-#: godotengine/partials/footer.htm:32
+#: godotengine/partials/footer.htm:33
 msgid "Code of Conduct"
 msgstr ""
 
-#: godotengine/partials/footer.htm:33
+#: godotengine/partials/footer.htm:34
 msgid "Privacy Policy"
 msgstr ""
 
-#: godotengine/partials/footer.htm:37
+#: godotengine/partials/footer.htm:38
 msgid "Project Team"
 msgstr ""
 
-#: godotengine/partials/footer.htm:38
+#: godotengine/partials/footer.htm:39
 msgid "Governance"
 msgstr ""
 
-#: godotengine/partials/footer.htm:39
+#: godotengine/partials/footer.htm:40
 msgid "Teams"
 msgstr ""
 
-#: godotengine/partials/footer.htm:41
+#: godotengine/partials/footer.htm:42
 msgid "Extra Resources"
 msgstr ""
 
-#: godotengine/partials/footer.htm:42
+#: godotengine/partials/footer.htm:43
 msgid "Asset Library"
 msgstr ""
 
-#: godotengine/partials/footer.htm:43
+#: godotengine/partials/footer.htm:44
 msgid "Documentation"
 msgstr ""
 
-#: godotengine/partials/footer.htm:44
+#: godotengine/partials/footer.htm:45
 msgid "Code Repository"
 msgstr ""
 
-#: godotengine/partials/footer.htm:48
+#: godotengine/partials/footer.htm:49
 msgid "Contact us"
 msgstr ""
 
@@ -265,4 +265,28 @@ msgstr ""
 
 #: godotengine/partials/header.htm:35
 msgid "Contribute"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:101
+msgid "Language"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:113
+msgid "English"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:119
+msgid "German"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:125
+msgid "Spanish"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:131
+msgid "French"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:137
+msgid "Russian"
 msgstr ""

--- a/themes/godotengine/i18n/po/messages.ru.po
+++ b/themes/godotengine/i18n/po/messages.ru.po
@@ -25,7 +25,7 @@ msgid ""
 "makes it easy for you to create 2D and 3D games."
 msgstr ""
 
-#: godotengine/layouts/home.htm:251 godotengine/partials/footer.htm:18
+#: godotengine/layouts/home.htm:251 godotengine/partials/footer.htm:19
 #: godotengine/partials/header.htm:33
 msgid "Download"
 msgstr ""
@@ -147,7 +147,7 @@ msgid ""
 "developers can track it down."
 msgstr ""
 
-#: godotengine/layouts/home.htm:467 godotengine/partials/footer.htm:34
+#: godotengine/layouts/home.htm:467 godotengine/partials/footer.htm:35
 #: godotengine/partials/header.htm:37
 msgid "Donate"
 msgstr ""
@@ -162,107 +162,107 @@ msgstr ""
 msgid "Sponsored by"
 msgstr ""
 
-#: godotengine/partials/footer.htm:9
+#: godotengine/partials/footer.htm:10
 msgid "and"
 msgstr ""
 
-#: godotengine/partials/footer.htm:9
+#: godotengine/partials/footer.htm:10
 msgid "contributors"
 msgstr ""
 
-#: godotengine/partials/footer.htm:10
+#: godotengine/partials/footer.htm:11
 msgid "Godot is a member of the"
 msgstr ""
 
-#: godotengine/partials/footer.htm:11
+#: godotengine/partials/footer.htm:12
 msgid "Kindly hosted by"
 msgstr ""
 
-#: godotengine/partials/footer.htm:12
+#: godotengine/partials/footer.htm:13
 msgid "Website source code on GitHub"
 msgstr ""
 
-#: godotengine/partials/footer.htm:17
+#: godotengine/partials/footer.htm:18
 msgid "Get Godot"
 msgstr ""
 
-#: godotengine/partials/footer.htm:19
+#: godotengine/partials/footer.htm:20
 msgid "Web Editor"
 msgstr ""
 
-#: godotengine/partials/footer.htm:21
+#: godotengine/partials/footer.htm:22
 msgid "Public Relations"
 msgstr ""
 
-#: godotengine/partials/footer.htm:22 godotengine/partials/header.htm:26
+#: godotengine/partials/footer.htm:23 godotengine/partials/header.htm:26
 msgid "News"
 msgstr ""
 
-#: godotengine/partials/footer.htm:23
+#: godotengine/partials/footer.htm:24
 msgid "Communities and Events"
 msgstr ""
 
-#: godotengine/partials/footer.htm:24
+#: godotengine/partials/footer.htm:25
 msgid "Press Kit"
 msgstr ""
 
-#: godotengine/partials/footer.htm:27
+#: godotengine/partials/footer.htm:28
 msgid "About Godot"
 msgstr ""
 
-#: godotengine/partials/footer.htm:28 godotengine/partials/header.htm:22
+#: godotengine/partials/footer.htm:29 godotengine/partials/header.htm:22
 msgid "Features"
 msgstr ""
 
-#: godotengine/partials/footer.htm:29 godotengine/partials/header.htm:24
+#: godotengine/partials/footer.htm:30 godotengine/partials/header.htm:24
 msgid "Showcase"
 msgstr ""
 
-#: godotengine/partials/footer.htm:30
+#: godotengine/partials/footer.htm:31
 msgid "Education"
 msgstr ""
 
-#: godotengine/partials/footer.htm:31
+#: godotengine/partials/footer.htm:32
 msgid "License"
 msgstr ""
 
-#: godotengine/partials/footer.htm:32
+#: godotengine/partials/footer.htm:33
 msgid "Code of Conduct"
 msgstr ""
 
-#: godotengine/partials/footer.htm:33
+#: godotengine/partials/footer.htm:34
 msgid "Privacy Policy"
 msgstr ""
 
-#: godotengine/partials/footer.htm:37
+#: godotengine/partials/footer.htm:38
 msgid "Project Team"
 msgstr ""
 
-#: godotengine/partials/footer.htm:38
+#: godotengine/partials/footer.htm:39
 msgid "Governance"
 msgstr ""
 
-#: godotengine/partials/footer.htm:39
+#: godotengine/partials/footer.htm:40
 msgid "Teams"
 msgstr ""
 
-#: godotengine/partials/footer.htm:41
+#: godotengine/partials/footer.htm:42
 msgid "Extra Resources"
 msgstr ""
 
-#: godotengine/partials/footer.htm:42
+#: godotengine/partials/footer.htm:43
 msgid "Asset Library"
 msgstr ""
 
-#: godotengine/partials/footer.htm:43
+#: godotengine/partials/footer.htm:44
 msgid "Documentation"
 msgstr ""
 
-#: godotengine/partials/footer.htm:44
+#: godotengine/partials/footer.htm:45
 msgid "Code Repository"
 msgstr ""
 
-#: godotengine/partials/footer.htm:48
+#: godotengine/partials/footer.htm:49
 msgid "Contact us"
 msgstr ""
 
@@ -284,4 +284,28 @@ msgstr ""
 
 #: godotengine/partials/header.htm:35
 msgid "Contribute"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:101
+msgid "Language"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:113
+msgid "English"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:119
+msgid "German"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:125
+msgid "Spanish"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:131
+msgid "French"
+msgstr ""
+
+#: godotengine/partials/localePicker/default.htm:137
+msgid "Russian"
 msgstr ""

--- a/themes/godotengine/partials/footer.htm
+++ b/themes/godotengine/partials/footer.htm
@@ -1,7 +1,17 @@
 description = "footer partial"
+
+[localePicker]
+==
+<?php
+function onStart() {
+  $user = BackendAuth::getUser();
+  $this['isAuthorized'] = !!$user;
+}
+?>
 ==
 {##}
 
+{# main starts in header.htm #}
 </main>
 
 <footer>
@@ -46,9 +56,9 @@ description = "footer partial"
         <li><a href="https://github.com/godotengine">{{ TR('Code Repository') }}</a></li>
       </ul>
     </div>
-    <div id="social" class="dark-desaturate">
+    <div id="social">
       <h4 class="text-right"><a href="/contact">{{ TR('Contact us') }}</a></h4>
-      <div class="flex justify-space-between">
+      <div class="flex justify-space-between dark-desaturate">
         <a href="https://github.com/godotengine" target="_blank" rel="noopener">
           <img src="{{ 'assets/footer/github_logo.svg' | theme }}" width="32" height="32" alt="GitHub">
         </a>
@@ -67,6 +77,11 @@ description = "footer partial"
           <img src="{{ 'assets/footer/feed_logo.svg' | theme }}" width="32" height="32" alt="RSS feed">
         </a>
       </div>
+
+      {# Only show the locale picker for authorized users for the time being. #}
+      {% if isAuthorized %}
+      {% component 'localePicker' %}
+      {% endif %}
     </div>
   </div>
 </footer>
@@ -78,6 +93,10 @@ description = "footer partial"
 <script defer src="{{ 'assets/js/highlight.gdscript.min.js?1' | theme }}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
+    // We will use this DOM parser with barba to fetch the new metadata and update HTML/HEAD tags
+    // properly on transition.
+    const domParser = new DOMParser();
+
     barba.init({
       // Increase timeout from the default value (2000) as our server is relatively slow to respond.
       // Otherwise, the current page will be reloaded instead of loading the new page.
@@ -104,7 +123,18 @@ description = "footer partial"
             // Simple transition to let the user know that the page is currently loading.
             document.body.style.opacity = 0.6;
           },
-          enter() {
+          enter(data) {
+            // Parse the new document to extract and update the metadata.
+            const nextDocument = domParser.parseFromString(data.next.html, "text/html");
+            document.documentElement.setAttribute('lang', nextDocument.documentElement.getAttribute('lang'));
+
+            document.head.querySelectorAll('link[hreflang]').forEach((link) => {
+              link.remove();
+            });
+            nextDocument.head.querySelectorAll('link[hreflang]').forEach((link) => {
+              document.head.insertAdjacentHTML('beforeend', link.outerHTML);
+            });
+
             document.body.style.opacity = 1.0;
             // Scroll back to top and close the mobile menu to simulate
             // traditional navigation. Don't do this on initial page load

--- a/themes/godotengine/partials/head.htm
+++ b/themes/godotengine/partials/head.htm
@@ -46,7 +46,7 @@ description = "head partial"
   <link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
   <link rel="icon" href="{{ 'assets/favicon.png' | theme }}" sizes="any">
   <link rel="icon" href="{{ 'assets/favicon.svg' | theme }}" type="image/svg+xml">
-  <link rel="stylesheet" href="{{ 'assets/css/main.css?16' | theme }}">
+  <link rel="stylesheet" href="{{ 'assets/css/main.css?17' | theme }}">
   <link rel="stylesheet" href="{{ 'assets/css/tobii.min.css?1' | theme }}">
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-Bold.woff2?1' | theme }}" crossorigin>
   <link rel="preload" as="font" href="{{ 'assets/fonts/Montserrat-ExtraBold.woff2?1' | theme }}" crossorigin>

--- a/themes/godotengine/partials/header.htm
+++ b/themes/godotengine/partials/header.htm
@@ -43,4 +43,5 @@ description = "header partial"
   </div>
 </header>
 
+{# main ends in footer.htm #}
 <main data-barba="container" data-barba-namespace="default">

--- a/themes/godotengine/partials/localePicker/default.htm
+++ b/themes/godotengine/partials/localePicker/default.htm
@@ -1,0 +1,161 @@
+<style>
+  .locale-picker {
+    padding: 18px 0;
+    text-align: right;
+    position: relative;
+  }
+
+  .locale-toggle {
+    cursor: pointer;
+  }
+  .locale-toggle:hover {
+    filter: brightness(117.5%);
+  }
+  .locale-toggle:active {
+    filter: brightness(82.5%);
+  }
+
+  .locale-selected {
+    color: var(--footer-link-color);
+    text-decoration: underline;
+    text-decoration-color: var(--footer-link-underline-color);
+  }
+
+  .locale-list {
+    display: none;
+    background-color: var(--locale-background-color);
+    border-radius: 3px;
+    box-shadow: var(--base-shadow);
+    margin: 0 -8px;
+    padding: 6px 8px;
+    width: 100%;
+    position: absolute;
+    bottom: 48px;
+  }
+  .locale-list.active {
+    display: block;
+  }
+
+  .locale-list > li {
+    font-size: 16px;
+    margin-bottom: 2px;
+  }
+  .locale-list > li:hover {
+    background-color: var(--footer-background-color);
+  }
+
+  .locale-list > li a {
+    display: block;
+    padding: 4px 4px;
+    text-decoration: none;
+  }
+
+  @media (max-width: 900px) {
+    .locale-picker {
+      text-align: center;
+    }
+
+    .locale-list {
+      margin: 0;
+      padding: 4px 0;
+    }
+
+    .locale-list > li {
+      margin-bottom: 4px;
+    }
+
+    .locale-list > li a {
+      padding: 6px 4px;
+    }
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    // Make the toggle element interactive.
+    const localeToggle = document.querySelector('.locale-toggle');
+    localeToggle.addEventListener('click', () => {
+      const localeList = document.querySelector('.locale-list');
+      localeList.classList.toggle('active');
+    });
+
+    // Auto-hide the locale picker list when clicked outside.
+    document.addEventListener('click', (event) => {
+      let node = event.target;
+      while (node) {
+        if (node.classList && node.classList.contains('locale-picker')) {
+          return;
+        }
+
+        node = node.parentNode;
+      }
+
+      const localeList = document.querySelector('.locale-list');
+      if (localeList.classList && localeList.classList.contains('active')) {
+        localeList.classList.toggle('active');
+      }
+    });
+
+    // Enable locale switching for locale picker options.
+    document.querySelectorAll('.locale-option').forEach((it) => {
+      it.addEventListener('click', () => {
+        // We will use the matching alternate link, as it contains the address
+        // that is properly formatted and qualified.
+        const alterLinks = document.head.querySelectorAll('link[hreflang]');
+
+        for (let link of alterLinks) {
+          const linkLocale = link.getAttribute('hreflang');
+
+          if (linkLocale == it.dataset.locale) {
+            window.location = link.getAttribute('href');
+            break;
+          }
+        }
+      });
+    });
+  });
+</script>
+
+<div class="locale-picker">
+  <div class="locale-toggle">
+    {{ TR('Language') }}: <span class="locale-selected" data-locale="{{ activeLocale }}">{{ TR(activeLocaleName) }}</span>
+  </div>
+
+  {#
+    Options are listed as "LocaleName (TranslatedLocaleName)", unless it's the current locale.
+    This allows you to see both the name of each locale as it should be in its native language,
+    and as it would be in the current language.
+  #}
+  <ul class="locale-list">
+    <li>
+      <a href="javascript:;" class="locale-option" data-locale="en">
+        English
+        {% if activeLocale != 'en' %} ({{ TR('English') }}){% endif %}
+      </a>
+    </li>
+    <li>
+      <a href="javascript:;" class="locale-option" data-locale="de">
+        Deutsch
+        {% if activeLocale != 'de' %} ({{ TR('German') }}){% endif %}
+      </a>
+    </li>
+    <li>
+      <a href="javascript:;" class="locale-option" data-locale="es">
+        Español
+        {% if activeLocale != 'es' %} ({{ TR('Spanish') }}){% endif %}
+      </a>
+    </li>
+    <li>
+      <a href="javascript:;" class="locale-option" data-locale="fr">
+        français
+        {% if activeLocale != 'de' %} ({{ TR('French') }}){% endif %}
+      </a>
+    </li>
+    <li>
+      <a href="javascript:;" class="locale-option" data-locale="ru">
+        русский
+        {% if activeLocale != 'ru' %} ({{ TR('Russian') }}){% endif %}
+      </a>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
Only available for the authorized users for now, so we can test it without making translations completely public (they'll still work if users change the URL directly).

This PR also makes barba.js update some meta information on navigation, such as the lang attribute of `<html>` and alternate links in the `<head>`. This should make transitions more complete, as well as enable the locale picker to work with barba.

Looks like this:
[Desktop](https://user-images.githubusercontent.com/11782833/208256426-7d981327-7db6-44bf-8000-e01df7cdc38d.png) | [Mobile](https://user-images.githubusercontent.com/11782833/208256438-d49ec2ec-4df8-407b-be31-b33f721143e8.png)
