### PR TITLE
Drop 'Blender ESCN exporter' from download pages

### DIFF
--- a/_layouts/download-3.html
+++ b/_layouts/download-3.html
@@ -6,7 +6,7 @@ layout: default
 {% include header.html %}
 
 <link rel="stylesheet" href="/assets/css/transparent-nav.css">
-<link rel="stylesheet" href="/assets/css/download.css?2">
+<link rel="stylesheet" href="/assets/css/download.css?3">
 <style>
 	.digital-stores .digital-store-list {
 		grid-template-columns: 1fr 1fr;
@@ -261,15 +261,6 @@ layout: default
 						{% unless aar_library_info.caption == empty %} {{ aar_library_info.caption }}{% endunless %}
 					</a>
 				</p>
-			</div>
-
-			<div class="other-download-card">
-				<h3>Blender ESCN exporter</h3>
-				<p>
-					Blender add-on to export scenes to Godot's scene format directly.<br>
-					Godot 3 also supports glTF 2.0 and OBJ.
-				</p>
-				<a href="https://github.com/godotengine/godot-blender-exporter">Godot Blender exporter</a>
 			</div>
 
 		</div>

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -6,7 +6,7 @@ layout: default
 {% include header.html %}
 
 <link rel="stylesheet" href="/assets/css/transparent-nav.css">
-<link rel="stylesheet" href="/assets/css/download.css?2">
+<link rel="stylesheet" href="/assets/css/download.css?3">
 <style>
 	.hero {
 		background-image: url('/assets/download/download-background-4.x.webp');
@@ -248,15 +248,6 @@ layout: default
 						{% unless aar_library_info.caption == empty %} - {{ aar_library_info.caption }}{% endunless %}
 					</a>
 				</p>
-			</div>
-
-			<div class="other-download-card">
-				<h3>Blender ESCN exporter</h3>
-				<p>
-					Blender add-on to export scenes to Godot's scene format directly.<br>
-					Godot 3 also supports glTF 2.0 and OBJ.
-				</p>
-				<a href="https://github.com/godotengine/godot-blender-exporter">Godot Blender exporter</a>
 			</div>
 
 		</div>

--- a/assets/css/download.css
+++ b/assets/css/download.css
@@ -155,7 +155,7 @@
 }
 @media (min-width: 768px) {
     .other-download {
-        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
     }
 }
 


### PR DESCRIPTION
[Blender ESCN exporter](https://github.com/godotengine/godot-blender-exporter) is unmaintained and experimental with [51 open bug tickets][openbugs].

As discussed in #713, drop the prominent mention on the download pages.

Fixes #713

I haven't run it locally (no Ruby/Jekyll env), but I tested with DOM changes directly.

The CSS break point `768px` looks better now that it's two columns, so no need to change it despite now being two instead of three layout/card columns.

[openbugs]: https://github.com/godotengine/godot-blender-exporter/issues?q=label%3A%22bug%22+is%3Aopen+sort%3Aupdated-desc