### PR TITLE
Add GodotCon 2023 banner

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,20 @@
 <input type="checkbox" id="nav_toggle_cb">
 <header>
+	<a href="https://conference.godotengine.org/" style="
+		position: absolute;
+		top: 2.65rem;
+		right: -3.65rem;
+		transform: rotateZ(45deg);
+		z-index: 9999;
+		padding: 0.5rem 3.5rem;
+		background-color: #f36a7f;
+		box-shadow: 0 2px 2px hsla(0, 0%, 0%, 0.3);
+		color: black;
+		text-decoration: none;
+		font-weight: 700;
+	">
+		GodotCon 2023!
+	</a>
 	<div class="container flex align-center">
 		<div id="nav_head">
 			<a href="/" id="logo-link">


### PR DESCRIPTION
This reuses the design from https://github.com/godotengine/godot-website/pull/316.

## Preview

![Screenshot 2023-11-03 at 08-21-07 Godot Engine - Free and open source 2D and 3D game engine](https://github.com/godotengine/godot-website/assets/180032/064f4e07-2b1a-4a4f-8236-b38f8860d57c)

In the future, we should investigate a design that's more easily seen on wide displays (example on a 4K display at 100% scale):

![Screenshot 2023-11-03 at 08-16-59 Godot Engine - Free and open source 2D and 3D game engine](https://github.com/godotengine/godot-website/assets/180032/b313e115-e735-426e-bae4-43b31376ade6)
