### PR TITLE
Update Discord invite URL for card title

### DIFF
--- a/pages/community/community.html
+++ b/pages/community/community.html
@@ -190,7 +190,7 @@ layout: default
 						loading="lazy">
 				</a>
 				<div class="base-padding">
-					<h3><a href="https://discord.gg/bdcfAYM4W9">Discord</a></h3>
+					<h3><a href="https://discord.gg/godotengine">Discord</a></h3>
 					<p>A space to socialize with other community members.</p>
 				</div>
 			</div>


### PR DESCRIPTION
It seems the invite URL was updated for the [card header image](https://github.com/godotengine/godot-website/pull/944/files#diff-2e7c9bbbe9ecae459c102c676766c7bca677062749441b2b04992c270724cd42R187), but not the title.

See previous commit: https://github.com/godotengine/godot-website/commit/397e6d31e97164be281b5712b84ecb091b0a3bac