### PR TITLE
Promote Play Store version of the Android editor

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -339,7 +339,11 @@ layout: default
 			{% for download in featured_downloads %}
 
 			{% capture download_url %}
-				https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/{% if download.mono %}mono/{% endif %}Godot_v{{site.stable_version}}-stable_{{ download.slug }}
+				{% if download.custom %}
+					{{download.custom}}
+				{% else %}
+					https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/{% if download.mono %}mono/{% endif %}Godot_v{{site.stable_version}}-stable_{{ download.slug }}
+				{% endif %}
 			{% endcapture %}
 
 			<div class="main-download">
@@ -393,7 +397,11 @@ layout: default
 				{% for download in page.downloads %}
 
 				{% capture download_url %}
-					https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/{% if download.mono %}mono/{% endif %}Godot_v{{site.stable_version}}-stable_{{ download.slug }}
+					{% if download.custom %}
+						{{download.custom}}
+					{% else %}
+						https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/{% if download.mono %}mono/{% endif %}Godot_v{{site.stable_version}}-stable_{{ download.slug }}
+					{% endif %}
 				{% endcapture %}
 
 				<div class="download">
@@ -402,19 +410,21 @@ layout: default
 				</div>
 				{% endfor %}
 
-				<div class="download">
-					<a href="https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/Godot_v{{site.stable_version}}-stable_export_templates.tpz">
-						Export templates (Standard)
-					</a>
-					<span class="download-details">Used to export your games to all supported platforms</span>
-				</div>
-				{% unless page.ignore_mono %}
-				<div class="download">
-					<a href="https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/mono/Godot_v{{site.stable_version}}-stable_mono_export_templates.tpz">
-						Export templates (.NET)
-					</a>
-					<span class="download-details">Used to export your games to all supported platforms · C# support</span>
-				</div>
+				{% unless page.ignore_export %}
+					<div class="download">
+						<a href="https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/Godot_v{{site.stable_version}}-stable_export_templates.tpz">
+							Export templates (Standard)
+						</a>
+						<span class="download-details">Used to export your games to all supported platforms</span>
+					</div>
+					{% unless page.ignore_mono %}
+					<div class="download">
+						<a href="https://downloads.tuxfamily.org/godotengine/{{site.stable_version}}/mono/Godot_v{{site.stable_version}}-stable_mono_export_templates.tpz">
+							Export templates (.NET)
+						</a>
+						<span class="download-details">Used to export your games to all supported platforms · C# support</span>
+					</div>
+					{% endunless %}
 				{% endunless %}
 
 				{% if page.content_note %}

--- a/collections/_download/android.md
+++ b/collections/_download/android.md
@@ -4,13 +4,25 @@ description: Download the latest stable version of the Godot Engine for Android
 platform: Android
 
 downloads:
-  - caption: Universal (ARM64 + ARMv7 + x86_64 + x86)
-    slug: android_editor.apk
+  - caption: Universal - Play Store (ARM64 + ARMv7 + x86_64 + x86)
+    custom: https://play.google.com/store/apps/details?id=org.godotengine.editor.v3
     featured: true
+    featured_flavor: Play Store
     tags:
+      - Play Store
       - ARM64/v7
       - x86 (64 & 32 bit)
-     
+
+  - caption: Universal - APK (ARM64 + ARMv7 + x86_64 + x86)
+    slug: android_editor.apk
+    featured: true
+    featured_flavor: APK
+    tags:
+      - APK download
+      - ARM64/v7
+      - x86 (64 & 32 bit)
+
+ignore_export: true
 ignore_mono: true
 
 content_note: |
@@ -32,6 +44,6 @@ content_instructions: |
   </p>
 
   <p>
-    Compared to using the editor on desktop platforms, the experience may be frustrating, especially if you do not use a hardware keyboard and mouse. See the <a href="https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aopen+label%3Aplatform%3Aandroid+label%3Atopic%3Aeditor+">list of known issues affecting the Android editor</a> for more information.
+    Compared to using the editor on desktop platforms, the experience may be suboptimal, especially if you do not use a hardware keyboard and mouse. See the <a href="https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aopen+label%3Aplatform%3Aandroid+label%3Atopic%3Aeditor+">list of known issues affecting the Android editor</a> for more information.
   </p>
 ---


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-website/issues/571. I made very simple changes, but we can sure expand on the information for this page if we need to.

![chrome_2023-02-24_16-08-12](https://user-images.githubusercontent.com/11782833/221214444-9c85194c-0e69-4be3-88fb-2ae64fff56f7.png)
![image](https://user-images.githubusercontent.com/11782833/221216059-fabca2af-86f6-497c-83af-0bdb5f6ce789.png)

