### PR TITLE
Showcase: update store names

### DIFF
--- a/_layouts/showcase-item.html
+++ b/_layouts/showcase-item.html
@@ -114,7 +114,7 @@ layout: default
 
 				{% if page.itch %}
 				<a href="{{ page.itch }}" class="btn" style="margin: 0 0.5rem; white-space: nowrap" target="_blank">
-					View on Itch.io
+					View on itch.io
 				</a>
 				{% endif %}
 
@@ -126,13 +126,13 @@ layout: default
 
 				{% if page.gog %}
 				<a href="{{ page.gog }}" class="btn" style="margin: 0 0.5rem; white-space: nowrap" target="_blank">
-					View on Humble GOG
+					View on GOG.com
 				</a>
 				{% endif %}
 
 				{% if page.nintendo %}
 				<a href="{{ page.nintendo }}" class="btn" style="margin: 0 0.5rem; white-space: nowrap" target="_blank">
-					View on Switch
+					View on Nintendo Switch
 				</a>
 				{% endif %}
 


### PR DESCRIPTION
- "Humble GOG" -> "GOG.com". Remove copy/paste error and add ".com", judging from the website title, the logo and various articles on https://support.gog.com/ the store name is "GOG.com" or "GOG.COM".
- "itch.io" should be all lowercase, see https://itch.io/press-kit#naming-and-typography.
- "Switch" -> "Nintendo Switch". Unlike e.g. Wii or Wii U, "Nintendo" is part of the name. Though maybe this should be reworded to "View *for* Nintendo Switch" as it is the console's name. (Might also be true for Xbox, but there the website is called "Xbox" as well.)