### PR TITLE
Make `/releases` redirect to `/releases/4.3/`

### DIFF
--- a/pages/releases/index.html
+++ b/pages/releases/index.html
@@ -1,0 +1,5 @@
+---
+permalink: /releases/index.html
+redirect_to:
+ - /releases/4.3/
+---


### PR DESCRIPTION
Currently, if you go to https://godotengine.org/releases, you'll end up on a 404 page. This PR redirects this page to https://godotengine.org/releases/4.3 for the time being.