### PR TITLE
Fix link for Standardized hand, body, and face tracking

### DIFF
--- a/pages/releases/4.3.html
+++ b/pages/releases/4.3.html
@@ -1408,7 +1408,7 @@ authors_list: "0x0ACB,8,8|0xafbf,1,1|20kdc,2,2|2nafish117,1,1|31,3,3|398utubzyt,
 								</div>
 								<div class="c-link"
 									data-contributors="Malcolmnixon,dsnopek,BastiaanOlij"
-									data-read-more="https://github.com/godotengine/godot/pulls?q=88312,88639,88798"
+									data-read-more="https://github.com/godotengine/godot/pulls?q=88312+88639+88798"
 								></div>
 							</div>
 						</div>


### PR DESCRIPTION
The "read more" redirect to github issues without showing any pull requests.