### PR TITLE
Fix typos in reverse z blog post

### DIFF
--- a/collections/_article/introducing-reverse-z.md
+++ b/collections/_article/introducing-reverse-z.md
@@ -62,8 +62,8 @@ Writing to `DEPTH` comes with the same warnings as writing to `POSITION`. If the
 ```
 // This will continue to work.
 vec4 clip_pos = PROJECTION_MATRIX * vec4(VERTEX, 1.0);
-clip_space.xyz /= clip_space.w;
-DEPTH = clip_space.z;
+clip_pos.xyz /= clip_pos.w;
+DEPTH = clip_pos.z;
 
 // This will need to change.
 DEPTH = 0.0;  // Needs to change to 1.0.
@@ -91,7 +91,7 @@ This code will require no modification. Where users will need to make modificati
 
 ```
 vec4 clip_pos = PROJECTION_MATRIX * vec4(VERTEX, 1.0);
-clip_space.xyz /= clip_space.w;
+clip_pos.xyz /= clip_pos.w;
 float depth = textureLod(depth_texture, SCREEN_UV, 0.0).r;
 
 if (clip_pos > depth) {


### PR DESCRIPTION
In a few places I used `clip_space` variable (which was undefined) instead of the proper `clip_pos`

Thanks to @lyuma for pointing this out on discord