### PR TITLE
Sync Maintenance links to Community page

### DIFF
--- a/pages/maintenance.html
+++ b/pages/maintenance.html
@@ -20,19 +20,28 @@ permalink: /maintenance/index.html
 		<li><a href="https://downloads.tuxfamily.org/godotengine">Download Godot from TuxFamily</a></li>
 	</ul>
 
+	<h2>Documentation</h2>
+	<ul>
+		<li><a href="https://docs.godotengine.org/">Online Documentation</a></li>
+	</ul>
+
 	<h2>Community</h2>
 	<ul>
-		<li><a href="https://forum.godotengine.org/">Forum</a></li>
+		<li><a href="https://forum.godotengine.org/">Godot Forum</a></li>
 		<li><a href="https://discord.gg/4JBkykG">Discord</a></li>
-		<li><a href="https://web.libera.chat/#godotengine">IRC</a></li>
-		<li><a href="https://matrix.to/#/#godotengine:matrix.org">Matrix</a></li>
-		<li><a href="https://www.facebook.com/groups/godotengine/">Facebook</a></li>
 		<li><a href="https://reddit.com/r/godot/">Reddit</a></li>
-		<li><a href="https://github.com/godotengine/godot">GitHub</a></li>
+		<li><a href="https://www.facebook.com/groups/godotengine/">Facebook</a></li>
 		<li><a href="https://twitter.com/godotengine">Twitter</a></li>
-		<li><a href="https://godotforums.org/">Unofficial Forum</a></li>
-		<li><a href="https://steamcommunity.com/app/404790">Steam Community</a></li>
+		<li><a href="https://mastodon.gamedev.place/@godotengine/">Mastodon</a></li>
 		<li><a href="https://www.youtube.com/c/GodotEngineOfficial">YouTube</a></li>
+		<li><a href="https://godotforums.org/">Community Forum</a></li>
+		<li><a href="https://matrix.to/#/#godotengine:matrix.org">Matrix</a></li>
+	</ul>
+
+	<h2>Contributing</h2>
+	<ul>
+		<li><a href="https://github.com/godotengine/godot">GitHub</a></li>
+		<li><a href="https://chat.godotengine.org/">Godot Contributors Chat</a></li>
 	</ul>
 
 </body>

--- a/pages/maintenance.html
+++ b/pages/maintenance.html
@@ -22,7 +22,7 @@ permalink: /maintenance/index.html
 
 	<h2>Community</h2>
 	<ul>
-		<li><a href="https://ask.godotengine.org/">Questions &amp; Answers</a></li>
+		<li><a href="https://forum.godotengine.org/">Forum</a></li>
 		<li><a href="https://discord.gg/4JBkykG">Discord</a></li>
 		<li><a href="https://web.libera.chat/#godotengine">IRC</a></li>
 		<li><a href="https://matrix.to/#/#godotengine:matrix.org">Matrix</a></li>
@@ -30,7 +30,7 @@ permalink: /maintenance/index.html
 		<li><a href="https://reddit.com/r/godot/">Reddit</a></li>
 		<li><a href="https://github.com/godotengine/godot">GitHub</a></li>
 		<li><a href="https://twitter.com/godotengine">Twitter</a></li>
-		<li><a href="https://godotforums.org/">Forum</a></li>
+		<li><a href="https://godotforums.org/">Unofficial Forum</a></li>
 		<li><a href="https://steamcommunity.com/app/404790">Steam Community</a></li>
 		<li><a href="https://www.youtube.com/c/GodotEngineOfficial">YouTube</a></li>
 	</ul>


### PR DESCRIPTION
Removed Q&A link and changed it to the new forum link.