### PR TITLE
Update GDScript team

### DIFF
--- a/pages/teams.html
+++ b/pages/teams.html
@@ -199,7 +199,11 @@ current_tab: "teams"
 				<th class="teams-subteam-name">GDScript (<a href="https://chat.godotengine.org/channel/gdscript">#gdscript</a>)
 				</th>
 				<td class="teams-subteam-members">
-					<span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+					<span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>,
+					Adam Scott (<a href="https://github.com/adamscott">@adamscott</a>),
+					Danil Alexeev (<a href="https://github.com/dalexeev">@dalexeev</a>),
+					Dmitry Maganov (<a href="https://github.com/vonagam">@vonagam</a>),
+					ocean (they/them) (<a href="https://github.com/anvilfolk">@anvilfolk</a>)
 				</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
This PR updates the GDScript team. It is currently, on the website, only formed of @vnen.

![Capture d’écran 2023-04-23 à 20 24 41](https://user-images.githubusercontent.com/270928/233875483-f056c349-8020-4f6f-ae28-37f5551fa2bd.png)
