### PR TITLE
Update Godot website license and update Godot license on the website

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
-Copyright (c) 2014 - present Godot Engine contributors (cf. https://github.com/godotengine/godot/blob/master/AUTHORS.md).
-Copyright (c) 2007 Juan Linietsky, Ariel Manzur.
+Copyright (c) 2017-present Godot Engine contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pages/license.html
+++ b/pages/license.html
@@ -60,8 +60,8 @@ current_tab: "license"
 	</p>
 
 	<pre>
-  Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.
-  Copyright (c) 2014-2022 Godot Engine contributors.
+  Copyright (c) 2014-present Godot Engine contributors.
+  Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-website/issues/561. Follow-up to https://github.com/godotengine/godot/commit/d95794ec8a7c362b06a9cf080e2554ef77adb667. Also updates website's own license to be in line with other Godot sub-projects.