### PR TITLE
Add jekyll_picture_tag for image conversion and optimization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem 'jekyll-watch'
 gem 'jekyll-paginate-v2'
 gem 'jekyll-multiple-languages-plugin'
 gem 'jekyll-redirect-from'
+gem 'jekyll_picture_tag', '~> 2.0'
 
 gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.5)
-    ffi (1.15.5-x64-unknown)
+    ffi (1.16.3)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jekyll (4.2.2)
       addressable (~> 2.4)
@@ -40,34 +39,48 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    jekyll_picture_tag (2.1.0)
+      addressable (~> 2.6)
+      jekyll (~> 4.0)
+      mime-types (~> 3.0)
+      objective_elements (~> 1.1)
+      rainbow (~> 3.0)
+      ruby-vips (~> 2.0.17)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.7.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0206)
+    objective_elements (1.1.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.1)
+    public_suffix (5.0.4)
+    rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rouge (3.30.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.8.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
 
 PLATFORMS
   arm64-darwin-22
-  x64-unknown
+  arm64-darwin-23
   x64-unknown
   x86_64-linux
 
@@ -77,6 +90,7 @@ DEPENDENCIES
   jekyll-paginate-v2
   jekyll-redirect-from
   jekyll-watch
+  jekyll_picture_tag (~> 2.0)
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ To build the website locally, follow these steps:
    - Make sure `bundle` is available from the command line.
 2. Clone this repository.
 3. Install the necessary dependencies: `bundle install`.
-4. Build the site: `bundle exec jekyll build`.
+4. Install the `libvips` dependency necessary for [jekyll_picture_tag](https://rbuchberger.github.io/jekyll_picture_tag/users/installation.html).
+5. Build the site: `bundle exec jekyll build`.
    - Append `--config _config.yml,_config.development.yml` to use the development config with your build.
 
 For simplicity, these two commands are also available as a `build.sh` script in this repository.

--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,7 @@ plugins:
   - jekyll-paginate-v2
   - jekyll-redirect-from
   # - jekyll-multiple-languages-plugin
+  - jekyll_picture_tag
 
 # Internationalization
 languages: ["en", "es"]
@@ -91,3 +92,6 @@ pagination:
   category: "posts"
   tag: ""
   locale: ""
+
+picture:
+  suppress_warnings: true

--- a/_config.yml
+++ b/_config.yml
@@ -95,3 +95,4 @@ pagination:
 
 picture:
   suppress_warnings: true
+  disabled: development

--- a/_data/picture.yaml
+++ b/_data/picture.yaml
@@ -1,0 +1,251 @@
+media_queries:
+  showcase-showreel-thumbnail-sm: 'max-width: 711px'
+  showcase-showreel-thumbnail-md: 'max-width: 1027px'
+  showcase-showreel-thumbnail-lg: 'min-width: 1028px'
+  showcase-thumbnail-sm: 'max-width: 763px'
+  showcase-thumbnail-md: 'max-width: 978px'
+  showcase-thumbnail-lg: 'min-width: 979px'
+  showcase-thumbnail-details-sm: 'max-width: 900px'
+  showcase-thumbnail-details-lg: 'min-width: 901px'
+  showcase-carousel-md: 'max-width: 766px'
+  showcase-carousel-lg: 'min-width: 767px'
+  showcase-carousel-frame-md: 'max-width: 803px'
+  showcase-carousel-frame-lg: 'min-width: 804px'
+  latest-news-header-sm: 'max-width: 900px'
+  latest-news-header-md: 'max-width: 1246px'
+  latest-news-header-lg: 'min-width: 1247px'
+  latest-news-md: 'max-width: 767px'
+  latest-news-lg: 'min-width: 768px'
+  home-feature-sm: 'max-width: 900px'
+  home-feature-md: 'max-width: 1250px'
+  home-feature-lg: 'min-width: 1251px'
+  blog-thumbnail-sm: 'max-width: 767px'
+  blog-thumbnail-md: 'max-width: 1023px'
+  blog-thumbnail-lg: 'min-width: 1024px'
+  blog-article-header-sm: 'max-width: 900px'
+  blog-article-header-md: 'max-width: 1250px'
+  blog-article-header-lg: 'min-width: 1251px'
+  article-card-download-md: 'max-width: 768px'
+  article-card-download-lg: 'min-width: 769px'
+
+
+presets:
+  default:
+    formats: []
+    widths: []
+    fallback_width: 0
+
+  featured-hero-home:
+    markup: direct_url
+    fallback_width: 1920
+    fallback_format: webp
+    format_quality:
+      webp: 80
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+
+  featured-hero-download:
+    markup: direct_url
+    fallback_width: 1920
+    fallback_format: webp
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+
+  showcase-showreel-thumbnail:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      showcase-showreel-thumbnail-sm: 100vw
+      showcase-showreel-thumbnail-md: calc((100vw - 64px) / 2)
+      showcase-showreel-thumbnail-lg: calc((1200px - 32px) / 3)
+
+  showcase-thumbnail:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      showcase-thumbnail-sm: calc(100vw - 32px)
+      showcase-thumbnail-md: calc((100vw - 32px - 16px) / 2)
+      showcase-thumbnail-lg: calc(calc(min(1200px, calc(100vw - 32px)) - 32px) / 3)
+
+  showcase-thumbnail-details:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      showcase-thumbnail-details-sm: calc(100vw - 32px)
+      showcase-thumbnail-details-lg: calc(min(1200px, calc(100vw - 32px)) - 748px)
+
+  lightbox-expanded-thumbnail:
+    markup: direct_url
+    fallback_width: 1920
+    fallback_format: webp
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+
+  showcase-carousel:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      showcase-carousel-md: calc(100vw - 32px)
+      showcase-carousel-lg: 720px
+
+  showcase-carousel-frame:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      showcase-carousel-frame-md: calc(100vw + 413px) # 413px is how much the image overflows on the sides
+      showcase-carousel-frame-lg: 1224px
+
+  latest-news-header:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      latest-news-header-sm: calc(100vw - 16px)
+      latest-news-header-md: calc((100vw - 62px) / 2)
+      latest-news-header-lg: 585px
+
+  latest-news:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 80, 96, 128, 170, 200, 240 ]
+    fallback_width: 80
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      latest-news-md: 80px
+      latest-news-lg: 160px
+
+  home-feature:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      home-feature-sm: calc(100vw - 16px)
+      home-feature-md: calc((min(1200px, calc(100vw - 32px)) - 40px) / 3)
+      home-feature-lg: calc((min(1200px, calc(100vw - 32px)) - 40px) / 3)
+
+  blog-thumbnail:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      blog-thumbnail-sm: calc(100vw - 32px)
+      blog-thumbnail-md: calc((100vw - 32px - 30px) / 2)
+      blog-thumbnail-lg: calc(calc(min(1200px, calc(100vw - 32px)) - 60px) / 3)
+
+  blog-article-header:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      blog-article-header-sm: calc(100vw - 32px)
+      blog-article-header-md: calc(70vw - 32px)
+      blog-article-header-lg: 840px
+
+  article-card-download:
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
+    sizes:
+      article-card-download-md: calc(100vw - 64)
+      article-card-download-lg: 311px

--- a/_data/picture.yaml
+++ b/_data/picture.yaml
@@ -113,7 +113,7 @@ presets:
     dimension_attributes: true
     sizes:
       showcase-thumbnail-details-sm: calc(100vw - 32px)
-      showcase-thumbnail-details-lg: calc(min(1200px, calc(100vw - 32px)) - 748px)
+      showcase-thumbnail-details-lg: calc(min(600px, calc(50vw - 32px)))
 
   lightbox-expanded-thumbnail:
     markup: direct_url

--- a/_data/picture.yaml
+++ b/_data/picture.yaml
@@ -31,9 +31,17 @@ media_queries:
 
 presets:
   default:
-    formats: []
-    widths: []
-    fallback_width: 0
+    formats: [ webp ]
+    fallback_format: webp
+    widths: [ 640, 768, 1024, 1366, 1600, 1920 ]
+    fallback_width: 640
+    format_quality:
+      webp: 85
+    image_options:
+      webp:
+        smart_subsample: true
+        effort: 6
+    dimension_attributes: true
 
   featured-hero-home:
     markup: direct_url

--- a/_includes/articles/download_card.html
+++ b/_includes/articles/download_card.html
@@ -12,7 +12,7 @@
 
 	<div class="card-download-details">
 		{% unless release_article == empty %}
-			<img class="lightbox-ignore" src="{{ release_article.image }}" />
+			{% picture article-card-download {{ release_article.image }} alt="" class="lightbox-ignore" loading="lazy" %}
 		{% endunless %}
 
 		<div class="card-download-platforms">

--- a/_includes/events/events-list.html
+++ b/_includes/events/events-list.html
@@ -72,7 +72,11 @@
 				<h3>{{ event.name }}</h3>
 
 				{% unless event.cover_image == empty %}
-					<img src="{{ event.cover_image }}" alt="{{ event.name }} event banner">
+					{% if forloop.index == 1 %}
+						<img src="{{ event.cover_image }}" alt="{{ event.name }} event banner">
+					{% else %}
+						<img src="{{ event.cover_image }}" alt="{{ event.name }} event banner" loading="lazy">
+					{% endif%}
 				{% endunless %}
 
 				{{ event.content }}

--- a/_includes/showreel-shelf.html
+++ b/_includes/showreel-shelf.html
@@ -1,35 +1,43 @@
 <style>
-	.showreel-video img {
-		max-width: 100%;
-		background-color: var(--card-background-color);
-		box-shadow: 0 5px 10px -3px #00000078;
-		border-radius: 7px;
-		display: block;
+	.showreel-video {
+		aspect-ratio: 16/9;
+
+		img {
+			display: block;
+			width: 100%;
+			background-color: var(--card-background-color);
+			box-shadow: 0 5px 10px -3px #00000078;
+			border-radius: 7px;
+		}
 	}
 </style>
 
 <section class="flex grid" style="grid-template-columns: repeat(auto-fill, minmax(300px, 1fr))">
-	<article>
-		<div class="showreel-video">
-			<a href="https://www.youtube.com/watch?v=UAS_pUTFA7o" target="_blank">
-				<img src="/assets/showcase/desktop-showcase.jpg" alt="Showreel: 2022 Godot Desktop Games">
-			</a>
-		</div>
-	</article>
-
-	<article>
-		<div class="showreel-video">
-			<a href="https://www.youtube.com/watch?v=xF3QiQfQxeQ" target="_blank">
-				<img src="/assets/showcase/mobile-showcase.jpg" alt="Showreel: 2022 Godot Mobile Games">
-			</a>
-		</div>
-	</article>
-
-	<article>
-		<div class="showreel-video">
-			<a href="https://www.youtube.com/watch?v=9kKp0oguzr8" target="_blank">
-				<img src="/assets/showcase/apps-showcase.jpg" alt="Showreel: 2022 Godot Apps &amp; Tools">
-			</a>
-		</div>
-	</article>
+	<a href="https://www.youtube.com/watch?v=UAS_pUTFA7o" target="_blank">
+		<article class="showreel-video">
+			{% if include.lazyload %}
+				{% picture showcase-showreel-thumbnail assets/showcase/desktop-showcase.jpg alt="Showreel: 2022 Godot Desktop Games" loading="lazy" %}
+			{% else %}
+				{% picture showcase-showreel-thumbnail assets/showcase/desktop-showcase.jpg alt="Showreel: 2022 Godot Desktop Games" %}
+			{% endif %}
+		</article>
+	</a>
+	<a href="https://www.youtube.com/watch?v=xF3QiQfQxeQ" target="_blank">
+		<article class="showreel-video">
+			{% if include.lazyload %}
+				{% picture showcase-showreel-thumbnail assets/showcase/mobile-showcase.jpg alt="Showreel: 2022 Godot Mobile Games" loading="lazy" %}
+			{% else %}
+				{% picture showcase-showreel-thumbnail assets/showcase/mobile-showcase.jpg alt="Showreel: 2022 Godot Mobile Games" %}
+			{% endif %}
+		</article>
+	</a>
+	<a href="https://www.youtube.com/watch?v=9kKp0oguzr8" target="_blank">
+		<article class="showreel-video">
+			{% if include.lazyload %}
+				{% picture showcase-showreel-thumbnail assets/showcase/apps-showcase.jpg alt="Showreel: 2022 Godot Apps &amp; Tools" loading="lazy" %}
+			{% else %}
+				{% picture showcase-showreel-thumbnail assets/showcase/apps-showcase.jpg alt="Showreel: 2022 Godot Apps &amp; Tools" %}
+			{% endif %}
+		</article>
+	</a>
 </section>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -169,9 +169,16 @@ layout: default
 				</figcaption>
 				{% endif %}
 
-				<img src="{{ page.image }}" title="{{ page.image_caption_title }}"
-					alt="{{ page.image_caption_title }} {{ page.image_caption_description }}" class="rounded-lg"
-					style="width: 100%; height: auto; background-color: transparent;" />
+				{%
+					picture
+					blog-article-header
+					{{ page.image }}
+					id="article-cover-img"
+					title="{{ page.image_caption_title }}"
+					alt="{{ page.image_caption_title }} {{ page.image_caption_description }}"
+					class="rounded-lg"
+					style="background-color: transparent;"
+				%}
 			</figure>
 
 			<div class="article-info">
@@ -214,22 +221,26 @@ layout: default
 <link rel="stylesheet" href="/assets/css/article-cards.css?2">
 <script src="/assets/js/anchor-link.js"></script>
 <script>
+	function addLightboxToImage(el, href) {
+		const lightbox = document.createElement('a');
+		lightbox.href = href;
+		lightbox.classList.add('lightbox');
+		lightbox.dataset.group = 'article';
+		el.parentNode.appendChild(lightbox);
+		lightbox.appendChild(el);
+	}
+
 	document.addEventListener('DOMContentLoaded', () => {
 		// Add icons to easily copy section links.
 		window.applyAnchorLinks('.article-body');
 
-		// Add lightbox elements in blog articles for Tobii.
-		document.querySelectorAll('.article-cover img, .article-body img').forEach((articleImg) => {
-			if (articleImg.classList.contains('lightbox-ignore')) {
-				return;
-			}
+		const articleCoverImgHref = '{% picture lightbox-expanded-thumbnail {{ page.image }} %}';
+		const articleCoverImg = document.getElementById('article-cover-img');
+		addLightboxToImage(articleCoverImg, articleCoverImgHref);
 
-			const lightbox = document.createElement('a');
-			lightbox.href = articleImg.src;
-			lightbox.classList.add('lightbox');
-			lightbox.dataset.group = 'article';
-			articleImg.parentNode.appendChild(lightbox);
-			lightbox.appendChild(articleImg);
+		// Add lightbox elements in blog articles for Tobii.
+		document.querySelectorAll('.article-body img:not(.lightbox-ignore)').forEach((articleImg) => {
+			addLightboxToImage(articleImg, articleImg.src);
 		});
 	});
 </script>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -33,7 +33,7 @@ collection: article
 		gap: 30px;
 		padding: 20px 0 39px;
 	}
-	.head .main > :last-child,  
+	.head .main > :last-child,
 	.head .main > :first-child {
 		margin: 0;
 	}
@@ -58,7 +58,6 @@ collection: article
 	}
 
 	.tags h3 {
-		margin-top: 1rem;
 		display: inline-block;
 		margin: 0;
 		font-size: 19px;
@@ -128,7 +127,7 @@ collection: article
 		{% for post in paginator.posts %}
 		<a href="{{ post.url }}" style="text-decoration: none">
 			<article class="article-card">
-				<div class="thumbnail" style="background-image: url('{{ post.image }}');" href="{{ post.url }}"></div>
+				{% picture blog-thumbnail {{ post.image }} class="thumbnail" alt="" loading="lazy" href="{{ post.url }}"%}
 				<div class="content">
 					<div class="info">
 						{% assign post_author = site.data.authors | find: "name", post.author %}

--- a/_layouts/download-3.html
+++ b/_layouts/download-3.html
@@ -16,6 +16,9 @@ layout: default
 			grid-template-columns: 1fr;
 		}
 	}
+	.hero {
+		background-image: url('{% picture featured-hero-download "assets/download/download-background.jpg" %}');
+	}
 </style>
 
 {% assign stable_version = site.data.versions | find: "featured", "3" %}

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -9,7 +9,7 @@ layout: default
 <link rel="stylesheet" href="/assets/css/download.css?2">
 <style>
 	.hero {
-		background-image: url('/assets/download/download-background-4.x.jpg');
+		background-image: url('{% picture featured-hero-download "assets/download/download-background-4.x.jpg" %}');
 	}
 </style>
 

--- a/_layouts/showcase-item.html
+++ b/_layouts/showcase-item.html
@@ -6,31 +6,47 @@ layout: default
 
 <style>
 	.showcase-video-image {
-		margin-top: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+
+		img {
+			width: 100%;
+			background:  linear-gradient(90deg, #947451 12%, #a8885f 29%, #8c8977 65%, #d2ba9f 98%)
+		}
+
+		.youtube {
+			border: 0;
+		}
 	}
 
 	.showcase-developer-quote {
 		font-style: italic;
 		color: var(--base-color-text-title);
 
+		p:first-child::before {
+			content: '“';
+			font-size: 150%;
+			margin-right: -0.1rem;
+		}
+
+		p:last-child::after {
+			content: '”';
+			font-size: 150%;
+			margin-left: -0.1rem;
+		}
 	}
 
-	.showcase-developer-quote p:first-child::before {
-		content: '“';
-		font-size: 150%;
-		margin-right: -0.1rem;
-	}
+	.showcase-intro-icons {
+		filter: invert(100%);
+		opacity: 0.75;
+		margin-top: 1rem;
+		display: flex;
+		gap: 0.5rem;
 
-	.showcase-developer-quote p:last-child::after {
-		content: '”';
-		font-size: 150%;
-		margin-left: -0.1rem;
-	}
-
-	@media (min-width: 900px) {
-		.showcase-video-image {
-			margin-left: 1rem;
-			margin-top: 0;
+		img {
+			width: 24px;
+			height: 24px;
 		}
 	}
 
@@ -56,47 +72,43 @@ layout: default
 				| {% if page.release_date == "TBD" %}Release date: <abbr title="To Be Determined">TBD</abbr>{% else %}{{
 				page.release_date }}{% endif %}
 			</h3>
-			<div style="filter: invert(100%); opacity: 0.75; margin-top: 1rem">
+			<div class="showcase-intro-icons">
 
 
 				{% if page.windows %}
-				<img src="/assets/images/platforms/windows.svg" alt="Windows" title="Windows" style="margin: 0 0.125rem" width="24"
-					height="24">
+				<img src="/assets/images/platforms/windows.svg" alt="Windows" title="Windows" width="24" height="24">
 				{% endif %}
 
 				{% if page.macos %}
-				<img src="/assets/images/platforms/macos.svg" alt="Mac" title="Mac" style="margin: 0 0.125rem" width="24" height="24">
+				<img src="/assets/images/platforms/macos.svg" alt="Mac" title="Mac" width="24" height="24">
 				{% endif %}
 
 				{% if page.linux %}
-				<img src="/assets/images/platforms/linux.svg" alt="Linux" title="Linux" style="margin: 0 0.125rem" width="24" height="24">
+				<img src="/assets/images/platforms/linux.svg" alt="Linux" title="Linux" width="24" height="24">
 				{% endif %}
 
 				{% if page.switch %}
-				<img src="/assets/images/platforms/switch.svg" alt="Nintendo Switch" title="Switch" style="margin: 0 0.125rem" width="24"
-					height="24">
+				<img src="/assets/images/platforms/switch.svg" alt="Nintendo Switch" title="Switch" width="24" height="24">
 				{% endif %}
 
 				{% if page.html5 %}
-				<img src="/assets/images/platforms/web.svg" alt="HTML5" title="HTML5" style="margin: 0 0.125rem" width="24" height="24">
+				<img src="/assets/images/platforms/web.svg" alt="HTML5" title="HTML5" width="24" height="24">
 				{% endif %}
 
 				{% if page.android %}
-				<img src="/assets/images/platforms/android.svg" alt="Android" title="Android" style="margin: 0 0.125rem" width="24"
-					height="24">
+				<img src="/assets/images/platforms/android.svg" alt="Android" title="Android" height="24">
 				{% endif %}
 
 				{% if page.ios %}
-				<img src="/assets/images/platforms/ios.svg" alt="iOS" title="iOS" style="margin: 0 0.125rem" width="24" height="24">
+				<img src="/assets/images/platforms/ios.svg" alt="iOS" title="iOS" width="24" height="24">
 				{% endif %}
 
 				{% if page.playstation %}
-				<img src="/assets/images/platforms/playstation.svg" alt="PlayStation" title="PlayStation" style="margin: 0 0.125rem"
-					width="24" height="24">
+				<img src="/assets/images/platforms/playstation.svg" alt="PlayStation" title="PlayStation" width="24" height="24">
 				{% endif %}
 
 				{% if page.xbox %}
-				<img src="/assets/images/platforms/xbox.svg" alt="Xbox" title="Xbox" style="margin: 0 0.125rem" width="24" height="24">
+				<img src="/assets/images/platforms/xbox.svg" alt="Xbox" title="Xbox"width="24" height="24">
 				{% endif %}
 
 			</div>
@@ -106,8 +118,8 @@ layout: default
 </div>
 
 <div class="container">
-	<section class="flex eqsize responsive">
-		<article>
+	<section class="flex responsive" style="gap: 1rem;">
+		<article style="flex: 1">
 			{{ content }}
 
 			<div class="flex responsive" style="justify-content: center; margin-top: 2rem">
@@ -183,16 +195,18 @@ layout: default
 			<div class="card youtube" style="padding-bottom: 56.25%">
 				<iframe src="https://www.youtube-nocookie.com/embed/{{ page.youtube_id }}"
 					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-					allowfullscreen="" frameborder="0">
+					allowfullscreen="">
 				</iframe>
 			</div>
 			{% endif %}
 
 			{% for image in page.gallery %}
-			<a href="{{ image }}" class="lightbox" data-group="showcase">
-				<img class="rounded-lg" src="{{ image }}" alt="Screenshot of {{ page.title }} by {{ page.author }}"
-					style="width: 100%; height: auto; margin-top: 1rem; background:  linear-gradient(90deg, #947451 12%, #a8885f 29%, #8c8977 65%, #d2ba9f 98%) "
-					width="16" height="9">
+			<a href="{% picture lightbox-expanded-thumbnail {{ image }} %}" class="lightbox" data-group="showcase">
+				{% if forloop.index < 3 %}
+					{% picture showcase-thumbnail-details {{ image }} class="rounded-lg" alt="Screenshot of {{ page.title }} by {{ page.author }}" %}
+				{% else %}
+					{% picture showcase-thumbnail-details {{ image }} class="rounded-lg" alt="Screenshot of {{ page.title }} by {{ page.author }}" loading="lazy" %}
+				{% endif%}
 			</a>
 			{% endfor %}
 		</article>

--- a/assets/css/article-cards.css
+++ b/assets/css/article-cards.css
@@ -55,31 +55,29 @@
 
 .card-download-details {
 	display: flex;
-	flex-direction: row;
 	justify-content: space-between;
 	align-items: flex-start;
 	gap: 12px;
 	width: 100%;
 }
+
 @media (max-width: 768px) {
 	.card-download-details {
 		flex-direction: column;
-		align-items: center;
+		align-items: stretch;
 		gap: 20px;
 	}
 }
 
 .card-download-details > img, article .content .card-download-details > img {
-	background-color: transparent;
-	display: inline-block;
 	margin: 0;
-	min-width: 0;
-	max-height: 150px;
+	flex: 1;
+	max-width: 311px;
 }
+
 @media (max-width: 768px) {
-	.card-download-details img, article .content .card-download-details img {
-		max-height: 220px;
-		max-width: 95%;
+	.card-download-details > img, article .content .card-download-details > img {
+		max-width: 100%;
 	}
 }
 

--- a/assets/css/download.css
+++ b/assets/css/download.css
@@ -1,6 +1,5 @@
 .hero {
     padding: 124px 0 60px;
-    background-image: url('/assets/download/download-background.jpg');
     background-size: cover;
     background-position: center;
     position: relative;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -214,6 +214,11 @@
     url("../fonts/Montserrat-ExtraBold.woff") format("woff");
 }
 
+* {
+  /* Easier to spot issue with the layout*/
+  min-width: 0;
+}
+
 *:focus {
   /* More visible outline for better keyboard navigation. */
   outline: 0.125rem solid hsl(220, 100%, 62.5%);
@@ -263,6 +268,33 @@ body a:active,
 .btn.flat:active,
 .search-bar-btn:active {
   filter: brightness(82.5%);
+}
+
+/*
+	1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+	2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+	This can trigger a poorly considered lint error in some tools but is included by design.
+	*/
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+	display: block;
+	vertical-align: middle;
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+img,
+video {
+	max-width: 100%;
+	height: auto;
 }
 
 h1,
@@ -363,6 +395,10 @@ hr {
   min-width: unset;
   margin-right: 0;
   margin-bottom: 0;
+}
+
+.grow {
+	flex-grow: 1;
 }
 
 .base-padding {
@@ -828,6 +864,7 @@ a.card {
   padding: 16px 24px 16px 24px;
   text-decoration: none;
   text-align: center;
+  min-width: unset;
 }
 
 .tabs a {
@@ -1350,12 +1387,10 @@ article.article-card h3 {
   margin-bottom: 10px;
 }
 article.article-card .thumbnail {
-  aspect-ratio: 16 / 9;
-  border-radius: 7px;
-  background-position: center;
-  background-size: cover;
-  background-color: var(--card-background-color);
-  box-shadow: 0 5px 10px -3px #00000078;
+	aspect-ratio: 16 / 9;
+	border-radius: 7px;
+	box-shadow: 0 5px 10px -3px #00000078;
+	background-color: var(--card-background-color);
 }
 article.article-card .info {
   display: flex;

--- a/pages/download/preview.html
+++ b/pages/download/preview.html
@@ -12,7 +12,7 @@ layout: default
 <link rel="stylesheet" href="/assets/css/download-version.css?2">
 <style>
 	.hero {
-		background-image: url('/assets/download/download-background-preview.jpg');
+		background-image: url('{% picture featured-hero-download "assets/download/download-background-preview.jpg" %}');
 	}
 
 	.hero-blurb {

--- a/pages/features.html
+++ b/pages/features.html
@@ -402,13 +402,12 @@ layout: default
 		</script>
 
 		<div class="showcase-carousel">
-			<img src="/assets/features/editor-frame.png?2" class="showcase-frame" />
-
+			{% picture showcase-carousel-frame "assets/features/editor-frame.png" class="showcase-frame" alt="" %}
 			<div class="showcase-items">
-				{% for project in site.showcase %}
+				{% for project in site.showcase  %}
 				{% if project.featured_in_home %}
 				<div class="showcase-item">
-					<img src="{{ project.gallery[0] }}" load="lazy" alt="{{ project.title }} - {{ project.author }}" />
+					{% picture showcase-carousel {{ project.gallery[0] }} alt="{{ project.title }} - {{ project.author }}" loading="lazy" %}
 					<div class="showcase-credits">
 						<a href="{{ project.url }}">
 							<span class="showcase-title">{{ project.title }}</span> <span class="showcase-author">- {{ project.author }}</span>
@@ -610,7 +609,7 @@ layout: default
 				Watch our annual showreel videos to see more examples of projects using Godot!
 			</p>
 
-			{% include showreel-shelf.html %}
+			{% include showreel-shelf.html lazyload=true %}
 		</div>
 	</div>
 

--- a/pages/home.html
+++ b/pages/home.html
@@ -161,10 +161,16 @@ layout: default
 			text-align: left;
 		}
 	}
+
+	.get-involved-item {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
 </style>
 
 <section class="hero">
-	<div class="background-image" style="background-image: url()"></div>
+	<div class="background-image"></div>
 	<div class="wrapper">
 		<div class="copy container">
 			<h1>The game engine you've been waiting&nbsp;for.</h1>
@@ -206,7 +212,7 @@ layout: default
 		{% for post in latest_posts limit:1 %}
 		<a href="{{ post.url }}" style="text-decoration: none">
 			<article class="article-card">
-				<div class="thumbnail" style="background-image: url('{{ post.image }}');"></div>
+				{% picture latest-news-header {{ post.image }} class="thumbnail" alt="" %}
 				<div class="content">
 					<h3>{{ post.title }}</h3>
 					<p class="excerpt">{{ post.excerpt }}</p>
@@ -222,7 +228,7 @@ layout: default
 				{% if post != posts[0] %}
 				<a href="{{ post.url }}" style="text-decoration: none;">
 					<article class="article-card row">
-						<div class="thumbnail" style="background-image: url('{{ post.image }}');" href="{{ post.url }}"></div>
+						{% picture latest-news {{ post.image }} class="thumbnail" alt="" href="{{ post.url }} %}
 						<div>
 							<h3>{{ post.title }}</h3>
 							<p class="excerpt">{{ post.excerpt | truncate: 103 }}</p>
@@ -247,8 +253,14 @@ layout: default
 	<div class="features-grid">
 		<a class="feature-link" href="/features#design" data-barba-prevent>
 			<div class="feature dark">
-				<img src="/assets/home/features/innovative.webp" alt="" width="1" height="1"
-					style="background: linear-gradient(90deg, #333747 11%, #2d3342 50%, #2d3342 68%, #272d3c 87%)" loading="lazy">
+				{%
+					picture
+					home-feature
+					"assets/home/features/innovative.webp"
+					style="background: linear-gradient(90deg, #333747 11%, #2d3342 50%, #2d3342 68%, #272d3c 87%)"
+					alt=""
+					loading="lazy"
+				%}
 				<div class="body">
 					<h4>Innovative design</h4>
 					<p>
@@ -261,8 +273,14 @@ layout: default
 
 		<a class="feature-link" href="/features#script" data-barba-prevent>
 			<div class="feature dark">
-				<img src="/assets/home/features/language.webp" alt="" width="1" height="1"
-					style="background: linear-gradient(90deg, #252a35 46%, #252a35 53%, #202630 76%, #202630 89%)" loading="lazy">
+				{%
+					picture
+					home-feature
+					"assets/home/features/language.webp"
+					style="background: linear-gradient(90deg, #252a35 46%, #252a35 53%, #202630 76%, #202630 89%)"
+					alt=""
+					loading="lazy"
+				%}
 				<div class="body">
 					<h4>Use the right language for the job</h4>
 					<p>
@@ -276,10 +294,17 @@ layout: default
 				</div>
 			</div>
 		</a>
+
 		<a class="feature-link" href="/features#features_2d" data-barba-prevent>
 			<div class="feature dark">
-				<img src="/assets/home/features/2d.webp" alt="" width="1" height="1"
-					style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)" loading="lazy">
+				{%
+					picture
+					home-feature
+					"assets/home/features/2d.webp"
+					style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)"
+					alt=""
+					loading="lazy"
+				%}
 				<div class="body">
 					<h4>Dedicated 2D engine</h4>
 					<p>
@@ -292,8 +317,14 @@ layout: default
 
 		<a class="feature-link" href="/features#features_3d" data-barba-prevent>
 			<div class="feature dark">
-				<img src="/assets/home/features/3d.webp" alt="" width="1" height="1"
-					style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)" loading="lazy">
+				{%
+					picture
+					home-feature
+					"assets/home/features/3d.webp"
+					style="background: linear-gradient(90deg, #196f36 7%, #28674e 29%, #2a4b46 65%, #3b6f4e 97%)"
+					alt=""
+					loading="lazy"
+				%}
 				<div class="body">
 					<h4>Simple and powerful 3D</h4>
 					<p>
@@ -346,36 +377,39 @@ layout: default
 
 	<div class="flex eqsize responsive">
 
-		<div class="text-center base-padding">
+		<div class="text-center base-padding get-involved-item">
 			<img src="/assets/home/code.svg" alt="" width="250" height="250" loading="lazy">
 			<h4>Code</h4>
 			<p>
 				If you know how to code, you can help by fixing bugs and working with engine contributors towards the
 				implementation of new features.
 			</p>
+			<span class="grow"></span>
 			<a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-code"
 				class="btn btn-flat btn-flat-frosted" target="_blank" rel="noopener">Learn more</a>
 		</div>
 
-		<div class="text-center base-padding">
+		<div class="text-center base-padding get-involved-item">
 			<img src="/assets/home/document.svg" alt="" width="250" height="250" loading="lazy">
 			<h4>Document</h4>
 			<p>
 				Documentation quality is essential in a game engine; help make it better by updating the API reference, writing
 				new guides or submitting corrections.
 			</p>
+			<span class="grow"></span>
 			<a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#contributing-to-the-documentation"
 				class="btn btn-flat btn-flat-frosted" target="_blank" rel="noopener">Learn more</a>
 		</div>
 
-		<div class="text-center base-padding">
+		<div class="text-center base-padding get-involved-item">
 			<img src="/assets/home/report.svg" alt="" width="250" height="250" loading="lazy">
 			<h4>Report</h4>
 			<p>
 				Found a problem with the engine? Don't forget to report it so that developers can track it down.
 			</p>
+			<span class="grow"></span>
 			<a href="https://docs.godotengine.org/en/stable/community/contributing/ways_to_contribute.html#testing-and-reporting-issues"
-				class="btn btn-flat btn-flat-frosted" target="_blank" rel="noopener">Learn more</a>
+				 class="btn btn-flat btn-flat-frosted" target="_blank" rel="noopener">Learn more</a>
 		</div>
 
 	</div>
@@ -397,60 +431,58 @@ layout: default
 
 {% include sponsors.html %}
 
-
 <script>
-	document.addEventListener('DOMContentLoaded', () => {
-		// Updating the hero on the home page
-		// get the current html lang attribute
-		const htmlLang = document.documentElement.lang;
-		if (window.location.pathname === '/' || window.location.pathname === '/' + htmlLang || window.location.pathname === '/' + htmlLang + '/') {
-			const authors = [
-				{% for project in site.showcase %}
-				{% if project.featured_in_home %}
-				{
-					game: '{{ project.title }}',
-					by: '{{ project.author }}',
-					url: '{{ project.url }}',
-					image: '{{ project.gallery[0] }}',
-				},
-				{% endif %}
-				{% endfor %}
-			];
+	// Updating the hero on the home page
+	// get the current html lang attribute
+	const htmlLang = document.documentElement.lang;
+	const isHome = window.location.pathname === '/' || window.location.pathname === '/' + htmlLang || window.location.pathname === '/' + htmlLang + '/'
+	if (isHome) {
+		loadHero();
+	}
 
-		let author = authors[Math.floor(Math.random() * authors.length)];
+	function loadHero() {
+		const authors = [
+			{% for project in site.showcase %}
+			{% if project.featured_in_home %}
+			{
+				game: '{{ project.title }}',
+				by: '{{ project.author }}',
+				url: '{{ project.url }}',
+				image: '{% picture featured-hero-home {{ project.gallery[0] }} %}',
+			},
+			{% endif %}
+			{% endfor %}
+		];
+		const author = authors[Math.floor(Math.random() * authors.length)];
 		document.querySelector('.hero .background-image').style.backgroundImage = `url(${author.image})`;
 		document.querySelector('.hero .credits a').href = author.url;
 		document.querySelector('.hero .credits a span.game').innerText = author.game;
 		document.querySelector('.hero .credits a span.by').innerText = ' - ' + author.by;
+		setupHeroParallaxEffect();
+	}
 
+	function setupHeroParallaxEffect() {
 		// Parallax effect: On page scroll move background-position up.
 		// This effect is disabled if user opted to have reduced motion in browser/OS settings.
-		const reducedMotionCheck = window.matchMedia('(prefers-reduced-motion)');
-		if (!reducedMotionCheck.matches) {
+		const reducedMotionIsActive = window.matchMedia('(prefers-reduced-motion)').matches;
+		if (reducedMotionIsActive) return;
 
+		const parallaxImage = document.querySelector('section.hero .background-image');
+		const parallaxMinWidth = 768;
+		const parallaxSpeed = 0.4;
+
+		function tick() {
 			// Parallax effect lags on mobile, so we disable it based on the window resolution.
-			const parallaxImage = document.querySelector('section.hero .background-image');
-			const parallaxMinWidth = 768;
-			const parallaxSpeed = 0.4;
-
-			const parallaxTick = () => {
-				if (window.innerWidth > parallaxMinWidth) {
-					parallaxImage.style.transform = `translateY(${window.pageYOffset * parallaxSpeed}px)`;
-				} else {
-					parallaxImage.style.transform = 'none';
-				}
+			if (window.innerWidth > parallaxMinWidth) {
+				parallaxImage.style.transform = `translateY(${window.scrollY * parallaxSpeed}px)`;
+			} else {
+				parallaxImage.style.transform = 'none';
 			}
-
-			window.addEventListener("scroll", () => {
-				window.requestAnimationFrame(parallaxTick)
-			});
-
-			window.addEventListener("resize", () => {
-				window.requestAnimationFrame(parallaxTick)
-			});
 		}
+
+		window.addEventListener("scroll", tick);
+		window.addEventListener("resize", tick);
 	}
-	});
 </script>
 
 {% include footer.html %}

--- a/pages/showcase.html
+++ b/pages/showcase.html
@@ -26,69 +26,7 @@ layout: default
 		Every year, we make a series of videos highlighting the best games made with Godot. Here are the latest ones:
 	</p>
 
-	{% include showreel-shelf.html %}
-
-	<style>
-		.showcase-card h3 {
-			font-size: 33px;
-			margin-bottom: 0px;
-		}
-
-		.showcase-card p {
-			font-size: 14px;
-			margin: 0;
-			color: var(--secondary-color-text);
-		}
-
-		.showcase-card img.thumbnail {
-			max-width: 100%;
-			border-radius: 7px;
-			background-color: var(--card-background-color);
-			box-shadow: 0 5px 10px -3px #00000078;
-			display: block;
-			margin-bottom: 6px;
-		}
-
-		.showcase-card-caption {
-			display: flex;
-			column-gap: 12px;
-			justify-content: space-between;
-			margin: 0 14px;
-		}
-
-		.showcase-card-authors {
-			display: grid;
-			align-content: center;
-		}
-
-		.showcase-card-icons {
-			filter: none;
-			padding: 7px 0px 0px;
-			opacity: 0.5;
-		}
-
-		@media (prefers-color-scheme: dark) {
-			.showcase-card-icons {
-				filter: invert();
-			}
-		}
-
-		.showcase-card .no-capsule {
-			aspect-ratio: 92 / 43;
-			background-size: cover;
-			background-position: center;
-			border-radius: 6px;
-			box-shadow: 0 5px 10px -3px #00000078;
-			margin-bottom: 7px;
-			text-align: center;
-			display: grid;
-			align-content: center;
-		}
-
-		.showcase-card .no-capsule h3 {
-			text-shadow: 0 4px 5px black;
-		}
-	</style>
+	{% include showreel-shelf.html lazyload=false %}
 
 	<!-- Filter will go here -->
 
@@ -101,54 +39,53 @@ layout: default
 		<a href="{{ project.url }}" style="text-decoration: none;">
 			<article class="showcase-card">
 				{% if project.image %}
-				<img class="thumbnail" src="{{ project.image }}" alt="{{ project.title }}" loading="lazy">
+					{% picture showcase-thumbnail {{ project.image }} class="thumbnail" alt="{{ project.title }}" loading="lazy" %}
 				{% else %}
-				<div class="no-capsule" style="background-image: url({{ project.gallery[0] }})">
+				<div style="position: relative">
 					<h3>{{ project.title }}</h3>
+					{% picture showcase-thumbnail {{ project.gallery[0]  }} class="thumbnail" alt="{{ project.title }}" loading="lazy" %}
 				</div>
 				{% endif %}
 				<div class="showcase-card-caption">
 					<div class="showcase-card-icons">
 						{% if project.windows %}
-						<img src="/assets/images/platforms/windows.svg" alt="Windows" title="Windows" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/windows.svg" alt="Windows" title="Windows" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.macos %}
-						<img src="/assets/images/platforms/macos.svg" alt="Mac" title="Mac" style="margin: 0 0.125rem" width="24" height="24">
+						<img src="/assets/images/platforms/macos.svg" alt="Mac" title="Mac" width="24" height="24">
 						{% endif %}
 
 						{% if project.linux %}
-						<img src="/assets/images/platforms/linux.svg" alt="Linux" title="Linux" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/linux.svg" alt="Linux" title="Linux" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.switch %}
-						<img src="/assets/images/platforms/switch.svg" alt="Nintendo Switch" title="Switch" style="margin: 0 0.125rem"
-							width="24" height="24">
+						<img src="/assets/images/platforms/switch.svg" alt="Nintendo Switch" title="Switch" width="24" height="24">
 						{% endif %}
 
 						{% if project.html5 %}
-						<img src="/assets/images/platforms/web.svg" alt="HTML5" title="HTML5" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/web.svg" alt="HTML5" title="HTML5" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.android %}
-						<img src="/assets/images/platforms/android.svg" alt="Android" title="Android" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/android.svg" alt="Android" title="Android" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.ios %}
-						<img src="/assets/images/platforms/ios.svg" alt="iOS" title="iOS" style="margin: 0 0.125rem" width="24" height="24">
+						<img src="/assets/images/platforms/ios.svg" alt="iOS" title="iOS" width="24" height="24">
 						{% endif %}
 
 						{% if project.playstation %}
-						<img src="/assets/images/platforms/playstation.svg" alt="PlayStation" title="PlayStation" style="margin: 0 0.125rem"
-							width="24" height="24">
+						<img src="/assets/images/platforms/playstation.svg" alt="PlayStation" title="PlayStation" width="24" height="24">
 						{% endif %}
 
 						{% if project.xbox %}
-						<img src="/assets/images/platforms/xbox.svg" alt="Xbox" title="Xbox" style="margin: 0 0.125rem" width="24" height="24">
+						<img src="/assets/images/platforms/xbox.svg" alt="Xbox" title="Xbox" width="24" height="24">
 						{% endif %}
 					</div>
 					<div class="showcase-card-authors">
@@ -170,54 +107,53 @@ layout: default
 		<a href="{{ project.url }}" style="text-decoration: none;">
 			<article class="showcase-card">
 				{% if project.image %}
-				<img class="thumbnail" src="{{ project.image }}" alt="{{ project.title }}" loading="lazy">
+					{% picture showcase-thumbnail {{ project.image }} class="thumbnail" alt="{{ project.title }}" loading="lazy" %}
 				{% else %}
-				<div class="no-capsule" style="background-image: url({{ project.gallery[0] }})">
+				<div style="position: relative">
 					<h3>{{ project.title }}</h3>
+					{% picture showcase-thumbnail {{ project.gallery[0] }} class="thumbnail" alt="{{ project.title }}" loading="lazy" %}
 				</div>
 				{% endif %}
 				<div class="showcase-card-caption">
 					<div class="showcase-card-icons">
 						{% if project.windows %}
-						<img src="/assets/images/platforms/windows.svg" alt="Windows" title="Windows" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/windows.svg" alt="Windows" title="Windows" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.macos %}
-						<img src="/assets/images/platforms/macos.svg" alt="Mac" title="Mac" style="margin: 0 0.125rem" width="24" height="24">
+						<img src="/assets/images/platforms/macos.svg" alt="Mac" title="Mac" width="24" height="24">
 						{% endif %}
 
 						{% if project.linux %}
-						<img src="/assets/images/platforms/linux.svg" alt="Linux" title="Linux" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/linux.svg" alt="Linux" title="Linux" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.switch %}
-						<img src="/assets/images/platforms/switch.svg" alt="Nintendo Switch" title="Switch" style="margin: 0 0.125rem"
-							width="24" height="24">
+						<img src="/assets/images/platforms/switch.svg" alt="Nintendo Switch" title="Switch" width="24" height="24">
 						{% endif %}
 
 						{% if project.html5 %}
-						<img src="/assets/images/platforms/web.svg" alt="HTML5" title="HTML5" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/web.svg" alt="HTML5" title="HTML5" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.android %}
-						<img src="/assets/images/platforms/android.svg" alt="Android" title="Android" style="margin: 0 0.125rem" width="24"
+						<img src="/assets/images/platforms/android.svg" alt="Android" title="Android" width="24"
 							height="24">
 						{% endif %}
 
 						{% if project.ios %}
-						<img src="/assets/images/platforms/ios.svg" alt="iOS" title="iOS" style="margin: 0 0.125rem" width="24" height="24">
+						<img src="/assets/images/platforms/ios.svg" alt="iOS" title="iOS" width="24" height="24">
 						{% endif %}
 
 						{% if project.playstation %}
-						<img src="/assets/images/platforms/playstation.svg" alt="PlayStation" title="PlayStation" style="margin: 0 0.125rem"
-							width="24" height="24">
+						<img src="/assets/images/platforms/playstation.svg" alt="PlayStation" title="PlayStation" width="24" height="24">
 						{% endif %}
 
 						{% if project.xbox %}
-						<img src="/assets/images/platforms/xbox.svg" alt="Xbox" title="Xbox" style="margin: 0 0.125rem" width="24" height="24">
+						<img src="/assets/images/platforms/xbox.svg" alt="Xbox" title="Xbox" width="24" height="24">
 						{% endif %}
 					</div>
 					<div class="showcase-card-authors">
@@ -238,10 +174,11 @@ layout: default
 		<a href="{{ project.url }}" style="text-decoration: none;">
 			<article class="showcase-card">
 				{% if project.image %}
-				<img class="thumbnail" src="{{ project.image }}" alt="{{ project.title }}" loading="lazy">
+					{% picture showcase-thumbnail {{ project.image }} class="thumbnail" alt="{{ project.title }}" loading="lazy" %}
 				{% else %}
-				<div class="no-capsule" style="background-image: url({{ project.gallery[0] }})">
+				<div style="position: relative">
 					<h3>{{ project.title }}</h3>
+					{% picture showcase-thumbnail {{ project.gallery[0] }} class="thumbnail" alt="{{ project.title }}" loading="lazy" %}
 				</div>
 				{% endif %}
 				<div class="showcase-card-caption">
@@ -263,5 +200,70 @@ layout: default
 			form</a>.
 	</p>
 </div>
+
+<style>
+	.showcase-card {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		gap: 6px;
+
+		h3 {
+			font-size: 33px;
+			margin-bottom: 0;
+			position: absolute;
+			text-align: center;
+			width: 100%;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+			text-shadow: 0 4px 5px black;
+		}
+
+		p {
+			font-size: 14px;
+			margin: 0;
+			color: var(--secondary-color-text);
+		}
+
+		.thumbnail {
+			width: 100%;
+			aspect-ratio: 92/43;
+			background-color: var(--card-background-color);
+			border-radius: 7px;
+			box-shadow: 0 5px 10px -3px #00000078;
+		}
+	}
+
+	.showcase-card-caption {
+		display: flex;
+		column-gap: 12px;
+		justify-content: space-between;
+		padding: 0.5rem 0.9rem;
+	}
+
+	.showcase-card-authors {
+		display: grid;
+		align-content: center;
+	}
+
+	.showcase-card-icons {
+		filter: none;
+		opacity: 0.5;
+		display: flex;
+		gap: 0.5rem;
+
+		img {
+			width: 24px;
+			height: 24px;
+		}
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.showcase-card-icons {
+			filter: invert();
+		}
+	}
+</style>
 
 {% include footer.html %}


### PR DESCRIPTION
Since my last pr got out of scope I've created this one for just the image optimizations

- Converted img tags to the new picture tag
- Fixed issues with the layout after introducing correct width and height to images

Uses this awesome gem [jekyll_picture_tag](https://rbuchberger.github.io/jekyll_picture_tag/)

