### PR TITLE
Fix broken Troubleshooting docs URL on download pages

### DIFF
--- a/collections/_download/android.md
+++ b/collections/_download/android.md
@@ -26,7 +26,7 @@ content_note: |
 
 content_instructions: |
   <ul>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 
   <p>

--- a/collections/_download/linux.md
+++ b/collections/_download/linux.md
@@ -23,6 +23,6 @@ redirect_from:
 content_instructions: |
   <ul>
     <li>Extract and run. Godot is self-contained and does not require installation.</li>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 ---

--- a/collections/_download/macos.md
+++ b/collections/_download/macos.md
@@ -19,7 +19,7 @@ redirect_from:
 content_instructions: |
   <ul>
     <li>Extract and run. Godot is self-contained and does not require installation.</li>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 
   <p>

--- a/collections/_download/windows.md
+++ b/collections/_download/windows.md
@@ -30,7 +30,7 @@ content_note: |
 content_instructions: |
   <ul>
     <li>Extract and run. Godot is self-contained and does not require installation.</li>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 
   <p>

--- a/collections/_download_3/android.md
+++ b/collections/_download_3/android.md
@@ -23,7 +23,7 @@ content_note: |
 
 content_instructions: |
   <ul>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 
   <p>

--- a/collections/_download_3/linux.md
+++ b/collections/_download_3/linux.md
@@ -20,6 +20,6 @@ downloads:
 content_instructions: |
   <ul>
     <li>Extract and run. Godot is self-contained and does not require installation.</li>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 ---

--- a/collections/_download_3/macos.md
+++ b/collections/_download_3/macos.md
@@ -15,7 +15,7 @@ downloads:
 content_instructions: |
   <ul>
     <li>Extract and run. Godot is self-contained and does not require installation.</li>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 
   <p>

--- a/collections/_download_3/server.md
+++ b/collections/_download_3/server.md
@@ -23,7 +23,7 @@ redirect_from:
 content_instructions: |
   <ul>
     <li>Extract and run. Godot is self-contained and does not require installation.</li>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
 
     <li>The <strong>headless</strong> build includes the editor tool functionality that enables it to run tests and export projects in an automated manner.</li>
     <li>The <strong>standard</strong> build is optimized to run dedicated game servers and does not include editor tools, graphics or audio support.</li>

--- a/collections/_download_3/windows.md
+++ b/collections/_download_3/windows.md
@@ -27,7 +27,7 @@ content_note: |
 content_instructions: |
   <ul>
     <li>Extract and run. Godot is self-contained and does not require installation.</li>
-    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/about/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
+    <li>If you run into an issue, check the <a href="https://docs.godotengine.org/en/stable/tutorials/troubleshooting.html">Troubleshooting</a> page for common issues and their solutions.</li>
   </ul>
 
   <p>


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-website/issues/773.
