### PR TITLE
Removing confusing pronunciation 

### DIFF
--- a/pages/press.html
+++ b/pages/press.html
@@ -225,8 +225,6 @@ layout: default
 				Godot</a></em>,
 		and is usually pronounced like in the play. Different languages have different
 		pronunciations for Godot and we find it beautiful.
-		<br>For native English speakers, we recommend "GOD-oh"; the "t" is silent like in the
-		French original.
 	</p>
 
 	<h3 class="title">Logo and icon usage guidelines</h3>


### PR DESCRIPTION
How to "properly" pronounce Godot is a confusing and divisive topic for many. I think that the current excerpt we have on our press page is good enough and we should not include the specification for English in particular. This was also not the best way to explain how to pronounce it since many people interpreted this line in a different way:

> For native English speakers, we recommend "GOD-oh"; the "t" is silent like in the French original.

What we have before this is more in line with our general stance about pronunciation and I think we should keep it that way. 

> Godot is named after the play [Waiting for Godot](https://en.wikipedia.org/wiki/Waiting_for_Godot), and is usually pronounced like in the play. Different languages have different pronunciations for Godot and we find it beautiful.

The wikipedia article contains the phonetic ([/ˈɡɒdoʊ/](https://en.wikipedia.org/wiki/Help:IPA/English) [GOD-oh](https://en.wikipedia.org/wiki/Help:Pronunciation_respelling_key)) which should also be enough if you really want to get some prescriptive way of saying it.