### PR TITLE
Add support for download config overrides

### DIFF
--- a/_data/download_configs.yml
+++ b/_data/download_configs.yml
@@ -5,6 +5,8 @@ defaults:
       android.apk: android_editor.apk
       linux.64: linux.x86_64.zip
       linux.32: linux.x86_32.zip
+      linux.arm64: linux.arm64.zip
+      linux.arm32: linux.arm32.zip
       macos.universal: macos.universal.zip
       windows.64: win64.exe.zip
       windows.32: win32.exe.zip
@@ -17,6 +19,8 @@ defaults:
       editor:
         linux.64: mono_linux_x86_64.zip
         linux.32: mono_linux_x86_32.zip
+        linux.arm64: mono_linux_arm64.zip
+        linux.arm32: mono_linux_arm32.zip
         macos.universal: mono_macos.universal.zip
         windows.64: mono_win64.zip
         windows.32: mono_win32.zip
@@ -68,3 +72,49 @@ defaults:
       windows.64: win64.exe.zip
       windows.32: win32.exe.zip
       linux_server.64: linux_server.64.zip
+
+overrides:
+  # Mono version of Godot 4 was only introduced in 4.0 alpha 17.
+  - version: 4
+    range:
+      - "4.0-alpha1"
+      - "4.0-alpha16"
+    config:
+      templates: export_templates.tpz
+      editor:
+        android.apk: android_editor.apk
+        linux.64: linux.x86_64.zip
+        linux.32: linux.x86_32.zip
+        macos.universal: macos.universal.zip
+        windows.64: win64.exe.zip
+        windows.32: win32.exe.zip
+        web: web_editor.zip
+      extras:
+        aar_library: template_release.aar
+
+  # Godot 4.2 beta 5 introduced Linux ARM builds.
+  - version: 4
+    range:
+      - "4.0-alpha17"
+      - "4.2-beta4"
+    config:
+      templates: export_templates.tpz
+      editor:
+        android.apk: android_editor.apk
+        linux.64: linux.x86_64.zip
+        linux.32: linux.x86_32.zip
+        macos.universal: macos.universal.zip
+        windows.64: win64.exe.zip
+        windows.32: win32.exe.zip
+        web: web_editor.zip
+      extras:
+        aar_library: template_release.aar
+
+      mono:
+        templates: mono_export_templates.tpz
+        editor:
+          linux.64: mono_linux_x86_64.zip
+          linux.32: mono_linux_x86_32.zip
+          macos.universal: mono_macos.universal.zip
+          windows.64: mono_win64.zip
+          windows.32: mono_win32.zip

--- a/_data/download_platforms.yml
+++ b/_data/download_platforms.yml
@@ -40,6 +40,20 @@
   tags:
     - 64 bit
 
+- name: "linux.arm32"
+  title: "Linux"
+  caption: "Standard (ARM32)"
+  tags:
+    - ARM32
+    - 32 bit
+
+- name: "linux.arm64"
+  title: "Linux"
+  caption: "Standard (ARM64)"
+  tags:
+    - ARM64
+    - 64 bit
+
 - name: "linux_server.64"
   title: "Linux Server"
   caption: "Standard (x86_64)"


### PR DESCRIPTION
- Add Linux ARM builds for 4.2 beta5 and later
- Add an override for previous releases to remove Linux ARM builds.
- Add an override for early 4.0 alphas to remove non-existent .NET builds.

Overrides operate on inclusive version ranges. You can see how it looks in the modified YAML file. The first match config is going to be used, so order matters. This can be important if we introduce and remove something in a number of releases inside another range.

When testing I've checked that the download block in articles is unaffected, and so are download pages. Expected changes are:
- `/download/archive/4.2-beta5/` shows Linux ARM builds.
- `/download/archive/4.1.3-stable/` doesn't show Linux ARM builds.
- `/download/archive/4.0-alpha17/` shows the same as 4.1.3 stable and all other intermediate releases.
- `/download/archive/4.0-alpha16/` doesn't show C#/.NET builds.

To match versions to ranges I use a simple hashing mechanism which turns version name (e.g. "4.1.3") and version flavor (e.g. "alpha17") into integer values. These are easy to compare.