### PR TITLE
Fixes contrast issue detailed in https://github.com/godotengine/godot-website/issues/913

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -62,7 +62,7 @@
   --download-hero-color: hsla(0, 0%, 100%, 0.9);
   --download-main-details-color: #f1f1f1;
   --download-table-color: rgba(22, 22, 22, 0.08);
-  --platform-note-background-color: rgba(48, 86, 210, 0.9);
+  --platform-note-background-color: rgba(212, 237, 255, 0.9);
   --platform-code-background-color: #e5ebf1;
   --download-mono-background-color: rgba(43, 58, 76, 0.82);
 
@@ -144,7 +144,7 @@
     --download-hero-color: hsla(0, 0%, 100%, 0.9);
     --download-main-details-color: #f1f1f1;
     --download-table-color: rgba(0, 0, 0, 0.2);
-    --platform-note-background-color: rgba(255, 255, 255, 0.9);
+    --platform-note-background-color: rgba(150, 150, 150, 0.9);
     --platform-code-background-color: #282b2e;
     --download-mono-background-color: rgba(132, 151, 174, 0.68);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-website/issues/913


| Browser Theme | Old (contrast issues) | New (fixed contrast issues) |
|--------|--------|--------|
| Light Mode  | ![image](https://github.com/user-attachments/assets/bd438c65-1e2a-47e0-bde9-7a77c57ec1ca) | ![image](https://github.com/user-attachments/assets/2aa8b6d6-aeff-4bcb-828f-033536ffd0ab) |
| Dark Mode | ![image](https://github.com/user-attachments/assets/48fddb27-ec20-4e07-b6fa-83004ede2693) | ![image](https://github.com/user-attachments/assets/d6c8fd7d-8b70-4f7c-b5a9-d6a5494328c7) | 