### PR TITLE
Unify "Godot Engine" in html titles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,8 +23,12 @@
 	<meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% elsif page.excerpt %}{{ page.excerpt }}{% else %}Develop your 2D & 3D games, cross-platform projects, or even XR ideas!{% endif %}">
 	<meta name="twitter:image" content="{{ site.url }}{{ page.image | default: '/assets/share-image.webp' }}">
 
-	<title>{{ page.title | default: "Godot Engine" }}</title>
-
+	{% if page.title %}
+		<title>{{ page.title | remove: " - Godot Engine" }}{% if page.notitlesuffix != true %} – Godot Engine{% endif %}</title>
+	{% else %}
+		<title>Godot Engine</title>
+	{% endif %}
+	
 	<link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
 	<link rel="icon" href="/assets/favicon.png" sizes="any">
 	<link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">

--- a/pages/community/community.html
+++ b/pages/community/community.html
@@ -1,6 +1,6 @@
 ---
 permalink: /community/index.html
-title: Godot Engine - Community
+title: Community
 layout: default
 ---
 

--- a/pages/education.html
+++ b/pages/education.html
@@ -1,4 +1,5 @@
 ---
+title: Education
 permalink: /education/index.html
 layout: default
 ---

--- a/pages/home.html
+++ b/pages/home.html
@@ -1,6 +1,7 @@
 ---
 permalink: /
 title: "Godot Engine - Free and open source 2D and 3D game engine"
+notitlesuffix: true
 description: "Godot provides a huge set of common tools, so you can just focus on making your game without reinventing
 the wheel."
 layout: default


### PR DESCRIPTION
Most pages have HTML title tags (which show in browser title bars, tabs, bookmarks etc,) with a suffix of "- Godot Engine", e.g.:

- Features - Godot Engine
- Contact - Godot Engine
- License - Godot Engine
- Download for Linux - Godot Engine

But some didn't conform, e.g.:

- Godot Engine - Blog
- Godot Engine - Community

or even just:

- Press Kit
- User Groups

This PR is an attempt to unify the page titles, including removing duplication of "Godot" when appropriate.

However, I'm not sure this is necessarily the best solution. Maybe the site name should be defined somewhere centrally and automatically added as a suffix, rather than added to pages manually as I have done.

Also, my solution doesn't fix pages like:

- https://godotengine.org/showcase/gourdlets/ which shows as "Gourdlets" not "Gourdlets - Godot Engine"
- https://godotengine.org/article/gamescom-2024/ which shows as "Gamescom here we come!" not "Gamescom here we come! - Godot Engine"
etc.

There may be other pages I've missed.

Also also, I'm not sure if the blog category pages should be like:
- "Blog - News - Godot Engine" as currently in the PR, or
- "News - Blog - Godot Engine", or even just
- "News - Godot Engine"

Hence marking this as a draft for now. Suggestions welcome!