### PR TITLE
Update the Teams page with current/active members

### DIFF
--- a/pages/teams.html
+++ b/pages/teams.html
@@ -52,7 +52,8 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
+			<span class="teams-subteam-leader">Juan Linietsky (<a
+					href="https://github.com/reduz">@reduz</a>)</span>,
 			George Marques (<a href="https://github.com/vnen">@vnen</a>),
 			HP van Braam (<a href="https://github.com/hpvb">@hpvb</a>),
 			Pedro J. Estébanez (<a href="https://github.com/RandomShaper">@RandomShaper</a>)
@@ -94,7 +95,6 @@ current_tab: "teams"
 		<p>
 
 		<p>
-			Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>),
 			Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
 			Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>),
 			Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>),
@@ -123,7 +123,6 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			Eric M (<a href="https://github.com/EricEzaM">@EricEzaM</a>),
 			Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
 			Hendrik Brucker (<a href="https://github.com/Geometror">@Geometror</a>),
 			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
@@ -159,7 +158,8 @@ current_tab: "teams"
 			<tr>
 				<th class="teams-subteam-name">Script editor</th>
 				<td class="teams-subteam-members">
-					<span class="teams-subteam-leader">Paul Batty (<a href="https://github.com/Paulb23">@Paulb23</a>)</span>,
+					<span class="teams-subteam-leader">Paul Batty (<a
+							href="https://github.com/Paulb23">@Paulb23</a>)</span>,
 					Michael Alexsander (<a href="https://github.com/YeldhamDev">@YeldhamDev</a>)
 				</td>
 			</tr>
@@ -187,6 +187,8 @@ current_tab: "teams"
 				<th class="teams-subteam-name">GDExtension (<a
 						href="https://chat.godotengine.org/channel/gdextension">#gdextension</a>)</th>
 				<td class="teams-subteam-members">
+					<span class="teams-subteam-leader">David Snopek (<a
+							href="https://github.com/dsnopek">@dsnopek</a>)</span>,
 					Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>),
 					Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
 					George Marques (<a href="https://github.com/vnen">@vnen</a>),
@@ -199,7 +201,8 @@ current_tab: "teams"
 				<th class="teams-subteam-name">GDScript (<a href="https://chat.godotengine.org/channel/gdscript">#gdscript</a>)
 				</th>
 				<td class="teams-subteam-members">
-					<span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>,
+					<span class="teams-subteam-leader">George Marques (<a
+							href="https://github.com/vnen">@vnen</a>)</span>,
 					Adam Scott (<a href="https://github.com/adamscott">@adamscott</a>),
 					Danil Alexeev (<a href="https://github.com/dalexeev">@dalexeev</a>),
 					Dmitry Maganov (<a href="https://github.com/vonagam">@vonagam</a>),
@@ -228,7 +231,8 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
+			<span class="teams-subteam-leader">Rémi Verschelde (<a
+					href="https://github.com/akien-mga">@akien-mga</a>)</span>,
 			Aaron Franke (<a href="https://github.com/aaronfranke">@aaronfranke</a>),
 			Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
 			HP van Braam (<a href="https://github.com/hpvb">@hpvb</a>),
@@ -250,8 +254,10 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>,
-			<span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>
+			<span class="teams-subteam-leader">Pāvels Nadtočajevs (<a
+					href="https://github.com/bruvzg">@bruvzg</a>)</span>,
+			<span class="teams-subteam-leader">Rémi Verschelde (<a
+					href="https://github.com/akien-mga">@akien-mga</a>)</span>
 		</p>
 
 		<table class="teams-subteams">
@@ -274,8 +280,7 @@ current_tab: "teams"
 				<th class="teams-subteam-name">iOS</th>
 				<td class="teams-subteam-members">
 					<span class="teams-subteam-leader">Pāvels Nadtočajevs (<a
-							href="https://github.com/bruvzg">@bruvzg</a>)</span>,
-					Sergey Minakov (<a href="https://github.com/naithar">@naithar</a>)
+							href="https://github.com/bruvzg">@bruvzg</a>)</span>
 				</td>
 			</tr>
 			<tr>
@@ -290,13 +295,15 @@ current_tab: "teams"
 			<tr>
 				<th class="teams-subteam-name">macOS</th>
 				<td class="teams-subteam-members">
-					<span class="teams-subteam-leader">Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)</span>
+					<span class="teams-subteam-leader">Pāvels Nadtočajevs (<a
+							href="https://github.com/bruvzg">@bruvzg</a>)</span>
 				</td>
 			</tr>
 			<tr>
 				<th class="teams-subteam-name">UWP</th>
 				<td class="teams-subteam-members">
-					<span class="teams-subteam-leader">George Marques (<a href="https://github.com/vnen">@vnen</a>)</span>
+					<span class="teams-subteam-leader">George Marques (<a
+							href="https://github.com/vnen">@vnen</a>)</span>
 				</td>
 			</tr>
 			<tr>
@@ -325,7 +332,8 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
+			<span class="teams-subteam-leader">Juan Linietsky (<a
+					href="https://github.com/reduz">@reduz</a>)</span>,
 			K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>),
 			<a href="https://github.com/lyuma">@lyuma</a>,
 			Silc 'Tokage' Renew (<a href="https://github.com/TokageItLab">@TokageItLab</a>),
@@ -355,7 +363,8 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>)</span>,
+			<span class="teams-subteam-leader">Juan Linietsky (<a
+					href="https://github.com/reduz">@reduz</a>)</span>,
 			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
 			Joan Fons Sanchez (<a href="https://github.com/JFonS">@JFonS</a>),
 			K. S. Ernest Lee (<a href="https://github.com/fire">@fire</a>),
@@ -373,7 +382,8 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>)</span>,
+			<span class="teams-subteam-leader">Fabio Alessandrelli (<a
+					href="https://github.com/Faless">@Faless</a>)</span>,
 			Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>)
 		</p>
 	</div>
@@ -386,7 +396,6 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			Andrea Catania (<a href="https://github.com/AndreaCatania">@AndreaCatania</a>),
 			Fabrice Cipolla (<a href="https://github.com/fabriceci">@fabriceci</a>),
 			Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>),
 			<a href="https://github.com/lawnjelly">@lawnjelly</a>,
@@ -404,7 +413,8 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)</span>,
+			<span class="teams-subteam-leader">Clay John (<a
+					href="https://github.com/clayjohn">@clayjohn</a>)</span>,
 			Bastiaan Olij (<a href="https://github.com/BastiaanOlij">@BastiaanOlij</a>),
 			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
 			<a href="https://github.com/lawnjelly">@lawnjelly</a>,
@@ -417,7 +427,8 @@ current_tab: "teams"
 			<tr>
 				<th class="teams-subteam-name">Shaders</th>
 				<td class="teams-subteam-members">
-					<span class="teams-subteam-leader">Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)</span>,
+					<span class="teams-subteam-leader">Yuri Rubinsky (<a
+							href="https://github.com/Chaosus">@Chaosus</a>)</span>,
 					Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>)
 				</td>
 			</tr>
@@ -427,6 +438,7 @@ current_tab: "teams"
 					Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
 					Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
 					Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
+					Patrick Exner (<a href="https://github.com/paddy-exe">@paddy-exe</a>),
 					Yuri Rubinsky (<a href="https://github.com/Chaosus">@Chaosus</a>)
 				</td>
 			</tr>
@@ -450,7 +462,8 @@ current_tab: "teams"
 			<tr>
 				<th class="teams-subteam-name">WebXR</th>
 				<td class="teams-subteam-members">
-					<span class="teams-subteam-leader">David Snopek (<a href="https://github.com/dsnopek">@dsnopek</a>)</span>
+					<span class="teams-subteam-leader">David Snopek (<a
+							href="https://github.com/dsnopek">@dsnopek</a>)</span>
 				</td>
 			</tr>
 		</table>
@@ -479,7 +492,6 @@ current_tab: "teams"
 			Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
 			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
 			Ilaria Cislaghi (<a href="https://github.com/QbieShay">@QbieShay</a>),
-			Raffaele Picca (<a href="https://github.com/RPicster">@RPicster</a>),
 			Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
 			Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
 		</p>
@@ -497,7 +509,8 @@ current_tab: "teams"
 		<p>
 			<span class="teams-subteam-leader">Aaron Franke (<a
 					href="https://github.com/aaronfranke">@aaronfranke</a>)</span>,
-			<span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>
+			<span class="teams-subteam-leader">Hugo Locurcio (<a
+					href="https://github.com/Calinou">@Calinou</a>)</span>
 		</p>
 	</div>
 
@@ -513,7 +526,6 @@ current_tab: "teams"
 		<p>
 			<span class="teams-subteam-leader">Max Hilbrunner (<a
 					href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>,
-			Chris Bradfield (<a href="https://github.com/cbscribe">@cbscribe</a>),
 			Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
 			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
 			Matthew (<a href="https://github.com/skyace65">@skyace65</a>),
@@ -530,13 +542,13 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)</span>,
+			<span class="teams-subteam-leader">Rémi Verschelde (<a
+					href="https://github.com/akien-mga">@akien-mga</a>)</span>,
 			Adam Scott (<a href="https://github.com/adamscott">@adamscott</a>),
 			Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
 			Emilio Coppola (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>),
 			Fredia Huya-Kouadio (<a href="https://github.com/m4gr3d">@m4gr3d</a>),
 			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
-			Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>),
 			Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>),
 			Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
 		</p>
@@ -571,10 +583,11 @@ current_tab: "teams"
 		</p>
 
 		<p>
-			<span class="teams-subteam-leader">Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>)</span>,
-			Max Hilbrunner (<a href="https://github.com/mhilbrunner">@mhilbrunner</a>),
-			Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
-			Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
+			<span class="teams-subteam-leader">Yuri Sizov (<a
+					href="https://github.com/YuriSizov">@YuriSizov</a>)</span>,
+			Emilio Coppola (<a href="https://github.com/coppolaemilio">@coppolaemilio</a>),
+			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
+			Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>)
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
- Removed **EricEzaM, AndreaCatania, naithar, RPicster,** and **cbscribe** from their teams due to inactivity at the moment.
- Added **dsnopek** to the GDExtension team, as the de facto leader too.
- Added **paddy-exe** to the Tech art team.
- Removed **reduz** from the listing for the Production team (he is still a part of it, but not on the day-to-day basis).
- Removed **mhilbrunner** from the Website team and added **coppolaemilio** to it.
- Set _myself_ as the de facto leader of the Website team in place of **Calinou**.

The rest are just formatting changes.