### PR TITLE
Add "en" to the value on the default html tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang }}">
+<html lang="en">
 
 <head>
 	<meta charset="utf-8">


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-website/issues/510

Since we are not using the localization plugin yet, I believe it is better to leave it like this without using any variable.
Once we enable that plugin again we can revert this.