### PR TITLE
Add Bromeon to the GDExtension team

### DIFF
--- a/pages/teams.html
+++ b/pages/teams.html
@@ -189,6 +189,7 @@ current_tab: "teams"
 					Fabio Alessandrelli (<a href="https://github.com/Faless">@Faless</a>),
 					George Marques (<a href="https://github.com/vnen">@vnen</a>),
 					Gilles Roudière (<a href="https://github.com/groud">@groud</a>),
+					Jan Haller (<a href="https://github.com/Bromeon">@Bromeon</a>),
 					Juan Linietsky (<a href="https://github.com/reduz">@reduz</a>),
 					Pāvels Nadtočajevs (<a href="https://github.com/bruvzg">@bruvzg</a>)
 				</td>


### PR DESCRIPTION
@Bromeon has been a member of the GDExtension team for a while. Let's get him listed on the website!