### PR TITLE
Link to Linux desktop integration instructions (#802)

### DIFF
--- a/_layouts/download-3.html
+++ b/_layouts/download-3.html
@@ -369,6 +369,13 @@ layout: default
 				<a href="https://godotengine.org/asset-library/asset?category=10&support[official]=1">official demo projects</a>
 				showcasing some of the engine features.
 			</li>
+			<li>
+				A guide to install Godot on
+				<a href="https://docs.godotengine.org/en/stable/about/faq.html#linux">Linux</a>,
+				<a href="https://docs.godotengine.org/en/stable/about/faq.html#windows">Windows</a>,
+				and
+				<a href="https://docs.godotengine.org/en/stable/about/faq.html#macos">macOS</a>.
+			</li>
 		</ul>
 
 		<div class="btn-back-to-downloads">

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -356,6 +356,13 @@ layout: default
 				<a href="https://godotengine.org/asset-library/asset?category=10&support[official]=1">official demo projects</a>
 				showcasing some of the engine features.
 			</li>
+			<li>
+				A guide to install Godot on
+				<a href="https://docs.godotengine.org/en/stable/about/faq.html#linux">Linux</a>,
+				<a href="https://docs.godotengine.org/en/stable/about/faq.html#windows">Windows</a>,
+				and
+				<a href="https://docs.godotengine.org/en/stable/about/faq.html#macos">macOS</a>.
+			</li>
 		</ul>
 
 		<div class="btn-back-to-downloads">


### PR DESCRIPTION
Add a guide to install Godot on Linux, Windows, and macOS.