### PR TITLE
Add links to the ARM binaries to the main download page.

### DIFF
--- a/collections/_download/linux.md
+++ b/collections/_download/linux.md
@@ -9,12 +9,22 @@ downloads:
 
   - platform: "linux.32"
 
+  - platform: "linux.arm64"
+
+  - platform: "linux.arm32"
+
   - platform: "linux.64"
     mono: true
     featured: true
     featured_flavor: .NET
 
   - platform: "linux.32"
+    mono: true
+
+  - platform: "linux.arm64"
+    mono: true
+
+  - platform: "linux.arm32"
     mono: true
 
 redirect_from:

--- a/collections/_download/windows.md
+++ b/collections/_download/windows.md
@@ -6,10 +6,10 @@ platform: Windows
 downloads:
   - platform:  "windows.64"
     featured: true
-    tags:
-      - 64 bit
 
   - platform:  "windows.32"
+
+  - platform:  "windows.arm64"
 
   - platform:  "windows.64"
     mono: true
@@ -17,6 +17,9 @@ downloads:
     featured_flavor: .NET
 
   - platform:  "windows.32"
+    mono: true
+
+  - platform:  "windows.arm64"
     mono: true
 
 redirect_from:


### PR DESCRIPTION
Adds missing links to ARM binaries to the main download page (currently visible only on the release archive page).

<img width="626" alt="Screenshot 2024-08-15 at 14 14 57" src="https://github.com/user-attachments/assets/de7a6252-5a22-4de2-aae6-24a265c8c4f9">
<img width="626" alt="Screenshot 2024-08-15 at 14 15 26" src="https://github.com/user-attachments/assets/0a02ad81-34cf-45fe-9eb7-4d470ba0ecbe">
