### PR TITLE
Fix Godot 4.4-dev1 download page preview

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,7 +1,7 @@
 - name: "4.4"
   flavor: "dev1"
   release_date: "26 August 2024"
-  release_notes: "/article/dev-snapshot-godot-4-4-dev-1"
+  release_notes: "/article/dev-snapshot-godot-4-4-dev-1/"
 
 - name: "4.3"
   flavor: "stable"


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| ![image](https://github.com/user-attachments/assets/4e3f4310-b3ad-485f-8af9-f84da16bc0a3) | ![image](https://github.com/user-attachments/assets/4cb3b254-ab67-4666-b300-2535a20c2081) |

@clayjohn, it seems that the ending slash in the URL is needed for previews to work properly.