### PR TITLE
Add untracked production files to .gitignore

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -46,5 +46,3 @@ jobs:
         git-config-email: '<>'
         # Remove outdated files from the target directory.
         clean: true
-        # Don't keep the history.
-        single-commit: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ vendor/
 
 # Code editors
 .vscode/
+
+# Website sections not tracked in this repo
+.htaccess
+asset-library/
+mirrorlist/
+qa/


### PR DESCRIPTION
We still need to be extra careful with stuff like `git clean -x` or `-X` which may remove those.

We could *not* add those to `.gitignore` so that `git clean -X` can be used, but since we don't build on the production instance, there's not much point to removing `.gitignore`'d files.
```
       -x
           Don’t use the standard ignore rules (see gitignore(5)), but still use the ignore rules given with -e options from the command line. This allows removing all untracked files, including build
           products. This can be used (possibly in conjunction with git restore or git reset) to create a pristine working directory to test a clean build.

       -X
           Remove only files ignored by Git. This may be useful to rebuild everything from scratch, but keep manually created files
```

Longer term, we need to find a better solution so that we're not at risk of deleting the QA, assetlib or mirrorlist by mistake...