### PR TITLE
Add site.baseurl variable to fix OG image previews

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,8 @@
 exclude: [".github", "Gemfile", "Gemfile.lock", "build.sh", "build-and-serve.sh", "README.md"]
 permalink: pretty
 
+baseurl: "https://godotengine.org"
+
 collections_dir: collections
 collections:
   article:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,12 @@
 	<meta name="description" content="{{ page.description | default: 'Free and open source 2D and 3D game engine' }}">
 	<meta name="theme-color" content="#3d8fcc">
 	<meta property="og:site_name" content="Godot Engine">
-	<meta property="og:url" content="https://godotengine.org">
+	<meta property="og:url" content="{{ site.baseurl }}">
 	<meta name="twitter:site" content="@godotengine">
 
 	<meta property="og:title" content="{{ page.title | default: 'Godot Engine' }}">
 	<meta property="og:description" content="{{ page.description | default: 'Free and open source 2D and 3D game engine' }}">
-	<meta property="og:image" content="{{ page.image | default: '/assets/og_image.png' }}">
+	<meta property="og:image" content="{{ site.baseurl }}{{ page.image | default: '/assets/og_image.png' }}">
 	<meta property="og:type" content="{{ page.og_type | default: 'website' }}">
 	<meta name="twitter:card" content="summary_large_image">
 	<title>{{ page.title | default: "Godot Engine" }}</title>

--- a/pages/rss.xml
+++ b/pages/rss.xml
@@ -7,15 +7,15 @@ permalink: /rss.xml
 	<channel>
 
 	<title>Godot Engine Official</title>
-	<link>https://godotengine.org</link>
+	<link>{{ site.baseurl }}</link>
 	<description>Godot is a 2D and 3D free and open source game engine developed by a community of contributors. It provides a huge set of common tools, so you can just focus on making your game without reinventing the wheel.</description>
-	<atom:link href="https://godotengine.org/rss.xml" rel="self" type="application/rss+xml" />
+	<atom:link href="{{ site.baseurl }}/rss.xml" rel="self" type="application/rss+xml" />
 
 	{% assign latest_posts = site.article | sort:"date" | reverse %}
 	{% for post in latest_posts limit:24 %}
 	<item>
 		<title>{{ post.title }}</title>
-		<link>https://godotengine.org{{ post.url }}</link>
+		<link>{{ site.baseurl }}{{ post.url }}</link>
 		<description>{{ post.content | xml_escape }}</description>
 		<pubDate>{{ post.date | date: "%a, %d %b %Y %X +0000" }}</pubDate>
 	</item>


### PR DESCRIPTION
The OG image was not formatted properly. Even if it worked in most sites, some others like Twitter were not pulling the images because we were using a relative path instead of an absolute one.

This PR adds a `_config.yml` variable to use in `/rss.xml` and `/_layouts/default.html`. 