### PR TITLE
Don't shadow base config options, add local dev config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To build the website locally, follow these steps:
 2. Clone this repository.
 3. Install the necessary dependencies: `bundle install`.
 4. Build the site: `bundle exec jekyll build`.
+   - Append `--config _config.yml,_config.development.yml` to use the development config with your build.
 
 For simplicity, these two commands are also available as a `build.sh` script in this repository.
 
@@ -149,7 +150,8 @@ the events. **Some files may be obsolete and unused.**
 
 ### Build system
 
-This project is build with Jekyll, with the build instructions located in `Gemfile` and `_config.yml`.
+This project is build with Jekyll, with the build instructions located in `Gemfile` and `_config.yml`. When building
+locally, some configuration options may need to be different. To define those, `_config.development.yml` is used.
 
 ## Content update guidelines
 

--- a/_config.development.yml
+++ b/_config.development.yml
@@ -1,0 +1,2 @@
+# Overrides from the main config
+url: "http://localhost:4000"

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 exclude: [".github", "Gemfile", "Gemfile.lock", "build.sh", "build-and-serve.sh", "README.md"]
 permalink: pretty
 
-baseurl: "https://godotengine.org"
+url: "https://godotengine.org"
 
 collections_dir: collections
 collections:

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -73,19 +73,19 @@ collection: article
 	<div class="flex pagination">
 		{% if paginator.previous_page %}
 		<a class="pagination-previous"
-			href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: 'index.html', '' }}">← Previous</a>
+			href="{{ paginator.previous_page_path | prepend: site.url | replace: 'index.html', '' }}">← Previous</a>
 		{% endif %}
 
 		{% if paginator.page_trail %}
 		{% for trail in paginator.page_trail %}
 		<a {% if page.url==trail.path %}class="active" {% endif %} title="{{trail.title}}"
-			href="{{ trail.path | prepend: site.baseurl | replace: 'index.html', '' }}">{{ trail.num }}</a>
+			href="{{ trail.path | prepend: site.url | replace: 'index.html', '' }}">{{ trail.num }}</a>
 		{% endfor %}
 		{% endif %}
 
 		{% if paginator.next_page %}
 		<a class="pagination-next"
-			href="{{ paginator.next_page_path | prepend: site.baseurl | replace: 'index.html', '' }}">Next →</a>
+			href="{{ paginator.next_page_path | prepend: site.url | replace: 'index.html', '' }}">Next →</a>
 		{% endif %}
 	</div>
 	<div class="posts">
@@ -110,19 +110,19 @@ collection: article
 	<div class="flex pagination">
 		{% if paginator.previous_page %}
 		<a class="pagination-previous"
-			href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: 'index.html', '' }}">← Previous</a>
+			href="{{ paginator.previous_page_path | prepend: site.url | replace: 'index.html', '' }}">← Previous</a>
 		{% endif %}
 
 		{% if paginator.page_trail %}
 		{% for trail in paginator.page_trail %}
 		<a {% if page.url==trail.path %}class="active" {% endif %} title="{{trail.title}}"
-			href="{{ trail.path | prepend: site.baseurl | replace: 'index.html', '' }}">{{ trail.num }}</a>
+			href="{{ trail.path | prepend: site.url | replace: 'index.html', '' }}">{{ trail.num }}</a>
 		{% endfor %}
 		{% endif %}
 
 		{% if paginator.next_page %}
 		<a class="pagination-next"
-			href="{{ paginator.next_page_path | prepend: site.baseurl | replace: 'index.html', '' }}">Next →</a>
+			href="{{ paginator.next_page_path | prepend: site.url | replace: 'index.html', '' }}">Next →</a>
 		{% endif %}
 	</div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,12 @@
 	<meta name="description" content="{{ page.description | default: 'Free and open source 2D and 3D game engine' }}">
 	<meta name="theme-color" content="#3d8fcc">
 	<meta property="og:site_name" content="Godot Engine">
-	<meta property="og:url" content="{{ site.baseurl }}">
+	<meta property="og:url" content="{{ site.url }}">
 	<meta name="twitter:site" content="@godotengine">
 
 	<meta property="og:title" content="{{ page.title | default: 'Godot Engine' }}">
 	<meta property="og:description" content="{{ page.description | default: 'Free and open source 2D and 3D game engine' }}">
-	<meta property="og:image" content="{{ site.baseurl }}{{ page.image | default: '/assets/og_image.png' }}">
+	<meta property="og:image" content="{{ site.url }}{{ page.image | default: '/assets/og_image.png' }}">
 	<meta property="og:type" content="{{ page.og_type | default: 'website' }}">
 	<meta name="twitter:card" content="summary_large_image">
 	<title>{{ page.title | default: "Godot Engine" }}</title>

--- a/build-and-serve.sh
+++ b/build-and-serve.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 bundle install
-bundle exec jekyll serve --host 0.0.0.0
+bundle exec jekyll serve --config _config.yml,_config.development.yml --host 0.0.0.0

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 bundle install
-bundle exec jekyll build
+bundle exec jekyll build --config _config.yml,_config.development.yml

--- a/pages/rss.xml
+++ b/pages/rss.xml
@@ -7,15 +7,15 @@ permalink: /rss.xml
 	<channel>
 
 	<title>Godot Engine Official</title>
-	<link>{{ site.baseurl }}</link>
+	<link>{{ site.url }}</link>
 	<description>Godot is a 2D and 3D free and open source game engine developed by a community of contributors. It provides a huge set of common tools, so you can just focus on making your game without reinventing the wheel.</description>
-	<atom:link href="{{ site.baseurl }}/rss.xml" rel="self" type="application/rss+xml" />
+	<atom:link href="{{ site.url }}/rss.xml" rel="self" type="application/rss+xml" />
 
 	{% assign latest_posts = site.article | sort:"date" | reverse %}
 	{% for post in latest_posts limit:24 %}
 	<item>
 		<title>{{ post.title }}</title>
-		<link>{{ site.baseurl }}{{ post.url }}</link>
+		<link>{{ site.url }}{{ post.url }}</link>
 		<description>{{ post.content | xml_escape }}</description>
 		<pubDate>{{ post.date | date: "%a, %d %b %Y %X +0000" }}</pubDate>
 	</item>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-website/issues/527. Supersedes https://github.com/godotengine/godot-website/pull/529.

Seems like our hunch was correct, the redirect plugin uses the `baseurl` setting to generate URLs. We tried to use it as a protocol + hostname base, but the plugin uses it as a base path, suggesting to use `url` for the domain. Furthermore, `baseurl` is a part of the Jekyll's default configuration options, though its usage there is not clear to me.

Either way, seems like a safer solution here is to define `url` instead of `baseurl`, and use that throughout the templates. RSS generation, and the rest still work, and the redirects are fixed now.

I also went ahead and created `_config.development.yml`, so we can define `url` for local development, as well as any future setting we might want to adjust locally. Without that all generated URLs refer to the `https://godotengine.org` domain, which makes it harder to test things locally.