### PR TITLE
Download: Add link for Horizon Store app on stable release

### DIFF
--- a/collections/_download/android.md
+++ b/collections/_download/android.md
@@ -13,6 +13,11 @@ downloads:
     featured: true
     featured_flavor: APK
 
+  - platform: "android.horizonstore"
+    custom: https://www.meta.com/en-gb/experiences/godot-game-engine/7713660705416473/
+    featured: true
+    featured_flavor: Horizon Store
+
 ignore_export: true
 ignore_mono: true
 


### PR DESCRIPTION
Depends on #936.

**To merge only when we release 4.4-stable.**

It adds a link to the `/download/android` page which is the one used for the current stable release. Currently it's 4.3 and the Horizon Store app is 4.4.dev2.

![image](https://github.com/user-attachments/assets/3c641872-3229-46b5-8923-0c26d787f1af)