### PR TITLE
Fix redirect template

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,12 @@
+{% assign target = page.redirect.to | replace_first: "/https:", "https:" %}
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ target }}">
+  <script>location="{{ target }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ target }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ target }}">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
The redirect plugin started to add a `/` before the url, so while this PR doesn't fix the underlying issue, it does fix the redirects.

Not sure what the origin of the bug is, but this PR will replace the first instance of `/https` with `https` so that we get rid of that first forward slash if it exists. 

Should close: https://github.com/godotengine/godot-website/issues/527