### PR TITLE
Rename "LTS" to "3.x LTS"

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -49,7 +49,7 @@ layout: default
 			{% endfor %}
 
 			<p class="previous-releases">
-				<strong class="previous-releases-featured">For the LTS version, <a href="/download/3.x/windows" class="set-os-download-url" data-version="3">Download Godot 3</a>.</strong>
+				<strong class="previous-releases-featured">For the 3.x LTS version, <a href="/download/3.x/windows" class="set-os-download-url" data-version="3">Download Godot 3</a>.</strong>
 				<br>
 				You can find previous releases in the <a href="/download/archive">download archive</a>.
 			</p>

--- a/pages/download/preview.html
+++ b/pages/download/preview.html
@@ -141,7 +141,7 @@ layout: default
 		<p>Want to stick to the <strong>true and trusted Godot 3</strong>? Download the long-term support version!</p>
 		<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="3"
 			title="Download the long-term support version of Godot 3">
-			<div class="download-title">Download LTS</div>
+			<div class="download-title">Download 3.x LTS</div>
 			<div class="download-hint">{{ stable_version_3.name }}</div>
 		</a>
 	</div>

--- a/pages/features.html
+++ b/pages/features.html
@@ -695,7 +695,7 @@ layout: default
 		<p>Want to stick to the <strong>true and trusted Godot 3</strong>? Download the long-term support version!</p>
 		<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="3"
 			title="Download the long-term support version of Godot 3">
-			<div class="download-title">Download LTS</div>
+			<div class="download-title">Download 3.x LTS</div>
 			<div class="download-hint">{{ stable_version_3.name }}</div>
 		</a>
 	</div>

--- a/pages/home.html
+++ b/pages/home.html
@@ -184,7 +184,7 @@ layout: default
 
 					<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="3"
 						title="Download the long-term support version of Godot 3">
-						<div class="download-title">Download LTS</div>
+						<div class="download-title">Download 3.x LTS</div>
 						<div class="download-hint">{{ stable_version_3.name }}</div>
 					</a>
 				</div>


### PR DESCRIPTION
This PR renames "LTS" to "3.x LTS" as there's no such concept of LTS right now for Godot. 4.2 is the most stable 4.x release up-to-date and we should encourage people to use the 4.x branch instead of the aging 3.x one.

Hopefully, with this PR, we still say that our 3.x is well supported, but that the LTS term doens't implicate that 4.x isn't like long-term supported.

![image](https://github.com/godotengine/godot-website/assets/270928/e9bc8cd3-e6f4-426f-be53-7b06c4506d67)
