### PR TITLE
Remove QbieShay/Ilaria Cislaghi from conduct and board

### DIFF
--- a/pages/code-of-conduct.html
+++ b/pages/code-of-conduct.html
@@ -113,13 +113,6 @@ current_tab: "code-of-conduct"
 			</ul>
 		</li>
 		<li>
-			Ilaria Cislaghi, ilaria@godotengine.org (she/her)
-			<ul>
-				<li>GitHub / Contributors Chat / Discord / Twitter: <em>QbieShay</em></li>
-				<li>Languages: English, Italian</li>
-			</ul>
-		</li>
-		<li>
 			Julian Murgia, julian@godotengine.org (he/him)
 			<ul>
 				<li>GitHub / Contributors Chat / Discord/ Reddit: <em>StraToN</em> – Twitter: <em>TheStraToN</em></li>

--- a/pages/governance.html
+++ b/pages/governance.html
@@ -40,7 +40,6 @@ current_tab: "governance"
 		<li>Clay John — <em>clay@godotengine.org</em></li>
 		<li>George Marques — <em>george@godotengine.org</em></li>
 		<li>HP van Braam — <em>hp@godotengine.org</em></li>
-		<li>Ilaria Cislaghi — <em>ilaria@godotengine.org</em></li>
 		<li>Juan Linietsky — <em>juan@godotengine.org</em></li>
 		<li>Julian Murgia — <em>julian@godotengine.org</em></li>
 		<li>Rémi Verschelde — <em>remi@godotengine.org</em></li>


### PR DESCRIPTION
Being a part of the board and the conduct team has been a really great experience and i'm glad i got to contribute to godot with my time.
When I joined these groups, I didn't feel like my coding skills were enough to contribute meaningfully to the engine, and growing them would have costed me a lot of effort. In reality, I didn't realize yet at the time that coding was not something I enjoyed enough to spend the time reading lengthy documentation pages, research papers, and guides.
I decided, at the time, that offering my time and effort for moderation, event organization and bureaucracy was a better way to contribute than my code.
Fast forward to today, things have changed. I have moved to a VFX artist carreer, which i love, and I have pivoted my contribution back to coding and advocacy for artists. I love making sparkles and swooshies and shiny things, and I am glad i got to [enable more artists to do it](https://godotengine.org/article/progress-report-state-of-particles/).

I step down from the board and conduct not with sadness, failure or regret, but with love and excitement for what comes next.
I plan to continue my involvement in Godot by focusing on particles, shaders, vfx and tech art. See you around!

And for the rest of the board and conduct team, with whom i worked so far: love y'all <3 I know you'll do great 