### PR TITLE
Make hero shorter and update call to actions

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
 
 			<ul class="right">
 				<li><a href="/download/windows" class="set-os-download-url">Download</a></li>
-				<li><a href="https://docs.godotengine.org">Learn</a></li>
+				<li><a href="https://docs.godotengine.org">Docs</a></li>
 				<li><a href="https://docs.godotengine.org/en/stable/community/contributing/index.html">Contribute</a></li>
 				{% comment %}
 				We add the control character at the end to force the heart to render as text and not as an emoji.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1246,7 +1246,6 @@ section.hero .copy p {
   font-size: 20px;
   line-height: 1.5;
   margin-bottom: 20px;
-  max-width: 550px;
   text-shadow: 0 0 28px #00000080;
   color: white;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1232,7 +1232,6 @@ section.hero .background-image {
 section.hero .copy {
   position: relative;
   z-index: 1;
-  max-width: 670px;
   margin-left: 0;
 }
 
@@ -1270,7 +1269,7 @@ section.hero .wrapper {
   position: relative;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 200px 20px 120px;
+  padding: 180px 20px 100px;
 }
 
 @media (max-width: 650px) {

--- a/pages/home.html
+++ b/pages/home.html
@@ -26,16 +26,15 @@ layout: default
 	.main-download-links .btn-download {
 		width: 100%;
 	}
-	.main-download-links .btn-download:nth-of-type(2n) {
-		background-color: rgb(132 151 174 / 68%);
-		-webkit-backdrop-filter: blur(4px);
-		backdrop-filter: blur(4px);
-	}
-	.main-download-links .btn-download:nth-of-type(2n) .download-title {
-		color: #f7f7f7;
-	}
-	.main-download-links .btn-download:nth-of-type(2n) .download-hint {
-		background-color: var(--primary-color-subdued);
+	
+	.main-download-links .download-lts {
+		text-align: center;
+		text-decoration-color: inherit;
+		color: white;
+		text-shadow: 0 0 10px black;
+		font-weight: 100;
+		text-decoration-thickness: 1px;
+		font-size: 16px;
 	}
 
 	@media (max-width: 900px) {
@@ -168,8 +167,7 @@ layout: default
 	<div class="wrapper">
 		<div class="copy container">
 			<h1>
-				Your free,<br>
-				open&#8209;source<br>
+				Your free, open&#8209;source<br>
 				game engine.
 			</h1>
 			<p>Develop your 2D &amp; 3D games, cross-platform projects, or even XR ideas!</p>
@@ -185,14 +183,11 @@ layout: default
 						<div class="download-hint">{{ stable_version_4.name }}</div>
 					</a>
 
-					<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="3"
+					<a href="/download/windows" class="download-lts set-os-download-url" data-version="3"
 						title="Download the long-term support version of Godot 3">
-						<div class="download-title">Download LTS</div>
-						<div class="download-hint">{{ stable_version_3.name }}</div>
+						<span class="download-title">Download Godot LTS - v{{ stable_version_3.name }}</span>
 					</a>
 				</div>
-
-				<a href="/features" class="btn btn-flat btn-flat-white btn-flat-frosted btn-hero-learn-more">Learn more</a>
 			</div>
 		</div>
 	</div>

--- a/pages/home.html
+++ b/pages/home.html
@@ -27,16 +27,23 @@ layout: default
 		width: 100%;
 	}
 	
-	.main-download-links .download-lts {
+	.main-download-links .download-3 {
 		text-align: center;
-		text-decoration-color: inherit;
-		color: white;
+		color: #ffffffd6;
 		text-shadow: 0 0 10px black;
 		font-weight: 100;
-		text-decoration-thickness: 1px;
-		font-size: 16px;
+		font-size: 14px;
 	}
-
+	
+	.main-download-links .download-3 a {
+		color: inherit;
+		text-decoration-color: inherit;
+		text-decoration-thickness: 1px;
+	}
+	.main-download-links .download-3 a:hover {
+		color: white;
+	}
+	
 	@media (max-width: 900px) {
 		.main-download {
 			align-items: center;
@@ -183,9 +190,7 @@ layout: default
 						<div class="download-hint">{{ stable_version_4.name }}</div>
 					</a>
 
-					<a href="/download/windows" class="download-lts set-os-download-url" data-version="3"
-						title="Download the long-term support version of Godot 3">
-						<span class="download-title">Download Godot LTS - v{{ stable_version_3.name }}</span>
+					<span class="download-3">Looking for <a href="/download/windows" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
 					</a>
 				</div>
 			</div>


### PR DESCRIPTION
# Current version
<img width="1510" alt="image" src="https://github.com/godotengine/godot-website/assets/2206700/a3806815-d588-4b3d-82ba-69fbea7bb633">

The current version of the hero is too tall. It includes 3 different prominent buttons to click and it hides the news under the fold. 

# This PR
<img width="1509" alt="image" src="https://github.com/godotengine/godot-website/assets/2206700/0138b443-1dd5-4d51-b817-39f9e9117a8c">


This PR makes the overall height of the hero section to be shorter, and gives less weight to the Godot 3 download. 
The "learn more" button goes to the same place as the nav's "features" button, so it really doesn't make sense to have it so accessible there. 
It also adds a new link to the archive in case you need to download another version of the engine. This is something similar to what we or Blender have in the download page.

Supersedes https://github.com/godotengine/godot-website/pull/769

