### PR TITLE
Add Godot Québec Discord to usergroups

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -49,6 +49,10 @@ Canada:
     links:
       - title: MeetUp
         url: https://www.meetup.com/Godot-Toronto/
+  - name: Godot Québec
+    links:
+      - title: Discord
+        url: https://discord.gg/AemZhPjqyM
 China:
   - name: Godot China
     links:


### PR DESCRIPTION
This is a new Discord usergroup destined to Québec Godot gamedevs and users.

![godot-québec-4-export](https://github.com/godotengine/godot-website/assets/270928/01f6ff87-3ed5-4faa-a44a-f472fb23f0b9)
