### PR TITLE
Add coordinates for Godot {Toronto, Québec}

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -46,10 +46,16 @@ Bulgaria:
         url: https://discord.gg/j3KRdV3b4P
 Canada:
   - name: Godot Toronto
+    coordinates:
+      - 43.65348
+      - -79.38394
     links:
       - title: MeetUp
         url: https://www.meetup.com/Godot-Toronto/
   - name: Godot Québec
+    coordinates:
+      - 45.50318
+      - -73.56981
     links:
       - title: Discord
         url: https://discord.gg/AemZhPjqyM


### PR DESCRIPTION
As Canada is a huge country, I added coordinates for Toronto and Montréal (Québec) for the two Canadian usergroups.

### Before
![image](https://github.com/godotengine/godot-website/assets/270928/4537c299-cf98-4a66-a6ee-7118a70cdc4f)

### After
![image](https://github.com/godotengine/godot-website/assets/270928/052b8b6b-2b04-4ab5-87ce-b4bb4a58f7b7)
