### PR TITLE
Add User Group listing for godot.community

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -346,3 +346,8 @@ United States:
     links:
       - title: Discord
         url: https://discord.gg/MjA6HUzzAE
+Other:
+  - name: Godot Community
+    links:
+      - title: Website
+        url: https://godot.community/


### PR DESCRIPTION
I'm running a small Godot Community website that I would like to be added to the list.
The website is not a physical bound/regional community, but an online based community. The address is https://godot.community

I've already sent (without knowing) an email to the webmaster, however 😃 Yuri on Contributors Chat pointed me out that I could just submit a PR for it.

Unsure where to put it, so I added it down on the list.