### PR TITLE
Replace excerpt of Godot 4.4.dev5 article

### DIFF
--- a/collections/_article/dev-snapshot-godot-4-4-dev-5.md
+++ b/collections/_article/dev-snapshot-godot-4-4-dev-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Dev snapshot: Godot 4.4 dev 5"
-excerpt: "The pre-release train stops for no-one!"
+excerpt: "With GodotCon behind us and our developers recuperated, we're thrilled to return to a more frequent release-cycle."
 categories: ["pre-release"]
 author: Thaddeus Crews
 image: /storage/blog/covers/dev-snapshot-godot-4-4-dev-5.webp


### PR DESCRIPTION
The excerpt of the dev5 article was more fitting with the dev4 image. But now, it's kinda awkward.

**Before**
<img width="1260" alt="Capture d’écran, le 2024-11-21 à 12 26 38" src="https://github.com/user-attachments/assets/5815fcbd-f4b9-4ff6-a0cf-4834ff480c3c">

**After**
<img width="1073" alt="Capture d’écran, le 2024-11-21 à 12 27 48" src="https://github.com/user-attachments/assets/c29c6afb-7566-48a4-88ba-318f30f1b7ef">
