### PR TITLE
Add way to customize host and port for `build-and-serve.sh`

### DIFF
--- a/build-and-serve.sh
+++ b/build-and-serve.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+SERVER_HOST="${SERVER_HOST:-0.0.0.0}"
+SERVER_PORT="${SERVER_PORT:-4000}"
+
 bundle install
-bundle exec jekyll serve --config _config.yml,_config.development.yml --host 0.0.0.0
+bundle exec jekyll serve --config _config.yml,_config.development.yml --host "$SERVER_HOST" --port "$SERVER_PORT"


### PR DESCRIPTION
With this PR, we can customize the host and port for `build-and-serve.sh` utility script.

```console
# Sets the host to localhost instead of the default 0.0.0.0
SERVER_HOST=localhost ./build-and-serve.sh
# Sets the port to 4001 instead of the default 4000
SERVER_PORT=4001 ./build-and-serve.sh
# Sets both values
SERVER_HOST=localhost SERVER_PORT=4001 ./build-and-serve.h
```