### PR TITLE
Fix recent post highlight date threshold

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -84,7 +84,7 @@
 
 		document.querySelectorAll('[data-post-date]').forEach((postDate) => {
 			// Highlight post dates that are less than 48 hours old.
-			if (Date.parse(postDate.dataset.postDate) > (Date.now() - 1000 * 60 * 60 * 96)) {
+			if (Date.parse(postDate.dataset.postDate) > (Date.now() - 1000 * 60 * 60 * 48)) {
 				postDate.classList.add("post-recent-highlight");
 			};
 		});


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-website/pull/793.

It was actually set to 96 hours for testing.