### PR TITLE
Reduce homepage hero font size on mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1258,7 +1258,7 @@ section.hero .copy p {
     margin: 0 auto;
   }
   section.hero .copy h1 {
-    font-size: 50px;
+    font-size: 40px;
   }
   section.hero .copy p {
     text-align: center;


### PR DESCRIPTION
As per #831, reduces the font size of the hero header on mobile.

See below for iPhone SE (pretty small) and iPad (pretty large) viewports; I wonder if iPad is now too small and we need another breakpoint?

![Screenshot from 2024-04-14 18-56-55](https://github.com/godotengine/godot-website/assets/4892574/cb7e7c4c-b540-4b78-b625-49d041df18bb)

![Screenshot from 2024-04-14 18-57-32](https://github.com/godotengine/godot-website/assets/4892574/23b307e4-6e9a-45e5-9b9b-de4ccf55f3c0)

## Where this breaks

At 302px (on Firefox), this breaks and we get #831 again - but this is far tinier than the majority of phones now.

![Screenshot from 2024-04-14 18-59-20](https://github.com/godotengine/godot-website/assets/4892574/f1f9ab42-7c1d-4a96-a97b-4bf910655076)

