### PR TITLE
Fix RSS feed format

### DIFF
--- a/pages/rss.xml
+++ b/pages/rss.xml
@@ -15,9 +15,9 @@ permalink: /rss.xml
 	{% for post in latest_posts limit:24 %}
 	<item>
 		<title>{{ post.title }}</title>
-		<link>{{ post.url }}</link>
+		<link>https://godotengine.org{{ post.url }}</link>
 		<description>{{ post.content | xml_escape }}</description>
-		<pubDate>{{ post.date | date: "%a, %B %e %Y %X +0000" }}</pubDate>
+		<pubDate>{{ post.date | date: "%a, %e %b %Y %X +0000" }}</pubDate>
 	</item>
 	{% endfor %}
 

--- a/pages/rss.xml
+++ b/pages/rss.xml
@@ -17,7 +17,7 @@ permalink: /rss.xml
 		<title>{{ post.title }}</title>
 		<link>https://godotengine.org{{ post.url }}</link>
 		<description>{{ post.content | xml_escape }}</description>
-		<pubDate>{{ post.date | date: "%a, %e %b %Y %X +0000" }}</pubDate>
+		<pubDate>{{ post.date | date: "%a, %d %b %Y %X +0000" }}</pubDate>
 	</item>
 	{% endfor %}
 


### PR DESCRIPTION
This PR fixes: https://github.com/godotengine/godot-website/issues/515

The pubDate should now be properly formatted and the link tag includes the full domain