### PR TITLE
Add Code of Conduct team section in the contact page

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -29,6 +29,14 @@ redirect_from:
 		to find the right person for you.
 	</p>
 
+	<h3 class="title">Code of Conduct team</h3>
+	<p>
+		If you need to report a breach, please follow the <a href="/code-of-conduct/#reporting-breach">instructions</a> of the Code of Conduct page.
+	</p>
+	<p>
+		The <a href="/code-of-conduct/#coc-team">list of the Code of Conduct team members</a> is available, along with their emails, if needed.
+	</p>
+
 	<h3 class="title">Reporting security vulnerabilities</h3>
 	<p>
 		If you've found a security vulnerability in Godot, please do not create an


### PR DESCRIPTION
This PR adds a Code of Conduct team section in the contact page following @mhilbrunner's [comment on the dev chat](https://chat.godotengine.org/channel/website?msg=2dX4SfmCZ3zft3XvA).