### PR TITLE
Use correct logo license link

### DIFF
--- a/pages/press.html
+++ b/pages/press.html
@@ -23,7 +23,7 @@ layout: default
 		from better scaling and lower file sizes.
 	</p>
 	<p>
-		<a href="https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.md">Godot logos are licensed under Creative
+		<a href="https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.txt">Godot logos are licensed under Creative
 			Commons Attribution 4.0 International.</a>
 	</p>
 


### PR DESCRIPTION
the logo license was recently switched from markdown to plain text, but still links to the markdown file on the website