### PR TITLE
Improve readability of the blog's search bar

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -49,6 +49,8 @@
   --button-background-color: #ffffff;
   --footer-color: rgb(175, 180, 220);
   --footer-background-color: #414d69;
+  --pagination-active-color: #284786;
+  --placeholder-text-color: #7a87a2;
 
   --code-background-color: #dcdfe2;
   --codeblock-background-color: #282b2e;
@@ -134,6 +136,8 @@
     --button-background-color: #333639;
     --footer-color: hsla(0, 0%, 100%, 0.625);
     --footer-background-color: #333639;
+    --pagination-active-color: #4080ff;
+    --placeholder-text-color: #a6a6a6;
 
     --code-background-color: #333639;
     --codeblock-background-color: #333639;
@@ -593,7 +597,7 @@ footer a {
 }
 
 .pagination a.active {
-  background-color: hsl(220, 100%, 62.5%);
+  background-color: var(--pagination-active-color);
   color: white;
 }
 
@@ -912,9 +916,10 @@ pre > code {
   display: flex;
   height: 40px;
   margin-bottom: 2rem;
-  box-shadow: var(--base-shadow);
-  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 18px;
   overflow: hidden;
+  min-width: 65%;
 }
 .search-bar input {
   flex-grow: 1;
@@ -923,8 +928,11 @@ pre > code {
   font-size: 18px;
   border: none;
   border-right: 1px solid var(--transparent-cover);
-  background-color: var(--card-background-color);
+  background-color: var(--card-footer-color);
   color: var(--base-color-text);
+}
+.search-bar input::placeholder {
+  color: var(--placeholder-text-color);
 }
 .search-bar .search-bar-btn {
   cursor: pointer;
@@ -932,8 +940,7 @@ pre > code {
   width: 3rem;
   padding: 0;
   margin: 0;
-  /* background-color: hsl(220, 100%, 62.5%); */
-  background-color: var(--primary-color);
+  background-color: var(--pagination-active-color);
   color: var(--primary-color-text-title);
 }
 .search-bar .search-bar-btn img {

--- a/pages/404.html
+++ b/pages/404.html
@@ -58,11 +58,6 @@ description: "The requested resource is not available on the server."
 		grid-column: span 2;
 	}
 
-	.search-bar {
-		border: 1px solid rgba(0, 0, 0, 0.2);
-		box-shadow: none;
-	}
-
 	.search-bar input {
 		background-color: var(--base-color);
 	}


### PR DESCRIPTION
As reported in https://github.com/godotengine/godot-website/pull/624, the bar lacks contrast and readability after the recent changes. This attempts to slightly improve it. (This also affects the 404 page, but the changes aren't very noticeable there).

![chrome_2023-04-20_19-57-19](https://user-images.githubusercontent.com/11782833/233449508-e3d821f7-f67c-468c-b145-b3aa6485ee40.png)
![chrome_2023-04-20_19-57-10](https://user-images.githubusercontent.com/11782833/233449520-e9604b28-57ce-48d7-9531-8f25a57dabd0.png)
