### PR TITLE
Fix missing image in 4.3 download page

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,7 +1,7 @@
 - name: "4.3"
   flavor: "stable"
   release_date: "15 August 2024"
-  release_notes: "/releases/4.3/"
+  release_notes: "/article/godot-4-3-a-shared-effort/"
   featured: "4"
   releases:
     - name: "rc3"


### PR DESCRIPTION
See issue [mentioned in the Godot developers chat](https://chat.godotengine.org/channel/general?msg=TwkCYxvofDeQL3g9v).

![image](https://github.com/user-attachments/assets/da5185ba-96db-4f35-b985-a9000730f589)
