### PR TITLE
Update docs team members

### DIFF
--- a/pages/teams.html
+++ b/pages/teams.html
@@ -479,8 +479,7 @@ current_tab: "teams"
 
 	<p>
 		The following teams do not impact the engine code directly, but take care of all other important parts of the Godot
-		ecosystem such
-		as the documentation, demos, website, etc.
+		ecosystem such as the documentation, demos, website, etc.
 	</p>
 
 	<div class="teams-team-section">
@@ -532,9 +531,12 @@ current_tab: "teams"
 		<p>
 			<span class="teams-subteam-leader">Max Hilbrunner (<a
 					href="https://github.com/mhilbrunner">@mhilbrunner</a>)</span>,
+			A Thousand Ships (<a href="https://github.com/AThousandShips">@AThousandShips</a>),
 			Clay John (<a href="https://github.com/clayjohn">@clayjohn</a>),
+			Hana - Piralein (<a href="https://github.com/Piralein">@Piralein</a>),
 			Hugo Locurcio (<a href="https://github.com/Calinou">@Calinou</a>),
 			Matthew (<a href="https://github.com/skyace65">@skyace65</a>),
+			Raul Santos (<a href="https://github.com/raulsntos">@raulsntos</a>),
 			Rémi Verschelde (<a href="https://github.com/akien-mga">@akien-mga</a>),
 			Yuri Sizov (<a href="https://github.com/YuriSizov">@YuriSizov</a>)
 		</p>


### PR DESCRIPTION
Adds @AThousandShips, @Piralein and @raulsntos to the listed docs team members and removes a unncessary linebreak in the section description.