### PR TITLE
Update URLs for Croatia

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -85,12 +85,12 @@ China:
       - title: QQ Group
         url: https://qm.qq.com/cgi-bin/qm/qr?k=hEscGFbQTiOX0bhsTT2myxM3PifsAmIp&jump_from=webapi
 Croatia:
-  - name: Croatia
+  - name: Game Developers Croatia
     links:
       - title: Discord
-        url: https://discord.gg/6gjwfSG
+        url: https://discord.gg/CbZKkqR
       - title: Facebook
-        url: https://web.facebook.com/groups/godotenginecroatia/
+        url: https://www.facebook.com/groups/gamedevcro
 Czech Republic and Slovakia:
   - name: Godot CZ/SK
     links:


### PR DESCRIPTION
Replace URLs for Croatia Godot-specific servers (which are getting deleted) with general-purpose gamedev servers.

----

We have decided to delete Godot-specific Discord server and Facebook website due to very low usage and demand.

I have replaced the URLs with general-purpose gamedev server/website that we have which has a ton more users. Discord server has a #engine-godot channel, and Facebook website is open for any discussions, including Godot.

In case of this PR not getting approved, I will update it and delete Croatia from the list as it won't have any Godot-specific servers/websites starting May 26th.