### PR TITLE
Add a "what's new" button to home page

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -24,12 +24,26 @@ layout: default
 		gap: 24px;
 	}
 
+	.main-download-links-buttons {
+		display: flex;
+		flex-direction: row;
+		gap: 12px;
+	}
+
 	.main-download-links .btn-download {
 		width: 100%;
 	}
 
+	.main-download-links .btn-whats-new {
+		width: min-content;
+		text-wrap: nowrap;
+		background-color: var(--dark-color);
+		color: var(--primary-color-text-title);
+		box-sizing: border-box;
+	}
+
 	.main-download-links .download-3 {
-		text-align: center;
+		text-align: left;
 		color: #ffffffd6;
 		text-shadow: 0 0 10px black;
 		font-weight: 300;
@@ -50,6 +64,17 @@ layout: default
 			align-items: center;
 			flex-direction: column;
 			gap: 36px;
+		}
+		.main-download-links-buttons {
+			flex-direction: column;
+			align-items: center;
+		}
+		.main-download-links .download-3 {
+			text-align: center;
+		}
+		.main-download-links .btn-download,
+		.main-download-links .btn-whats-new {
+			width: 100%;
 		}
 	}
 
@@ -185,13 +210,19 @@ layout: default
 				{% assign stable_version_4 = site.data.versions | find: "featured", "4" %}
 
 				<div class="main-download-links">
-					<a href="/download/windows/" class="btn btn-download set-os-download-url" data-version="4"
-						title="Download the latest version of Godot 4">
-						<div class="download-title">Download Latest</div>
-						<div class="download-hint">{{ stable_version_4.name }}</div>
-					</a>
+					<div class="main-download-links-buttons">
+						<a href="/download/windows/" class="btn btn-download set-os-download-url" data-version="4"
+							title="Download the latest version of Godot 4">
+							<div class="download-title">Download Latest</div>
+							<div class="download-hint">{{ stable_version_4.name }}</div>
+						</a>
+						<a href="/releases/" class="btn btn-whats-new"
+							title="See what's new in Godot">
+							<div class="download-title">What's new?</div>
+						</a>
+					</div>
 
-					<span class="download-3">Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
+					<span class="download-3">Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a>, our <a href="/download/archive">experimental releases</a>, or a <a href="/download/archive">previous version</a>?</span>
 				</div>
 			</div>
 		</div>

--- a/pages/home.html
+++ b/pages/home.html
@@ -37,7 +37,7 @@ layout: default
 	.main-download-links .btn-whats-new {
 		width: min-content;
 		text-wrap: nowrap;
-		background-color: var(--dark-color);
+		background-color: #818181a8;
 		color: var(--primary-color-text-title);
 		box-sizing: border-box;
 	}


### PR DESCRIPTION
- Add a "what's new" button to home page
  - This adds a link to the latest release page
- Add "experimental releases" link
  - Same link as "previous version", but makes it clearer that we offer those too.

## Preview

![Screenshot 2024-10-07 at 09-19-50 Godot Engine - Free and open source 2D and 3D game engine](https://github.com/user-attachments/assets/e2939ff4-e848-476a-9cad-de2abd924b10)
