### PR TITLE
Add Godot User Group Berlin data

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -147,6 +147,9 @@ Germany:
       - title: Facebook
         url: https://www.facebook.com/groups/359812631518879
   - name: Godot User Group Berlin
+    coordinates:
+      - 52.51279
+      - 13.44978
     links:
       - title: Meetup
         url: https://www.meetup.com/godot-user-group-berlin/

--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -146,6 +146,14 @@ Germany:
     links:
       - title: Facebook
         url: https://www.facebook.com/groups/359812631518879
+  - name: Godot User Group Berlin
+    links:
+      - title: Meetup
+        url: https://www.meetup.com/godot-user-group-berlin/
+      - title: Mastodon
+        url: https://mastodon.gamedev.place/@GodotUserGroupBerlin
+      - title: Discord
+        url: https://discord.gg/Sm3CgrqqQa
 India:
   - name: Godot India
     links:


### PR DESCRIPTION
The GPS coordinates point to: xHain hack+makespace, Grünberger Str. 16, 10243 Berlin, Germany
Fixes #612