### PR TITLE
Fix relative path issue with `minify`

### DIFF
--- a/_plugins/minify-assets.rb
+++ b/_plugins/minify-assets.rb
@@ -1,8 +1,11 @@
+require 'pathname'
+
 # Minify assets after each build
 Jekyll::Hooks.register :site, :post_write do
   puts "Minifying assets"
   # Project path
-  site_path_from = File.join(Dir.pwd, "_site")
-  site_path_to = Dir.pwd
-  `minify -r -o #{site_path_to} #{site_path_from}`
+  Pathname here = Pathname.new(Dir.pwd)
+  Pathname from = Pathname.new(File.join(Dir.pwd, "_site"))
+  Pathname to = Pathname.new(Dir.pwd)
+  `minify -r -o #{to.relative_path_from(here)} #{from.relative_path_from(here)}`
 end


### PR DESCRIPTION
The minify generation had the following error on the github action:
```
Minifying assets
ERROR: stat .//home/runner/work/godot-website/godot-website/_site: no such file or directory
                    done in 8.002 seconds.
```

This now uses ruby `pathname` library to get a relative path.

Follow-up of #863
Fixes #860 