### PR TITLE
Update C# platform support notice for Godot 4.2

### DIFF
--- a/pages/features.html
+++ b/pages/features.html
@@ -493,7 +493,10 @@ layout: default
 				for the .NET platform. Power your game with familiar libraries and give
 				them performance boost, while still benefiting from close engine integration.
 				<br><br>
-				<strong>Note:</strong> .NET support is provided as a dedicated engine executable. C# support is currently only available for desktop platforms in Godot 4. Use <a href="/download/3.x/">Godot 3</a> to run C# on Android, iOS and Web.
+				<strong>Note:</strong> .NET support is provided as a dedicated engine executable.
+				<a href="https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html#c-platform-support">C# support is available for desktop and mobile platforms as of Godot 4.2.</a>
+				Web support should be added in the future, but until then,
+				<a href="/download/3.x/">Godot 3</a> remains a supported option.
 			</p>
 		</div>
 

--- a/pages/home.html
+++ b/pages/home.html
@@ -267,8 +267,8 @@ layout: default
 						Keep your code modular with an object-oriented API using Godot's own
 						GDScript, C#, C++, or bring your own using GDExtension.
 						<div style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.6; opacity: 0.8">
-							C# support is currently only available for desktop platforms in Godot 4.
-							Use Godot 3 to run C# on Android, iOS and Web.
+							C# support is currently only available for desktop and mobile platforms
+							as of Godot 4.2.<br>Use Godot 3 to run C# on the Web platform.
 						</div>
 					</p>
 				</div>


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-website/pull/671.

Exporting C# projects to Android and iOS is now possible in Godot 4.2.

**Marked as draft**, as this should only be merged after Godot 4.2.stable is released.