### PR TITLE
Improve page metadata across the board

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,5 +1,5 @@
 ---
-title: "Godot Engine - Blog"
+title: "Blog - Godot Engine"
 description: "Keep up-to-date with the latest Godot Engine development news."
 layout: default
 pagination:

--- a/collections/_download/android.md
+++ b/collections/_download/android.md
@@ -1,5 +1,6 @@
 ---
-title: Download - Godot Engine
+title: Download for Android - Godot Engine
+description: Download the latest stable version of the Godot Engine for Android
 platform: Android
 
 downloads:

--- a/collections/_download/linux.md
+++ b/collections/_download/linux.md
@@ -1,5 +1,6 @@
 ---
-title: Download - Godot Engine
+title: Download for Linux - Godot Engine
+description: Download the latest stable version of the Godot Engine for Linux
 platform: Linux
 
 downloads:

--- a/collections/_download/macos.md
+++ b/collections/_download/macos.md
@@ -1,6 +1,7 @@
 ---
-title: Download - Godot Engine
-platform: MacOS
+title: Download for macOS - Godot Engine
+description: Download the latest stable version of the Godot Engine for macOS
+platform: macOS
 
 downloads:
   - caption: Universal (x86_64 + Apple Silicon)

--- a/collections/_download/server.md
+++ b/collections/_download/server.md
@@ -1,5 +1,6 @@
 ---
-title: Download - Godot Engine
+title: Download for Linux Server - Godot Engine
+description: Download the latest stable version of the Godot Engine for Linux Server
 platform: Linux Server
 
 downloads:

--- a/collections/_download/windows.md
+++ b/collections/_download/windows.md
@@ -1,5 +1,6 @@
 ---
-title: Download - Godot Engine
+title: Download for Windows - Godot Engine
+description: Download the latest stable version of the Godot Engine for Windows
 platform: Windows
 
 downloads:

--- a/pages/code-of-conduct.html
+++ b/pages/code-of-conduct.html
@@ -1,6 +1,6 @@
 ---
 permalink: /code-of-conduct/index.html
-title: "Godot Engine - Code of Conduct"
+title: "Code of Conduct - Godot Engine"
 description: "Godot community's Code of Conduct."
 layout: more
 header_text: "Code of Conduct"

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -1,6 +1,6 @@
 ---
 permalink: /contact/index.html
-title: "Godot Engine - Contact"
+title: "Contact - Godot Engine"
 description: "Contact information for Godot's development team."
 layout: more
 header_text: "Contact us"

--- a/pages/download.html
+++ b/pages/download.html
@@ -1,19 +1,23 @@
 ---
 permalink: /download/index.html
+title: "Download - Godot Engine"
+description: "Download the latest stable version of the Godot Engine for Linux, macOS, Windows, or Android"
+layout: default
 ---
-<html>
 
-<body>
-	Redirecting...
-	<script type="text/javascript">
-		if (navigator.platform.indexOf('Mac') !== -1) {
-			window.location = "/download/macos";
-		} else if (navigator.platform.indexOf('Linux') !== -1) {
-			window.location = "/download/linux";
-		} else { // default to windows
-			window.location = "/download/windows";
-		}
-	</script>
-</body>
+<div style="padding: 16px 32px">
+	<h3>Redirecting...</h3>
+	<p>
+		If you are not being redirected automatically, <a href="/download/windows" class="set-os-download-url">click here</a>.
+	</p>
+</div>
 
-</html>
+<script type="text/javascript">
+	if (navigator.platform.indexOf('Mac') !== -1) {
+		window.location = "/download/macos";
+	} else if (navigator.platform.indexOf('Linux') !== -1) {
+		window.location = "/download/linux";
+	} else { // default to windows
+		window.location = "/download/windows";
+	}
+</script>

--- a/pages/events.html
+++ b/pages/events.html
@@ -1,7 +1,7 @@
 ---
 permalink: /events/index.html
 layout: default
-title: "Godot Engine - Events"
+title: "Events - Godot Engine"
 description: "This page lists the upcoming and previous Godot community events."
 ---
 

--- a/pages/features.html
+++ b/pages/features.html
@@ -1,6 +1,6 @@
 ---
 permalink: /features/index.html
-title: "Godot Engine - Features"
+title: "Features - Godot Engine"
 description: "Discover what Godot has to offer for 2D and 3D game development."
 layout: default
 ---

--- a/pages/governance.html
+++ b/pages/governance.html
@@ -1,6 +1,6 @@
 ---
 permalink: /governance/index.html
-title: "Godot Engine - Governance"
+title: "Governance - Godot Engine"
 description: "Governance model."
 layout: more
 header_text: "Governance model"

--- a/pages/license.html
+++ b/pages/license.html
@@ -1,6 +1,6 @@
 ---
 permalink: /license/index.html
-title: "Godot Engine - License"
+title: "License - Godot Engine"
 description: "Godot Engine is free and open source software released under the permissive MIT license."
 layout: more
 header_text: "License"

--- a/pages/privacy-policy.html
+++ b/pages/privacy-policy.html
@@ -1,6 +1,6 @@
 ---
 permalink: /privacy-policy/index.html
-title: "Godot Engine - Privacy Policy"
+title: "Privacy Policy - Godot Engine"
 description: "Teams and engine areas overview."
 layout: more
 header_text: "Privacy policy"

--- a/pages/showcase.html
+++ b/pages/showcase.html
@@ -1,6 +1,6 @@
 ---
 permalink: /showcase/index.html
-title: "Godot Engine - Showcase"
+title: "Showcase - Godot Engine"
 description: "Games made with the Godot Engine."
 layout: default
 ---

--- a/pages/teams.html
+++ b/pages/teams.html
@@ -1,6 +1,6 @@
 ---
 permalink: /teams/index.html
-title: "Godot Engine - Teams"
+title: "Teams - Godot Engine"
 description: "Teams and engine areas overview."
 layout: more
 header_text: "Godot Engine teams"


### PR DESCRIPTION
- Make "Godot Engine" a suffix instead of a prefix in page titles.
- Add missing descriptions and improve page titles for the new download pages.
- Make the base downloads page used for redirect noscript and OG friendly.