### PR TITLE
Upload site as artifact

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,3 +31,10 @@ jobs:
 
     - name: Build the static website
       run: bundle exec jekyll build
+
+    # Upload resulting "_site" directory as artifact
+    
+    - uses: actions/upload-artifact@v4
+      with:
+        name: site
+        path: _site/


### PR DESCRIPTION
This adds a step to the GitHub Action for PRs to upload the resulting `_site` directory as an artifact. This allows to easily inspect the generated site for pull requests.