### PR TITLE
Avoid redirects in internal links by appending trailing slash

### DIFF
--- a/_includes/articles/download_card.html
+++ b/_includes/articles/download_card.html
@@ -57,7 +57,7 @@
 		<a class="card-download-other" href="/download/archive/{{ release_version.name }}-{{ release_version.flavor }}">
 			Export templates and other downloads
 		</a>
-		<a class="card-download-donate" href="/donate">
+		<a class="card-download-donate" href="/donate/">
 			Make a Donation
 		</a>
 	</div>

--- a/_includes/download/download-section.html
+++ b/_includes/download/download-section.html
@@ -47,7 +47,7 @@
 		font-weight: 100;
 		font-size: 15px;
 	}
-	
+
 	.section-download .download-3 a {
 		color: inherit;
 		text-decoration-color: inherit;
@@ -69,12 +69,12 @@
 		{% assign stable_version_4 = site.data.versions | find: "featured", "4" %}
 
 		<p>Download the <strong>latest version of Godot 4</strong> right now and begin your creative journey!</p>
-		<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="4"
+		<a href="/download/windows/" class="btn btn-download set-os-download-url" data-version="4"
 			title="Download the latest version of Godot 4">
 			<div class="download-title">Download Latest</div>
 			<div class="download-hint">{{ stable_version_4.name }}</div>
 		</a>
 
-		<span class="download-3">Looking for <a href="/download/windows" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
+		<span class="download-3">Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
 	</div>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,38 +14,38 @@
 		<div id="sitemap">
 			<ul class="sitemap-group">
 				<li><strong>Get Godot</strong></li>
-				<li><a href="/download/windows" class="set-os-download-url">Download</a></li>
+				<li><a href="/download/windows/" class="set-os-download-url">Download</a></li>
 				<li><a href="/download/archive/">Release Archive</a></li>
 				<li><a href="https://editor.godotengine.org/releases/latest/">Web Editor</a></li>
 				<li>&nbsp;</li>
 				<li><strong>Public Relations</strong></li>
-				<li><a href="/blog">Blog</a></li>
-				<li><a href="/community">Communities and Events</a></li>
-				<li><a href="/press">Press Kit</a></li>
+				<li><a href="/blog/">Blog</a></li>
+				<li><a href="/community/">Communities and Events</a></li>
+				<li><a href="/press/">Press Kit</a></li>
 			</ul>
 			<ul class="sitemap-group">
 				<li><strong>About Godot</strong></li>
-				<li><a href="/features">Features</a></li>
-				<li><a href="/showcase">Showcase</a></li>
-				<li><a href="/education">Education</a></li>
-				<li><a href="/license">License</a></li>
-				<li><a href="/code-of-conduct">Code of Conduct</a></li>
-				<li><a href="/privacy-policy">Privacy Policy</a></li>
+				<li><a href="/features/">Features</a></li>
+				<li><a href="/showcase/">Showcase</a></li>
+				<li><a href="/education/">Education</a></li>
+				<li><a href="/license/">License</a></li>
+				<li><a href="/code-of-conduct/">Code of Conduct</a></li>
+				<li><a href="/privacy-policy/">Privacy Policy</a></li>
 				<li><a href="https://fund.godotengine.org">Donate</a></li>
 			</ul>
 			<ul class="sitemap-group">
 				<li><strong>Project Team</strong></li>
-				<li><a href="/governance">Governance</a></li>
-				<li><a href="/teams">Teams</a></li>
+				<li><a href="/governance/">Governance</a></li>
+				<li><a href="/teams/">Teams</a></li>
 				<li>&nbsp;</li>
 				<li><strong>Extra Resources</strong></li>
-				<li><a href="/asset-library/asset">Asset Library</a></li>
+				<li><a href="https://godotengine.org/asset-library/asset">Asset Library</a></li>
 				<li><a href="https://docs.godotengine.org">Documentation</a></li>
 				<li><a href="https://github.com/godotengine">Code Repository</a></li>
 			</ul>
 		</div>
 		<div id="social" class="dark-desaturate">
-			<h4 class="text-right"><a href="/contact">Contact us</a></h4>
+			<h4 class="text-right"><a href="/contact/">Contact us</a></h4>
 			<div class="flex justify-space-between" style="gap: 3px;">
 				<a href="https://github.com/godotengine" target="_blank" rel="noopener">
 					<img src="/assets/footer/github_logo.svg" width="32" height="32" alt="GitHub">
@@ -111,7 +111,7 @@
 				link_platform = 'linux';
 			}
 
-			link.href = `/${link_slug}/${link_platform}`;
+			link.href = `/${link_slug}/${link_platform}/`;
 		}
 	});
 </script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,16 +13,16 @@
 
 		<nav id="nav">
 			<ul class="left">
-				<li><a href="/features">Features</a></li>
-				<li class="only-on-mobile"><a href="/showcase">Showcase</a></li>
-				<li><a href="/blog">Blog</a></li>
-				<li><a href="/community">Community</a></li>
-				<li><a href="/contact">About</a></li>
+				<li><a href="/features/">Features</a></li>
+				<li class="only-on-mobile"><a href="/showcase/">Showcase</a></li>
+				<li><a href="/blog/">Blog</a></li>
+				<li><a href="/community/">Community</a></li>
+				<li><a href="/contact/">About</a></li>
 				<li><a href="https://godotengine.org/asset-library/asset">Assets</a></li>
 			</ul>
 
 			<ul class="right">
-				<li><a href="/download/windows" class="set-os-download-url">Download</a></li>
+				<li><a href="/download/windows/" class="set-os-download-url">Download</a></li>
 				<li><a href="https://docs.godotengine.org">Docs</a></li>
 				<li><a href="https://docs.godotengine.org/en/stable/community/contributing/index.html">Contribute</a></li>
 				{% comment %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -33,7 +33,7 @@ collection: article
 		gap: 30px;
 		padding: 20px 0 39px;
 	}
-	.head .main > :last-child,  
+	.head .main > :last-child,
 	.head .main > :first-child {
 		margin: 0;
 	}
@@ -82,13 +82,13 @@ collection: article
 
 <div class="container">
 	<!-- Search -->
-	
+
 
 	<!-- Categories -->
-	
+
 	<div class="tags">
 		<h3>Categories </h3>
-		<a href="/blog" title="Show all categories">
+		<a href="/blog/" title="Show all categories">
 			<div class="tag tag--default {% if page.category == 'all' %}active{% endif %}">All</div>
 		</a>
 

--- a/_layouts/download-3.html
+++ b/_layouts/download-3.html
@@ -54,7 +54,7 @@ layout: default
 			{% endfor %}
 
 			<p class="previous-releases">
-				<strong class="previous-releases-featured">For the latest version, <a href="/download/windows" class="set-os-download-url" data-version="4">Download Godot 4</a>.</strong>
+				<strong class="previous-releases-featured">For the latest version, <a href="/download/windows/" class="set-os-download-url" data-version="4">Download Godot 4</a>.</strong>
 				<br>
 				You can find previous releases in the <a href="/download/archive">download archive</a>.
 			</p>

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -200,7 +200,7 @@ layout: default
 				<img width="24" height="24" src="/assets/images/platforms/macos.svg" title="macOS" alt="macOS" />
 				<span>macOS</span>
 			</a>
-			<a href="/download/windows" class="tab title-font {% if page.platform == 'Windows' %} active {% endif %}">
+			<a href="/download/windows/" class="tab title-font {% if page.platform == 'Windows' %} active {% endif %}">
 				<img width="24" height="24" src="/assets/images/platforms/windows.svg" title="Windows" alt="Windows" />
 				<span>Windows</span>
 			</a>
@@ -343,7 +343,7 @@ layout: default
 		<p class="thankyou-donate">
 			Godot exists thanks to people like you! Consider supporting continued development of the engine with a donation.
 		</p>
-		<a href="/donate" class="btn btn-donate">
+		<a href="/donate/" class="btn btn-donate">
 			Make a Donation
 		</a>
 

--- a/_layouts/more.html
+++ b/_layouts/more.html
@@ -14,22 +14,22 @@ current_tab: ''
 		</div>
 
 		<div class="tabs">
-			<a href="/contact" class="title-font {% if page.current_tab == 'contact' %} active {% endif %}">
+			<a href="/contact/" class="title-font {% if page.current_tab == 'contact' %} active {% endif %}">
 				Contact
 			</a>
-			<a href="/code-of-conduct" class="title-font {% if page.current_tab == 'code-of-conduct' %} active {% endif %}">
+			<a href="/code-of-conduct/" class="title-font {% if page.current_tab == 'code-of-conduct' %} active {% endif %}">
 				Code of Conduct
 			</a>
-			<a href="/privacy-policy" class="title-font {% if page.current_tab == 'privacy-policy' %} active {% endif %}">
+			<a href="/privacy-policy/" class="title-font {% if page.current_tab == 'privacy-policy' %} active {% endif %}">
 				Privacy
 			</a>
-			<a href="/governance" class="title-font {% if page.current_tab == 'governance' %} active {% endif %}">
+			<a href="/governance/" class="title-font {% if page.current_tab == 'governance' %} active {% endif %}">
 				Governance
 			</a>
-			<a href="/teams" class="title-font {% if page.current_tab == 'teams' %} active {% endif %}">
+			<a href="/teams/" class="title-font {% if page.current_tab == 'teams' %} active {% endif %}">
 				Teams
 			</a>
-			<a href="/license" class="title-font {% if page.current_tab == 'license' %} active {% endif %}">
+			<a href="/license/" class="title-font {% if page.current_tab == 'license' %} active {% endif %}">
 				License
 			</a>
 		</div>

--- a/_layouts/showcase-item.html
+++ b/_layouts/showcase-item.html
@@ -45,7 +45,7 @@ layout: default
 		<div class="main">
 
 			<div style="margin: 1.25rem 0">
-				<a href="/showcase"><strong>&lt;</strong>&nbsp;&nbsp;Back to showcase</a>
+				<a href="/showcase/"><strong>&lt;</strong>&nbsp;&nbsp;Back to showcase</a>
 			</div>
 
 			<h1 class="intro-title">{{ page.title }}</h1>

--- a/collections/_event/fosdem-2017.md
+++ b/collections/_event/fosdem-2017.md
@@ -41,7 +41,7 @@ cover_image: ""
 
 <p>
 	Want to help us with the stand, designing or ordering goodies and stand material (table cloth, kakemono,
-	etc.)? Get in touch with us on <a href="/community">one of the community channels</a> (especially IRC ;)).
+	etc.)? Get in touch with us on <a href="/community/">one of the community channels</a> (especially IRC ;)).
 </p>
 
 <h4>Escoria talk in the Open Game Development track</h4>

--- a/pages/404.html
+++ b/pages/404.html
@@ -87,9 +87,9 @@ description: "The requested resource is not available on the server."
 				<p>Or visit:</p>
 				<ul>
 					<li><a href="/">Home</a></li>
-					<li><a href="/download">Download</a></li>
+					<li><a href="/download/windows/" class="set-os-download-url">Download</a></li>
 					<li><a href="https://docs.godotengine.org/en/stable/">Documentation</a></li>
-					<li><a href="/community">Community</a></li>
+					<li><a href="/community/">Community</a></li>
 				</ul>
 			</div>
 		</div>
@@ -98,3 +98,26 @@ description: "The requested resource is not available on the server."
 					href="https://github.com/godotengine/godot-website/">issue on GitHub</a>.</p>
 		</div>
 	</div>
+
+	<script>
+		document.addEventListener('DOMContentLoaded', () => {
+			// Update any download link to point to identified user's OS.
+			const links = document.querySelectorAll('.set-os-download-url');
+			for (let i = 0; i < links.length; i++) {
+				const link = links[i];
+				let link_slug = 'download';
+				if ('version' in link.dataset && link.dataset['version'] === '3') {
+					link_slug = 'download/3.x';
+				}
+
+				let link_platform = 'windows';
+				if (navigator.platform.indexOf('Mac') !== -1) {
+					link_platform = 'macos';
+				} else if (navigator.platform.indexOf('Linux') !== -1) {
+					link_platform = 'linux';
+				}
+
+				link.href = `/${link_slug}/${link_platform}/`;
+			}
+		});
+	</script>

--- a/pages/community/community.html
+++ b/pages/community/community.html
@@ -131,7 +131,7 @@ layout: default
 			<h1 class="intro-title">Community</h1>
 			<p class="small">
 				Godot has a very active community across multiple channels.<br>
-				By joining Godot communities, you agree to follow Godot's <a href="/code-of-conduct">Code of Conduct</a>.
+				By joining Godot communities, you agree to follow Godot's <a href="/code-of-conduct/">Code of Conduct</a>.
 			</p>
 		</div>
 	</div>
@@ -140,7 +140,7 @@ layout: default
 <div class="container community-list">
 	<div class="community-stack">
 		<div class="community-block">
-			<a href="/events" class="card base-padding" id="events">
+			<a href="/events/" class="card base-padding" id="events">
 				<div>
 					<h3>Events</h3>
 					<p>Upcoming community and past events.</p>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -14,7 +14,7 @@ redirect_from:
 	<h3 class="title">Support</h3>
 	<p>
 		If you have a problem learning Godot or need help, please first
-		<a href="/community">use the various community channels</a>.
+		<a href="/community/">use the various community channels</a>.
 		Godot developers are busy working in making Godot better, so they can't
 		always answer questions. They will, however, be glad to assist you if
 		you can't get an answer from conventional means.
@@ -64,7 +64,7 @@ redirect_from:
 	<h3 class="title" id="plc">Project Leadership Committee (PLC)</h3>
 	<p style="font-style: italic">
 		Information about the Project Leadership Committee was moved to the
-		<a href="/governance">Governance</a> page.
+		<a href="/governance/">Governance</a> page.
 	</p>
 
 	<h3 class="title" id="devs">Godot&nbsp;Engine team</h3>

--- a/pages/download.html
+++ b/pages/download.html
@@ -11,7 +11,7 @@ redirect_from:
 <div style="padding: 16px 32px">
 	<h3>Redirecting...</h3>
 	<p>
-		If you are not being redirected automatically, <a href="/download/windows" class="set-os-download-url">click here</a>.
+		If you are not being redirected automatically, <a href="/download/windows/" class="set-os-download-url">click here</a>.
 	</p>
 </div>
 
@@ -21,6 +21,6 @@ redirect_from:
 	} else if (navigator.platform.indexOf('Linux') !== -1) {
 		window.location = "/download/linux";
 	} else { // default to windows
-		window.location = "/download/windows";
+		window.location = "/download/windows/";
 	}
 </script>

--- a/pages/education.html
+++ b/pages/education.html
@@ -31,17 +31,17 @@ layout: default
 	<div class="question">
 		<h3>Can I teach Godot in my classroom?</h3>
 		<p>Godot&nbsp;Engine is <a href="https://en.wikipedia.org/wiki/Free_and_open_source_software">free and open source
-				software</a> released under the permissive <a href="/license">MIT license</a>.<br>
+				software</a> released under the permissive <a href="/license/">MIT license</a>.<br>
 			You can use Godot in your classroom without any restrictions and with zero licensing
 			costs.
 		</p>
-		<p>You can read more about <a href="/license">our license here</a>.</p>
+		<p>You can read more about <a href="/license/">our license here</a>.</p>
 	</div>
 
 	<div class="question">
 		<h3>Will the Godot project sign a services agreement provided by my institution?</h3>
 		<p>The Godot Engine project is unable to accept any terms and conditions outside of the MIT license, nor will it
-			provide warranties or representations about the Godot Engine outside those of the <a href="/license">MIT
+			provide warranties or representations about the Godot Engine outside those of the <a href="/license/">MIT
 				license</a>.</p>
 		<p>As a free and open source project, Godot is not backed by a corporation or any individual. Accordingly, it
 			doesn't
@@ -62,7 +62,7 @@ layout: default
 			from
 			its users. The network requests include the bare minimum amount of information required to do an online search and
 			transmit substantially less information than most internet browsing will.</p>
-		</p> For more information, please see <a href="/privacy-policy">our privacy policy here</a>
+		</p> For more information, please see <a href="/privacy-policy/">our privacy policy here</a>
 	</div>
 
 	<div class="question">

--- a/pages/features.html
+++ b/pages/features.html
@@ -369,7 +369,7 @@ layout: default
 			<div class="showcase-flip-right"></div>
 		</div>
 
-		<a href="/showcase" class="btn btn-flat btn-flat-white btn-flat-frosted btn-see-showcase">
+		<a href="/showcase/" class="btn btn-flat btn-flat-white btn-flat-frosted btn-see-showcase">
 			See more projects made with Godot
 		</a>
 	</div>

--- a/pages/governance.html
+++ b/pages/governance.html
@@ -67,7 +67,7 @@ current_tab: "governance"
 	<p>
 		At the end of each operating year the Foundation publishes audited financial statements outlining funds received, and how such funds were used in that year. Financial reports take time to prepare and audit, as such they are not available immediately at year end. They are available on the <a href="https://godot.foundation">Foundation's website</a> as soon as feasible after they are prepared.
 	</p>
-	
+
 	<h3 id="technical-decisions">Technical decisions</h3>
 	<p>Technical decisions are made by Area Owners and the project leaders. Godot has the following established roles:</p>
 	<h4 id="leadership">Leadership</h4>
@@ -81,7 +81,7 @@ current_tab: "governance"
 
 	<h4 id="teams-and-area-owners">Teams and area owners</h4>
 	<p>
-		<a href="/teams">Engine teams</a> are groups of contributors interested in a specific area of the engine. Teams provide a way for contributors to have focused discussions with other people with similar expertise and interests. The opinion and expertise of team members is valued in discussions, but ultimately the authority over an area of the engine belongs solely to the area owner and the project leadership. Area owners are entrusted with final say for code merges in their areas. Area owners are trusted contributors who are chosen by the project leadership and have shown knowledge of the specific area of the engine and the engine's philosophy as a whole.
+		<a href="/teams/">Engine teams</a> are groups of contributors interested in a specific area of the engine. Teams provide a way for contributors to have focused discussions with other people with similar expertise and interests. The opinion and expertise of team members is valued in discussions, but ultimately the authority over an area of the engine belongs solely to the area owner and the project leadership. Area owners are entrusted with final say for code merges in their areas. Area owners are trusted contributors who are chosen by the project leadership and have shown knowledge of the specific area of the engine and the engine's philosophy as a whole.
 	</p>
 	<p>
 		In practice, area owners aim for consensus among contributors, especially among the relevant team. The "rule of thumb" is to not merge code if significant disputes exist over a change. However the final decision still remains with the area owner. The Godot project strives for rich, public, technical discussions where anyone can contribute and agree on the way to move forward. Additionally, the leadership and area owners consult with other contributors and the community as much as possible every time new features and improvements are planned.

--- a/pages/home.html
+++ b/pages/home.html
@@ -26,7 +26,7 @@ layout: default
 	.main-download-links .btn-download {
 		width: 100%;
 	}
-	
+
 	.main-download-links .download-3 {
 		text-align: center;
 		color: #ffffffd6;
@@ -34,7 +34,7 @@ layout: default
 		font-weight: 100;
 		font-size: 15px;
 	}
-	
+
 	.main-download-links .download-3 a {
 		color: inherit;
 		text-decoration-color: inherit;
@@ -43,7 +43,7 @@ layout: default
 	.main-download-links .download-3 a:hover {
 		color: white;
 	}
-	
+
 	@media (max-width: 900px) {
 		.main-download {
 			align-items: center;
@@ -184,13 +184,13 @@ layout: default
 				{% assign stable_version_4 = site.data.versions | find: "featured", "4" %}
 
 				<div class="main-download-links">
-					<a href="/download/windows" class="btn btn-download set-os-download-url" data-version="4"
+					<a href="/download/windows/" class="btn btn-download set-os-download-url" data-version="4"
 						title="Download the latest version of Godot 4">
 						<div class="download-title">Download Latest</div>
 						<div class="download-hint">{{ stable_version_4.name }}</div>
 					</a>
 
-					<span class="download-3">Looking for <a href="/download/windows" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
+					<span class="download-3">Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
 				</div>
 			</div>
 		</div>
@@ -235,7 +235,7 @@ layout: default
 				{% endif %}
 				{% endfor %}
 				<div class="button-container">
-					<a href="/blog" class="btn no-margin">More News</a>
+					<a href="/blog/" class="btn no-margin">More News</a>
 				</div>
 			</div>
 		</div>
@@ -336,7 +336,7 @@ layout: default
 	</div>
 
 	<div class="features-learn-more">
-		<a href="/features" class="btn btn-flat btn-flat-white btn-flat-frosted">Learn more about using Godot</a>
+		<a href="/features/" class="btn btn-flat btn-flat-white btn-flat-frosted">Learn more about using Godot</a>
 	</div>
 </section>
 

--- a/pages/license.html
+++ b/pages/license.html
@@ -42,7 +42,7 @@ current_tab: "license"
 		documentation.
 	</p>
 	<p>
-		The Godot&nbsp;Engine developers consider that a link to this page (<a href="/license">godotengine.org/license</a>)
+		The Godot&nbsp;Engine developers consider that a link to this page (<a href="/license/">godotengine.org/license</a>)
 		in your game documentation or credits would be an
 		acceptable way to satisfy the license terms.
 	</p>

--- a/pages/privacy-policy.html
+++ b/pages/privacy-policy.html
@@ -22,7 +22,7 @@ current_tab: "privacy-policy"
 	<p>Your privacy is important to Godot. To better protect your privacy and to comply
 		with various laws and regulations, we have provided this Statement explaining our information practices and the
 		choices you can make about the way your personal information is collected, used and disclosed. To make this
-		Statement easy to find, we have made it available on our <a href="/privacy-policy">homepage</a> and at many of the
+		Statement easy to find, we have made it available on our <a href="/privacy-policy/">homepage</a> and at many of the
 		locations where personally-identifiable information may be requested.</p>
 
 	<h3 class="title">The Information We Collect</h3>
@@ -36,7 +36,7 @@ current_tab: "privacy-policy"
 		<li>you visit the Godot web site (<a href="/">godotengine.org</a>);</li>
 		<li>you access the Asset Library in the Godot editor application to browse or download assets;</li>
 		<li>you sign up as a Godot Patreon (<a href="https://patreon.com/godotengine">https://patreon.com/godotengine</a>)
-			or otherwise donate to Godot (<a href="/donate">https://godotengine.org/donate</a>);</li>
+			or otherwise donate to Godot (<a href="/donate/">https://godotengine.org/donate</a>);</li>
 		<li>you sign up and log in to an account on the Godot Chat platform (<a
 				href="https://chat.godotengine.org">https://chat.godotengine.org</a>), and use it to participate in private and
 			public discussions;</li>
@@ -277,7 +277,7 @@ current_tab: "privacy-policy"
 
 	<ul>
 		<li>Software Freedom Conservancy's Privacy Policy, used under Attribute-Share Alike 4.0. <a
-				href="https://sfconservancy.org/privacy-policy">https://sfconservancy.org/privacy-policy</a></li>
+				href="https://sfconservancy.org/privacy-policy/">https://sfconservancy.org/privacy-policy</a></li>
 		<li>Red Hat's Privacy Policy for the Fedora Project, used under Attribution-Share Alike 3.0 Unported. <a
 				href="https://fedoraproject.org/wiki/Legal:PrivacyPolicy">https://fedoraproject.org/wiki/Legal:PrivacyPolicy</a>
 		</li>

--- a/pages/showcase.html
+++ b/pages/showcase.html
@@ -13,8 +13,8 @@ layout: default
 			<h1 class="intro-title">Showcase</h1>
 		</div>
 		<div class="tabs">
-			<a href="/features" class="title-font ">Features</a>
-			<a href="/showcase" class="title-font  active ">Showcase</a>
+			<a href="/features/" class="title-font ">Features</a>
+			<a href="/showcase/" class="title-font  active ">Showcase</a>
 		</div>
 	</div>
 </div>

--- a/pages/teams.html
+++ b/pages/teams.html
@@ -25,10 +25,10 @@ current_tab: "teams"
 
 	<p>
 		If you want to get in touch, use the link to each team's chat channel on the Godot&nbsp;Engine Contributors chat
-		after the team's names (see <a href="/community">Community</a>).<br>
+		after the team's names (see <a href="/community/">Community</a>).<br>
 		For general development discussions which may not fit a specific team channel, use the general purpose <a
 			href="https://chat.godotengine.org/channel/devel">#devel</a> channel.<br>
-		For general enquiries, private or security related matters, have a look at the <a href="/contact">Contact</a> page.
+		For general enquiries, private or security related matters, have a look at the <a href="/contact/">Contact</a> page.
 	</p>
 
 


### PR DESCRIPTION
The web server redirects pages like `/blog` to `/blog/`, which slows down navigation a bit. This can be avoided by fully spelling out the URLs in internal links.

This also adds the download link OS matching to the 404 page, and fixes the asset library link in the footer when hosting the site locally (so it points to godotengine.org).

I've tested this locally and navigation still works as expected.
