### PR TITLE
Simplify the version.json output

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,23 @@
 ---
 ---
-
-{{ site.data.versions | jsonify | replace: "/article/", "https://godotengine.org/article/" }}
+[
+	{% for v in site.data.versions %}
+		{
+			"name": "{{ v.name }}",
+			"releases": [
+				{
+					"name": "{{ v.flavor }}",
+					"release_date": "{{ v.release_date }}",
+					"release_notes": "{{ v.release_notes | replace: "/article/", "https://godotengine.org/article/" }}"
+				},
+				{% for r in v.releases %}
+				{
+					"name": "{{ r.name }}",
+					"release_date": "{{ r.release_date }}",
+					"release_notes": "{{ r.release_notes | replace: "/article/", "https://godotengine.org/article/" }}"
+				},
+				{% endfor %}
+			]
+		},
+	{% endfor %}
+	]


### PR DESCRIPTION
Instead of transforming the entire `_data/versions.yml` file into a json one, this creates a custom structure that will merge the "flavor" release with the rest of the releases in a simpler array.

To compare both versions:

## Current:
![image](https://github.com/godotengine/godot-website/assets/2206700/d31d6956-cc9a-4a81-98a9-f20b792d6b06)
## This PR:
![image](https://github.com/godotengine/godot-website/assets/2206700/3d0d9668-dbb6-47c9-b069-a1112a7466ae)
