### PR TITLE
Improve .NET note on the main download page.

### DIFF
--- a/collections/_download/windows.md
+++ b/collections/_download/windows.md
@@ -27,7 +27,7 @@ redirect_from:
 
 content_note: |
   <p>
-    <strong>Note:</strong> The 32-bit .NET binaries do not run on 64-bit Windows systems at the time being. Make sure to export 64-bit .NET binaries for your 64-bit target platforms.
+    <strong>Note:</strong> The .NET binaries run only on Windows systems with the matching architecture, running under emulation is not supported at the time being. Make sure to export .NET binaries for all target platforms (x86_64, x86_32, and arm64).
   </p>
 
 content_instructions: |


### PR DESCRIPTION
A small update to the .NET note, now we have support for arm64 the same limitation applies to running x86_32 and x86_64 .NET apps on arm64, not only to 32-bit apps on 64-bit windows.