### PR TITLE
Update download page to add Windows arm64 binaries

### DIFF
--- a/_data/download_configs.yml
+++ b/_data/download_configs.yml
@@ -10,10 +10,8 @@ defaults:
       macos.universal: macos.universal.zip
       windows.64: win64.exe.zip
       windows.32: win32.exe.zip
+      windows.arm64: windows_arm64.exe.zip
       web: web_editor.zip
-    extras:
-      aar_library: template_release.aar
-
     mono:
       templates: mono_export_templates.tpz
       editor:
@@ -24,6 +22,9 @@ defaults:
         macos.universal: mono_macos.universal.zip
         windows.64: mono_win64.zip
         windows.32: mono_win32.zip
+        windows.arm64: mono_windows_arm64.zip
+    extras:
+      aar_library: template_release.aar
 
   3:
     templates: export_templates.tpz
@@ -107,9 +108,6 @@ overrides:
         windows.64: win64.exe.zip
         windows.32: win32.exe.zip
         web: web_editor.zip
-      extras:
-        aar_library: template_release.aar
-
       mono:
         templates: mono_export_templates.tpz
         editor:
@@ -118,3 +116,35 @@ overrides:
           macos.universal: mono_macos.universal.zip
           windows.64: mono_win64.zip
           windows.32: mono_win32.zip
+      extras:
+        aar_library: template_release.aar
+
+  # Godot 4.3 RC 1 introduced Windows ARM builds.
+  - version: 4
+    range:
+      - "4.2-beta5"
+      - "4.3-beta3"
+    config:
+      templates: export_templates.tpz
+      editor:
+        android.apk: android_editor.apk
+        linux.64: linux.x86_64.zip
+        linux.32: linux.x86_32.zip
+        linux.arm64: linux.arm64.zip
+        linux.arm32: linux.arm32.zip
+        macos.universal: macos.universal.zip
+        windows.64: win64.exe.zip
+        windows.32: win32.exe.zip
+        web: web_editor.zip
+      mono:
+        templates: mono_export_templates.tpz
+        editor:
+          linux.64: mono_linux_x86_64.zip
+          linux.32: mono_linux_x86_32.zip
+          linux.arm64: mono_linux_arm64.zip
+          linux.arm32: mono_linux_arm32.zip
+          macos.universal: mono_macos.universal.zip
+          windows.64: mono_win64.zip
+          windows.32: mono_win32.zip
+      extras:
+        aar_library: template_release.aar

--- a/_data/download_platforms.yml
+++ b/_data/download_platforms.yml
@@ -14,64 +14,73 @@
 
 - name: "android.apk"
   title: "Android"
-  caption: "Universal APK (ARM64 + ARMv7 + x86_64 + x86)"
+  caption: "Universal APK"
   tags:
     - APK download
-    - ARM64/v7
-    - x86 (64 & 32 bit)
+    - arm64
+    - arm32
+    - x86_64
+    - x86_32
 
 - name: "android.playstore"
   title: "Android"
-  caption: "Play Store Universal (ARM64 + ARMv7 + x86_64 + x86)"
+  caption: "Play Store Universal"
   tags:
     - Play Store
-    - ARM64/v7
-    - x86 (64 & 32 bit)
+    - arm64
+    - arm32
+    - x86_64
+    - x86_32
 
 - name: "linux.32"
   title: "Linux"
-  caption: "Standard (x86)"
+  caption: "Standard (x86_32)"
   tags:
+    - x86_32
     - 32 bit
 
 - name: "linux.64"
   title: "Linux"
   caption: "Standard (x86_64)"
   tags:
+    - x86_64
     - 64 bit
 
 - name: "linux.arm32"
   title: "Linux"
-  caption: "Standard (ARM32)"
+  caption: "Standard (arm32)"
   tags:
-    - ARM32
+    - arm32
     - 32 bit
 
 - name: "linux.arm64"
   title: "Linux"
-  caption: "Standard (ARM64)"
+  caption: "Standard (arm64)"
   tags:
-    - ARM64
+    - arm64
     - 64 bit
 
 - name: "linux_server.64"
   title: "Linux Server"
   caption: "Standard (x86_64)"
   tags:
+    - x86_64
     - 64 bit
 
 - name: "linux_server.headless.64"
   title: "Linux Server"
   caption: "Headless (x86_64)"
   tags:
+    - x86_64
     - 64 bit
     - Headless
 
 - name: "macos.universal"
   title: "macOS"
-  caption: "Universal (x86_64 + Apple Silicon)"
+  caption: "Standard"
   tags:
-    - Intel/Apple Silicon
+    - Apple Silicon
+    - x86_64
     - 64 bit
 
 - name: "web"
@@ -83,12 +92,21 @@
 
 - name: "windows.32"
   title: "Windows"
-  caption: "Standard (x86)"
+  caption: "Standard (x86_32)"
   tags:
+    - x86_32
     - 32 bit
 
 - name: "windows.64"
   title: "Windows"
   caption: "Standard (x86_64)"
   tags:
+    - x86_64
+    - 64 bit
+
+- name: "windows.arm64"
+  title: "Windows"
+  caption: "Standard (arm64)"
+  tags:
+    - arm64
     - 64 bit


### PR DESCRIPTION
This PR:
- adds Windows ARM64 links
  - supports 4.3.rc1 links
- renames x86_64 to x86-64
- ~~renames build links to more standard names for 4.3.rc2 and onwards~~
  - ~~Standard:~~
    - ~~linux.64: linux_x86-64.zip _(instead of linux.x86_64.zip)_~~
    - ~~linux.32: linux_x86-32.zip _(instead of linux.x86_32.zip)_~~
    - ~~linux.arm64: linux_arm64.zip _(instead of linux.arm64.zip)_~~
    - ~~linux.arm32: linux_arm32.zip _(instead of linux.arm32.zip)_~~
    - ~~macos.universal: macos_universal.zip _(instead of macos.universal.zip)_~~
    - ~~windows.64: windows_x86-64.zip _(instead of win64.exe.zip)_~~
    - ~~windows.32: windows_x86-32.zip _(instead of win32.exe.zip)_~~
    - ~~windows.arm64: windows_arm64.zip _(instead of windows_arm64.exe.zip)_~~
  - ~~Mono:~~
    - ~~macos.universal: mono_macos_universal.zip _(instead of mono_macos.universal.zip)_~~
    - ~~windows.64: mono_windows_x86-64.zip _(instead of mono_win64.zip)_~~
    - ~~windows.32: mono_windows_x86-32.zip _(instead of mono_win32.zip)_~~
- adds x86 and x86-64 tags
- does some reordering/cleanup in download_configs.yml
  - removed the weird space between extras and mono
  - put extras after mono
- removes "(x86_64 - Apple Silicon)" from macOS build name
- updates Android tags

~~Commit https://github.com/godotengine/godot-website/pull/885/commits/48fe40b4b3bf809c292fa62ffcf2ad71c4015aa0 renames mono to dotnet _(dotnet.windows.x86_64.zip instead of mono_windows_x86_64.zip)_. Easily revertable if it's not what we want.~~ _Removed because `dotnet` is reserved by the dotnet team for the module._

| Before | After |
| ---- | ---- |
| <img width="1184" alt="Capture d’écran, le 2024-07-29 à 11 05 51" src="https://github.com/user-attachments/assets/9009d3f4-4d3c-4ed2-b0df-1716996f18f8"> | <img width="1184" alt="Capture d’écran, le 2024-07-29 à 11 09 14" src="https://github.com/user-attachments/assets/b146d704-d5ca-4746-b806-21a56f514440"> |