### PR TITLE
Fixes incorrect release date for Godot 3.6 on Download page

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -370,7 +370,7 @@
 
 - name: "3.6"
   flavor: "stable"
-  release_date: "9 August 2024"
+  release_date: "9 September 2024"
   release_notes: "/article/godot-3-6-finally-released/"
   featured: "3"
   releases:


### PR DESCRIPTION
Godot 3.6 download page had the wrong date as mentioned in this issue: https://github.com/godotengine/godot-website/issues/930