### PR TITLE
Fix C# platform support table

### DIFF
--- a/collections/_article/platform-state-in-csharp-for-godot-4-2.md
+++ b/collections/_article/platform-state-in-csharp-for-godot-4-2.md
@@ -85,9 +85,9 @@ As a summary, the current platform support as of 4.2 is described in the table b
 
 | Platform | Runtimes supported | Minimum required .NET version |
 | -: | - | - |
-| **Windows** | CoreCLR, Mono, NativeAOT | 6.0 (CoreCLR, Mono), 7.0 (NativeAOT) |
-| **macOS** | CoreCLR, Mono, NativeAOT | 6.0 (CoreCLR, Mono), 7.0 (NativeAOT) |
-| **Linux** | CoreCLR, Mono, NativeAOT | 6.0 (CoreCLR, Mono), 7.0 (NativeAOT) |
+| **Windows** | CoreCLR, Mono, NativeAOT | 6.0 (CoreCLR), 7.0 (Mono, NativeAOT) |
+| **macOS** | CoreCLR, Mono, NativeAOT | 6.0 (CoreCLR), 7.0 (Mono, NativeAOT) |
+| **Linux** | CoreCLR, Mono, NativeAOT | 6.0 (CoreCLR), 7.0 (Mono, NativeAOT) |
 | **Android** | Mono | 7.0 |
 | **iOS** | NativeAOT | 8.0 |
 | **Web** | - | - |


### PR DESCRIPTION
Mono requires .NET **7.0**, since we use `coreclr_create_delegate` which wasn't implemented in Mono before 7.0.
- See https://github.com/dotnet/runtime/pull/59962.

Thanks @paulloz for letting me know that the table was incorrect.