### PR TITLE
Remove PLC reference from the contact page

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -61,12 +61,6 @@ redirect_from:
 
 	<hr>
 
-	<h3 class="title" id="plc">Project Leadership Committee (PLC)</h3>
-	<p style="font-style: italic">
-		Information about the Project Leadership Committee was moved to the
-		<a href="/governance/">Governance</a> page.
-	</p>
-
 	<h3 class="title" id="devs">Godot&nbsp;Engine team</h3>
 	<p>
 		The Godot&nbsp;Engine team is made of hundreds of developers around the world,


### PR DESCRIPTION
As there's both the governance page AND a dedicated website (https://godot.foundation), I don't think we need to update this part for the Board.