### PR TITLE
Rename LTS to 3.x

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -49,7 +49,7 @@ layout: default
 			{% endfor %}
 
 			<p class="previous-releases">
-				<strong class="previous-releases-featured">For the LTS version, <a href="/download/3.x/windows" class="set-os-download-url" data-version="3">Download Godot 3</a>.</strong>
+				<strong class="previous-releases-featured">For the 3.x version, <a href="/download/3.x/windows" class="set-os-download-url" data-version="3">Download Godot 3</a>.</strong>
 				<br>
 				You can find previous releases in the <a href="/download/archive">download archive</a>.
 			</p>

--- a/pages/download/preview.html
+++ b/pages/download/preview.html
@@ -138,10 +138,10 @@ layout: default
 			<div class="download-hint">{{ stable_version_4.name }}</div>
 		</a>
 
-		<p>Want to stick to the <strong>true and trusted Godot 3</strong>? Download the long-term support version!</p>
+		<p>Want to stick to the <strong>true and trusted Godot 3</strong>? Download the latest 3.x version!</p>
 		<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="3"
-			title="Download the long-term support version of Godot 3">
-			<div class="download-title">Download LTS</div>
+			title="Download the latest version of Godot 3">
+			<div class="download-title">Download 3.x</div>
 			<div class="download-hint">{{ stable_version_3.name }}</div>
 		</a>
 	</div>

--- a/pages/features.html
+++ b/pages/features.html
@@ -692,10 +692,10 @@ layout: default
 			<div class="download-hint">{{ stable_version_4.name }}</div>
 		</a>
 
-		<p>Want to stick to the <strong>true and trusted Godot 3</strong>? Download the long-term support version!</p>
+		<p>Want to stick to the <strong>true and trusted Godot 3</strong>? Download the latest 3.x version!</p>
 		<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="3"
-			title="Download the long-term support version of Godot 3">
-			<div class="download-title">Download LTS</div>
+			title="Download the latest version of Godot 3">
+			<div class="download-title">Download 3.x</div>
 			<div class="download-hint">{{ stable_version_3.name }}</div>
 		</a>
 	</div>

--- a/pages/home.html
+++ b/pages/home.html
@@ -183,8 +183,8 @@ layout: default
 					</a>
 
 					<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="3"
-						title="Download the long-term support version of Godot 3">
-						<div class="download-title">Download LTS</div>
+						title="Download the latest version of Godot 3">
+						<div class="download-title">Download 3.x</div>
 						<div class="download-hint">{{ stable_version_3.name }}</div>
 					</a>
 				</div>


### PR DESCRIPTION
**_Supersedes #768_**

This PR renames "LTS" to "3.x" as there's no such concept of LTS right now for Godot. 4.2 is the most stable 4.x release up-to-date and we should encourage people to use the 4.x branch instead of the aging 3.x one.

We named 3.5 LTS as a way to signal that we still intended to support Godot 3.x, but LTS has a different meaning. People expect, with LTS, that the 3.5 branch will still be supported with security patches and such. But with the upcoming release of 3.6, it doesn't make sense to say that the LTS version is binded to either "3.x" or "3.6".

Hopefully, with this PR, we still say that our 3.x is well supported, but that the LTS term doesn't implicate that 4.x isn't long-term supported.

![image](https://github.com/godotengine/godot-website/assets/270928/d0c81891-01c7-4b04-b456-3d01115d3b70)
