### PR TITLE
Style: Modernize yaml formatting & syntax

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,28 +13,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    # Configure the build environment.
+      # Configure the build environment.
+      - name: Install Ruby 3.1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          # Runs 'bundle install' and caches installed gems automatically.
+          bundler-cache: true
 
-    - name: Install Ruby 3.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.1'
-        # Runs 'bundle install' and caches installed gems automatically
-        bundler-cache: true
+      - name: Install Minify
+        run: sudo apt-get update && sudo apt-get install minify
 
-    - name: Install Minify
-      run: sudo apt-get update && sudo apt-get install minify
+      # Build the website.
+      - name: Build the static website
+        run: bundle exec jekyll build
 
-    # Build the website.
-
-    - name: Build the static website
-      run: bundle exec jekyll build
-
-    # Upload resulting "_site" directory as artifact
-    
-    - uses: actions/upload-artifact@v4
-      with:
-        name: site
-        path: _site/
+      # Upload resulting "_site" directory as artifact.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: _site/

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -3,7 +3,7 @@ name: Build and publish
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [master]
 
 # Make sure jobs cannot overlap (e.g. one from push and one from schedule).
 concurrency:
@@ -16,37 +16,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: 'master'
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          submodules: recursive
 
-    # Configure the build environment.
+      # Configure the build environment.
+      - name: Install Ruby 3.1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          # Runs 'bundle install' and caches installed gems automatically.
+          bundler-cache: true
 
-    - name: Install Ruby 3.1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.1'
-        # Runs 'bundle install' and caches installed gems automatically
-        bundler-cache: true
+      - name: Install Minify
+        run: sudo apt-get update && sudo apt-get install minify
 
-    - name: Install Minify
-      run: sudo apt-get update && sudo apt-get install minify
+      # Build the website.
+      - name: Build the static website
+        run: bundle exec jekyll build
 
-    # Build the website.
-
-    - name: Build the static website
-      run: bundle exec jekyll build
-
-
-    # Publish the build results
-
-    - name: Deploy to the published branch 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: published
-        folder: _site
-        # Configure the commit author.
-        git-config-name: 'Godot Organization'
-        git-config-email: '<>'
-        # Remove outdated files from the target directory.
-        clean: true
+      # Publish the build results.
+      - name: Deploy to the published branch 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: published
+          folder: _site
+          # Configure the commit author.
+          git-config-name: Godot Organization
+          git-config-email: <>
+          # Remove outdated files from the target directory.
+          clean: true

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ build available for download.
 
 To create a new version, add the following block to the file:
 
-```
-- name: "4.0.1"
-  flavor: "stable"
-  release_date: "20 March 2023"
-  release_notes: "/article/maintenance-release-godot-4-0-1/"
+```yaml
+- name: '4.0.1'
+  flavor: stable
+  release_date: 20 March 2023
+  release_notes: /article/maintenance-release-godot-4-0-1/
 ```
 
 Make sure to order entries correctly, with the higher version number being closer to the top. Use the `flavor` field
@@ -188,12 +188,12 @@ information. Make sure to update this information when publishing the release no
 
 Stable releases featured across the website, must be marked with the `featured` field and the corresponding major version number. Only one record must be marked as featured per version, so don't forget to remove it from the current holder of the mark.
 
-```
-- name: "4.0.3"
-  flavor: "stable"
-  release_date: "19 May 2023"
-  release_notes: "/article/maintenance-release-godot-4-0-3/"
-  featured: "4"
+```yaml
+- name: '4.0.3'
+  flavor: stable
+  release_date: 19 May 2023
+  release_notes: /article/maintenance-release-godot-4-0-3/
+  featured: '4'
 ```
 
 There are two additional files providing data for download pages and links: `_data/download_configs.yml` and
@@ -206,10 +206,10 @@ some pages.
 If a new host needs to be supported by the mirrorlist, it needs to be added in a few places. For the data side of
 things you need to update `_data/mirrorlist_configs.yml` and add another record for the major-minor version code.
 
-```
-  - name: "4.1"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
+```yaml
+  - name: '4.1'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
 ```
 
 The `stable` key refers to hosts available for the stable release of that version, while the `preview` key refers

--- a/_config.development.yml
+++ b/_config.development.yml
@@ -1,5 +1,5 @@
 # Overrides from the main config
-url: "http://localhost:4000"
+url: http://localhost:4000
 
 # Enables incremental builds to speed up iteration times.
 incremental: true

--- a/_config.yml
+++ b/_config.yml
@@ -1,17 +1,15 @@
 # Settings
 exclude:
-  [
-    ".github",
-    "Gemfile",
-    "Gemfile.lock",
-    "build.sh",
-    "build-and-serve.sh",
-    "build-and-watch.sh",
-    "README.md",
-  ]
+  - .github,
+  - build-and-serve.sh,
+  - build-and-watch.sh,
+  - build.sh,
+  - Gemfile,
+  - Gemfile.lock,
+  - README.md,
 permalink: pretty
 
-url: "https://godotengine.org"
+url: https://godotengine.org
 
 collections_dir: collections
 collections:
@@ -32,34 +30,34 @@ future: true
 
 defaults:
   - scope:
-      type: "article"
+      type: article
     values:
-      layout: "article"
-      og_type: "article"
+      layout: article
+      og_type: article
   - scope:
-      type: "event"
+      type: event
     values:
-      layout: "event"
+      layout: event
   - scope:
-      type: "showcase"
+      type: showcase
     values:
-      layout: "showcase-item"
+      layout: showcase-item
   - scope:
-      type: "download"
+      type: download
     values:
-      layout: "download"
+      layout: download
   - scope:
-      type: "download_3"
+      type: download_3
     values:
-      layout: "download-3"
+      layout: download-3
   - scope:
-      type: "download_archive"
+      type: download_archive
     values:
-      layout: "download-archive"
+      layout: download-archive
   - scope:
-      type: "mirrorlist"
+      type: mirrorlist
     values:
-      layout: "mirrorlist"
+      layout: mirrorlist
 
 # Plugins
 plugins:
@@ -68,29 +66,29 @@ plugins:
   # - jekyll-multiple-languages-plugin
 
 # Internationalization
-languages: ["en", "es"]
-exclude_from_localizations: ["assets", "storage"]
-default_lang: "en"
+languages: [en, es]
+exclude_from_localizations: [assets, storage]
+default_lang: en
 
 # Pagination (used by the blog)
 pagination:
   enabled: true
   debug: false
 
-  collection: "article"
+  collection: article
   per_page: 24
-  sort_field: "date"
+  sort_field: date
   sort_reverse: true
   # Controls how the pagination trail for the paginated pages look like.
   trail:
     before: 2
     after: 2
 
-  title: ":title - Page :num"
-  permalink: "/:num/"
-  category: "posts"
-  tag: ""
-  locale: ""
+  title: :title - Page :num
+  permalink: /:num/
+  category: posts
+  tag: ''
+  locale: ''
 
 # .scss generation
 sass:

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -74,11 +74,11 @@
   image: /assets/images/authors/default_avatar.svg
 - name: Yuri Sizov
   image: /assets/images/authors/yuri.jpeg
-- name: "2000+ Godot contributors"
+- name: 2000+ Godot contributors
   image: /assets/images/authors/everyone.webp
-- name: "Godot contributors"
+- name: Godot contributors
   image: /assets/images/authors/everyone.webp
-- name: "Godot Foundation"
+- name: Godot Foundation
   image: /assets/images/authors/foundation.webp
 - name: default
   image: /assets/images/authors/default_avatar.svg

--- a/_data/download_configs.yml
+++ b/_data/download_configs.yml
@@ -79,8 +79,8 @@ overrides:
   # Mono version of Godot 4 was only introduced in 4.0 alpha 17.
   - version: 4
     range:
-      - "4.0-alpha1"
-      - "4.0-alpha16"
+      - 4.0-alpha1
+      - 4.0-alpha16
     config:
       templates: export_templates.tpz
       editor:
@@ -97,8 +97,8 @@ overrides:
   # Godot 4.2 beta 5 introduced Linux ARM builds.
   - version: 4
     range:
-      - "4.0-alpha17"
-      - "4.2-beta4"
+      - 4.0-alpha17
+      - 4.2-beta4
     config:
       templates: export_templates.tpz
       editor:
@@ -123,8 +123,8 @@ overrides:
   # Godot 4.3 RC 1 introduced Windows ARM builds.
   - version: 4
     range:
-      - "4.2-beta5"
-      - "4.3-beta3"
+      - 4.2-beta5
+      - 4.3-beta3
     config:
       templates: export_templates.tpz
       editor:
@@ -153,8 +153,8 @@ overrides:
   # Godot 4.4 dev 2 introduced Android Horizon OS builds.
   - version: 4
     range:
-      - "4.3-rc1"
-      - "4.4-dev1"
+      - 4.3-rc1
+      - 4.4-dev1
     config:
       templates: export_templates.tpz
       editor:

--- a/_data/download_platforms.yml
+++ b/_data/download_platforms.yml
@@ -1,20 +1,20 @@
-- name: "templates"
-  title: "Export templates"
-  caption: ""
+- name: templates
+  title: Export templates
+  caption: ''
   tags:
-    - "Used to export your games to all supported platforms"
+    - Used to export your games to all supported platforms
 
-- name: "aar_library"
-  title: "AAR library"
-  caption: ""
+- name: aar_library
+  title: AAR library
+  caption: ''
   tags:
     - Android plugins
     - Java
     - Kotlin
 
-- name: "android.apk"
-  title: "Android"
-  caption: "APK - Universal"
+- name: android.apk
+  title: Android
+  caption: APK - Universal
   tags:
     - APK download
     - arm64
@@ -22,9 +22,9 @@
     - x86_64
     - x86_32
 
-- name: "android.playstore"
-  title: "Android"
-  caption: "Play Store"
+- name: android.playstore
+  title: Android
+  caption: Play Store
   tags:
     - Play Store
     - arm64
@@ -32,88 +32,88 @@
     - x86_64
     - x86_32
 
-- name: "android.horizonos"
-  title: "Horizon OS"
-  caption: "APK - arm64"
+- name: android.horizonos
+  title: Horizon OS
+  caption: APK - arm64
   tags:
     - APK download
     - Meta Quest 3 & Pro
     - arm64
 
-- name: "android.horizonstore"
-  title: "Horizon OS"
-  caption: "Horizon Store"
+- name: android.horizonstore
+  title: Horizon OS
+  caption: Horizon Store
   tags:
     - Horizon Store
     - Meta Quest 3 & Pro
     - arm64
 
-- name: "linux.32"
-  title: "Linux"
-  caption: "x86_32"
+- name: linux.32
+  title: Linux
+  caption: x86_32
   tags:
     - x86_32
 
-- name: "linux.64"
-  title: "Linux"
-  caption: "x86_64"
+- name: linux.64
+  title: Linux
+  caption: x86_64
   tags:
     - x86_64
 
-- name: "linux.arm32"
-  title: "Linux"
-  caption: "arm32"
+- name: linux.arm32
+  title: Linux
+  caption: arm32
   tags:
     - arm32
 
-- name: "linux.arm64"
-  title: "Linux"
-  caption: "arm64"
+- name: linux.arm64
+  title: Linux
+  caption: arm64
   tags:
     - arm64
 
-- name: "linux_server.64"
-  title: "Linux Server"
-  caption: "Export Template - x86_64"
+- name: linux_server.64
+  title: Linux Server
+  caption: Export Template - x86_64
   tags:
     - x86_64
     - Headless
 
-- name: "linux_server.headless.64"
-  title: "Linux Server"
-  caption: "Editor - x86_64"
+- name: linux_server.headless.64
+  title: Linux Server
+  caption: Editor - x86_64
   tags:
     - x86_64
     - Headless
 
-- name: "macos.universal"
-  title: "macOS"
-  caption: "Universal"
+- name: macos.universal
+  title: macOS
+  caption: Universal
   tags:
     - arm64 (Apple Silicon)
     - x86_64 (Intel)
 
-- name: "web"
-  title: "Web editor"
-  caption: ""
+- name: web
+  title: Web editor
+  caption: ''
   tags:
     - Self-hosted
     - Cross-platform
 
-- name: "windows.32"
-  title: "Windows"
-  caption: "x86_32"
+- name: windows.32
+  title: Windows
+  caption: x86_32
   tags:
     - x86_32
 
-- name: "windows.64"
-  title: "Windows"
-  caption: "x86_64"
+- name: windows.64
+  title: Windows
+  caption: x86_64
   tags:
     - x86_64
 
-- name: "windows.arm64"
-  title: "Windows"
-  caption: "arm64"
+- name: windows.arm64
+  title: Windows
+  caption: arm64
   tags:
     - arm64

--- a/_data/mirrorlist_configs.yml
+++ b/_data/mirrorlist_configs.yml
@@ -1,57 +1,57 @@
 hosts:
-  - name: "github"
-    title: "Official GitHub Releases mirror"
-  - name: "github_builds"
-    title: "Official GitHub Releases mirror"
-  - name: "tuxfamily"
-    title: "Official TuxFamily mirror"
+  - name: github
+    title: Official GitHub Releases mirror
+  - name: github_builds
+    title: Official GitHub Releases mirror
+  - name: tuxfamily
+    title: Official TuxFamily mirror
 
 defaults:
-  - name: "4.4"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "4.3"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "4.2"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "4.1"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "4.0"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "3.6"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "3.5"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "3.4"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "3.3"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "3.2"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "3.1"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "3.0"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "2.1"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "2.0"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "1.1"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
-  - name: "1.0"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
+  - name: '4.4'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '4.3'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '4.2'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '4.1'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '4.0'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '3.6'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '3.5'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '3.4'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '3.3'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '3.2'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '3.1'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '3.0'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '2.1'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '2.0'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '1.1'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]
+  - name: '1.0'
+    stable: [github, tuxfamily]
+    preview: [github_builds, tuxfamily]

--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -1,58 +1,58 @@
 patron:
-  - name: "OSS Capital"
-    link: "https://oss.capital/"
-    image: "https://fund.godotengine.org/static/logos/ossc-logo.svg"
-  - name: "Khronos® Group"
-    link: "https://www.khronos.org/"
-    image: "https://fund.godotengine.org/static/logos/khronos.svg"
+  - name: OSS Capital
+    link: https://oss.capital/
+    image: https://fund.godotengine.org/static/logos/ossc-logo.svg
+  - name: Khronos® Group
+    link: https://www.khronos.org/
+    image: https://fund.godotengine.org/static/logos/khronos.svg
 platinum:
-  - name: "W4 Games"
-    link: "https://w4games.com/"
-    image: "https://fund.godotengine.org/static/logos/w4.png"
-  - name: "V-Sekai"
-    link: "https://github.com/V-Sekai"
-    image: "https://fund.godotengine.org/static/logos/v-sekai.png"
-  - name: "Google Play"
-    link: "https://play.google.com"
-    image: "https://fund.godotengine.org/static/logos/google-play.png"
+  - name: W4 Games
+    link: https://w4games.com/
+    image: https://fund.godotengine.org/static/logos/w4.png
+  - name: V-Sekai
+    link: https://github.com/V-Sekai
+    image: https://fund.godotengine.org/static/logos/v-sekai.png
+  - name: Google Play
+    link: https://play.google.com
+    image: https://fund.godotengine.org/static/logos/google-play.png
 gold:
-  - name: "Prehensile Tales"
-    link: "https://prehensile-tales.com"
-    image: "https://fund.godotengine.org/static/logos/pt.png"
-  - name: "Robot Gentleman"
-    link: "http://robotgentleman.com/"
-    image: "https://fund.godotengine.org/static/logos/robot-gentleman.png"
-  - name: "Mega Crit"
-    link: "https://www.megacrit.com/"
-    image: "https://fund.godotengine.org/static/logos/megacrit.png"
-  - name: "Pirate Software"
-    link: "https://gopiratesoftware.com/"
-    image: "https://fund.godotengine.org/static/logos/piratesoftware.webp"
+  - name: Prehensile Tales
+    link: https://prehensile-tales.com
+    image: https://fund.godotengine.org/static/logos/pt.png
+  - name: Robot Gentleman
+    link: http://robotgentleman.com/
+    image: https://fund.godotengine.org/static/logos/robot-gentleman.png
+  - name: Mega Crit
+    link: https://www.megacrit.com/
+    image: https://fund.godotengine.org/static/logos/megacrit.png
+  - name: Pirate Software
+    link: https://gopiratesoftware.com/
+    image: https://fund.godotengine.org/static/logos/piratesoftware.webp
 silver:
-  - name: "Playful Studios"
-    link: "https://playfulstudios.com/"
-    image: "https://fund.godotengine.org/static/logos/playful-studios.png"
-  - name: "Orbital Knight"
-    link: "https://www.orbitalknight.com/"
-    image: "https://fund.godotengine.org/static/logos/orbital-knight.png"
-  - name: "Broken Rules"
-    link: "https://brokenrul.es"
-    image: "https://fund.godotengine.org/static/logos/broken-rules.svg"
-  - name: "Chasing Carrots"
-    link: "https://www.chasing-carrots.com"
-    image: "https://fund.godotengine.org/static/logos/chasing-carrots.webp"
-  - name: "Indoor Astronaut"
-    link: "https://indoorastronaut.ch/"
-    image: "https://fund.godotengine.org/static/logos/indoor-astronaut.png"
-  - name: "LoadComplete"
-    link: "https://loadcomplete.com/"
-    image: "https://fund.godotengine.org/static/logos/loadcomplete.png"
-  - name: "Null"
-    link: "https://null.com/"
-    image: "https://fund.godotengine.org/static/logos/null.svg"
+  - name: Playful Studios
+    link: https://playfulstudios.com/
+    image: https://fund.godotengine.org/static/logos/playful-studios.png
+  - name: Orbital Knight
+    link: https://www.orbitalknight.com/
+    image: https://fund.godotengine.org/static/logos/orbital-knight.png
+  - name: Broken Rules
+    link: https://brokenrul.es
+    image: https://fund.godotengine.org/static/logos/broken-rules.svg
+  - name: Chasing Carrots
+    link: https://www.chasing-carrots.com
+    image: https://fund.godotengine.org/static/logos/chasing-carrots.webp
+  - name: Indoor Astronaut
+    link: https://indoorastronaut.ch/
+    image: https://fund.godotengine.org/static/logos/indoor-astronaut.png
+  - name: LoadComplete
+    link: https://loadcomplete.com/
+    image: https://fund.godotengine.org/static/logos/loadcomplete.png
+  - name: 'Null'
+    link: https://null.com/
+    image: https://fund.godotengine.org/static/logos/null.svg
   - name: Copia Wealth Studios
-    link: "https://copiawealthstudios.com/"
-    image: "https://fund.godotengine.org/static/logos/copia-wealth-studios.svg"
-  - name: "Re-Logic"
-    link: "https://re-logic.com/"
-    image: "https://fund.godotengine.org/static/logos/re-logic.png"
+    link: https://copiawealthstudios.com/
+    image: https://fund.godotengine.org/static/logos/copia-wealth-studios.svg
+  - name: Re-Logic
+    link: https://re-logic.com/
+    image: https://fund.godotengine.org/static/logos/re-logic.png

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,1015 +1,1015 @@
-- name: "4.4"
-  flavor: "dev5"
-  release_date: "21 November 2024"
-  release_notes: "/article/dev-snapshot-godot-4-4-dev-5/"
+- name: '4.4'
+  flavor: dev5
+  release_date: 21 November 2024
+  release_notes: /article/dev-snapshot-godot-4-4-dev-5/
   releases:
-    - name: "dev4"
-      release_date: "8 November 2024"
-      release_notes: "/article/dev-snapshot-godot-4-4-dev-4/"
-    - name: "dev3"
-      release_date: "3 October 2024"
-      release_notes: "/article/dev-snapshot-godot-4-4-dev-3/"
-    - name: "dev2"
-      release_date: "10 September 2024"
-      release_notes: "/article/dev-snapshot-godot-4-4-dev-2/"
-    - name: "dev1"
-      release_date: "26 August 2024"
-      release_notes: "/article/dev-snapshot-godot-4-4-dev-1/"
+    - name: dev4
+      release_date: 8 November 2024
+      release_notes: /article/dev-snapshot-godot-4-4-dev-4/
+    - name: dev3
+      release_date: 3 October 2024
+      release_notes: /article/dev-snapshot-godot-4-4-dev-3/
+    - name: dev2
+      release_date: 10 September 2024
+      release_notes: /article/dev-snapshot-godot-4-4-dev-2/
+    - name: dev1
+      release_date: 26 August 2024
+      release_notes: /article/dev-snapshot-godot-4-4-dev-1/
 
-- name: "4.3"
-  flavor: "stable"
-  release_date: "15 August 2024"
-  release_notes: "/article/godot-4-3-a-shared-effort/"
-  featured: "4"
+- name: '4.3'
+  flavor: stable
+  release_date: 15 August 2024
+  release_notes: /article/godot-4-3-a-shared-effort/
+  featured: '4'
   releases:
-    - name: "rc3"
-      release_date: "8 August 2024"
-      release_notes: "/article/release-candidate-godot-4-3-rc-3/"
-    - name: "rc2"
-      release_date: "1 August 2024"
-      release_notes: "/article/release-candidate-godot-4-3-rc-2/"
-    - name: "rc1"
-      release_date: "25 July 2024"
-      release_notes: "/article/release-candidate-godot-4-3-rc-1/"
-    - name: "beta3"
-      release_date: "9 July 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-beta-3/"
-    - name: "beta2"
-      release_date: "20 June 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-beta-2/"
-    - name: "beta1"
-      release_date: "31 May 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-beta-1/"
-    - name: "dev6"
-      release_date: "1 May 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-dev-6/"
-    - name: "dev5"
-      release_date: "15 March 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-dev-5/"
-    - name: "dev4"
-      release_date: "29 February 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-dev-4/"
-    - name: "dev3"
-      release_date: "8 February 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-dev-3/"
-    - name: "dev2"
-      release_date: "11 January 2024"
-      release_notes: "/article/dev-snapshot-godot-4-3-dev-2/"
-    - name: "dev1"
-      release_date: "21 December 2023"
-      release_notes: "/article/dev-snapshot-godot-4-3-dev-1/"
+    - name: rc3
+      release_date: 8 August 2024
+      release_notes: /article/release-candidate-godot-4-3-rc-3/
+    - name: rc2
+      release_date: 1 August 2024
+      release_notes: /article/release-candidate-godot-4-3-rc-2/
+    - name: rc1
+      release_date: 25 July 2024
+      release_notes: /article/release-candidate-godot-4-3-rc-1/
+    - name: beta3
+      release_date: 9 July 2024
+      release_notes: /article/dev-snapshot-godot-4-3-beta-3/
+    - name: beta2
+      release_date: 20 June 2024
+      release_notes: /article/dev-snapshot-godot-4-3-beta-2/
+    - name: beta1
+      release_date: 31 May 2024
+      release_notes: /article/dev-snapshot-godot-4-3-beta-1/
+    - name: dev6
+      release_date: 1 May 2024
+      release_notes: /article/dev-snapshot-godot-4-3-dev-6/
+    - name: dev5
+      release_date: 15 March 2024
+      release_notes: /article/dev-snapshot-godot-4-3-dev-5/
+    - name: dev4
+      release_date: 29 February 2024
+      release_notes: /article/dev-snapshot-godot-4-3-dev-4/
+    - name: dev3
+      release_date: 8 February 2024
+      release_notes: /article/dev-snapshot-godot-4-3-dev-3/
+    - name: dev2
+      release_date: 11 January 2024
+      release_notes: /article/dev-snapshot-godot-4-3-dev-2/
+    - name: dev1
+      release_date: 21 December 2023
+      release_notes: /article/dev-snapshot-godot-4-3-dev-1/
 
-- name: "4.2.2"
-  flavor: "stable"
-  release_date: "17 April 2024"
-  release_notes: "/article/maintenance-release-godot-4-2-2-and-4-1-4/"
+- name: '4.2.2'
+  flavor: stable
+  release_date: 17 April 2024
+  release_notes: /article/maintenance-release-godot-4-2-2-and-4-1-4/
   releases:
-    - name: "rc3"
-      release_date: "12 April 2024"
-      release_notes: "/article/release-candidate-godot-4-1-4-and-4-2-2-rc-3/"
-    - name: "rc2"
-      release_date: "15 March 2024"
-      release_notes: "/article/release-candidate-godot-4-1-4-and-4-2-2-rc-2/"
-    - name: "rc1"
-      release_date: "26 January 2024"
-      release_notes: "/article/release-candidate-godot-4-1-4-and-4-2-2-rc-1/"
+    - name: rc3
+      release_date: 12 April 2024
+      release_notes: /article/release-candidate-godot-4-1-4-and-4-2-2-rc-3/
+    - name: rc2
+      release_date: 15 March 2024
+      release_notes: /article/release-candidate-godot-4-1-4-and-4-2-2-rc-2/
+    - name: rc1
+      release_date: 26 January 2024
+      release_notes: /article/release-candidate-godot-4-1-4-and-4-2-2-rc-1/
 
-- name: "4.2.1"
-  flavor: "stable"
-  release_date: "12 December 2023"
-  release_notes: "/article/maintenance-release-godot-4-2-1/"
+- name: '4.2.1'
+  flavor: stable
+  release_date: 12 December 2023
+  release_notes: /article/maintenance-release-godot-4-2-1/
   releases:
-    - name: "rc1"
-      release_date: "8 December 2023"
-      release_notes: "/article/release-candidate-godot-4-2-1-rc-1/"
+    - name: rc1
+      release_date: 8 December 2023
+      release_notes: /article/release-candidate-godot-4-2-1-rc-1/
 
-- name: "4.2"
-  flavor: "stable"
-  release_date: "30 November 2023"
-  release_notes: "/article/godot-4-2-arrives-in-style/"
+- name: '4.2'
+  flavor: stable
+  release_date: 30 November 2023
+  release_notes: /article/godot-4-2-arrives-in-style/
   releases:
-    - name: "rc2"
-      release_date: "24 November 2023"
-      release_notes: "/article/release-candidate-godot-4-2-rc-2/"
-    - name: "rc1"
-      release_date: "17 November 2023"
-      release_notes: "/article/release-candidate-godot-4-2-rc-1/"
-    - name: "beta6"
-      release_date: "13 November 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-beta-6/"
-    - name: "beta5"
-      release_date: "7 November 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-beta-5/"
-    - name: "beta4"
-      release_date: "31 October 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-beta-4/"
-    - name: "beta3"
-      release_date: "24 October 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-beta-3/"
-    - name: "beta2"
-      release_date: "19 October 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-beta-2/"
-    - name: "beta1"
-      release_date: "12 October 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-beta-1/"
-    - name: "dev6"
-      release_date: "3 October 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-dev-6/"
-    - name: "dev5"
-      release_date: "19 September 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-dev-5/"
-    - name: "dev4"
-      release_date: "5 September 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-dev-4/"
-    - name: "dev3"
-      release_date: "11 August 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-dev-3/"
-    - name: "dev2"
-      release_date: "28 July 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-dev-2/"
-    - name: "dev1"
-      release_date: "19 July 2023"
-      release_notes: "/article/dev-snapshot-godot-4-2-dev-1/"
+    - name: rc2
+      release_date: 24 November 2023
+      release_notes: /article/release-candidate-godot-4-2-rc-2/
+    - name: rc1
+      release_date: 17 November 2023
+      release_notes: /article/release-candidate-godot-4-2-rc-1/
+    - name: beta6
+      release_date: 13 November 2023
+      release_notes: /article/dev-snapshot-godot-4-2-beta-6/
+    - name: beta5
+      release_date: 7 November 2023
+      release_notes: /article/dev-snapshot-godot-4-2-beta-5/
+    - name: beta4
+      release_date: 31 October 2023
+      release_notes: /article/dev-snapshot-godot-4-2-beta-4/
+    - name: beta3
+      release_date: 24 October 2023
+      release_notes: /article/dev-snapshot-godot-4-2-beta-3/
+    - name: beta2
+      release_date: 19 October 2023
+      release_notes: /article/dev-snapshot-godot-4-2-beta-2/
+    - name: beta1
+      release_date: 12 October 2023
+      release_notes: /article/dev-snapshot-godot-4-2-beta-1/
+    - name: dev6
+      release_date: 3 October 2023
+      release_notes: /article/dev-snapshot-godot-4-2-dev-6/
+    - name: dev5
+      release_date: 19 September 2023
+      release_notes: /article/dev-snapshot-godot-4-2-dev-5/
+    - name: dev4
+      release_date: 5 September 2023
+      release_notes: /article/dev-snapshot-godot-4-2-dev-4/
+    - name: dev3
+      release_date: 11 August 2023
+      release_notes: /article/dev-snapshot-godot-4-2-dev-3/
+    - name: dev2
+      release_date: 28 July 2023
+      release_notes: /article/dev-snapshot-godot-4-2-dev-2/
+    - name: dev1
+      release_date: 19 July 2023
+      release_notes: /article/dev-snapshot-godot-4-2-dev-1/
 
-- name: "4.1.4"
-  flavor: "stable"
-  release_date: "17 April 2024"
-  release_notes: "/article/maintenance-release-godot-4-2-2-and-4-1-4/"
+- name: '4.1.4'
+  flavor: stable
+  release_date: 17 April 2024
+  release_notes: /article/maintenance-release-godot-4-2-2-and-4-1-4/
   releases:
-    - name: "rc3"
-      release_date: "12 April 2024"
-      release_notes: "/article/release-candidate-godot-4-1-4-and-4-2-2-rc-3/"
-    - name: "rc2"
-      release_date: "15 March 2024"
-      release_notes: "/article/release-candidate-godot-4-1-4-and-4-2-2-rc-2/"
-    - name: "rc1"
-      release_date: "26 January 2024"
-      release_notes: "/article/release-candidate-godot-4-1-4-and-4-2-2-rc-1/"
+    - name: rc3
+      release_date: 12 April 2024
+      release_notes: /article/release-candidate-godot-4-1-4-and-4-2-2-rc-3/
+    - name: rc2
+      release_date: 15 March 2024
+      release_notes: /article/release-candidate-godot-4-1-4-and-4-2-2-rc-2/
+    - name: rc1
+      release_date: 26 January 2024
+      release_notes: /article/release-candidate-godot-4-1-4-and-4-2-2-rc-1/
 
-- name: "4.1.3"
-  flavor: "stable"
-  release_date: "1 November 2023"
-  release_notes: "/article/maintenance-release-godot-4-1-3/"
+- name: '4.1.3'
+  flavor: stable
+  release_date: 1 November 2023
+  release_notes: /article/maintenance-release-godot-4-1-3/
   releases:
-    - name: "rc1"
-      release_date: "27 October 2023"
-      release_notes: "/article/release-candidate-godot-4-1-3-rc-1/"
+    - name: rc1
+      release_date: 27 October 2023
+      release_notes: /article/release-candidate-godot-4-1-3-rc-1/
 
-- name: "4.1.2"
-  flavor: "stable"
-  release_date: "4 October 2023"
-  release_notes: "/article/maintenance-release-godot-4-1-2/"
+- name: '4.1.2'
+  flavor: stable
+  release_date: 4 October 2023
+  release_notes: /article/maintenance-release-godot-4-1-2/
   releases:
-    - name: "rc1"
-      release_date: "22 September 2023"
-      release_notes: "/article/release-candidate-godot-4-1-2-rc-1/"
+    - name: rc1
+      release_date: 22 September 2023
+      release_notes: /article/release-candidate-godot-4-1-2-rc-1/
 
-- name: "4.1.1"
-  flavor: "stable"
-  release_date: "17 July 2023"
-  release_notes: "/article/maintenance-release-godot-4-1-1/"
+- name: '4.1.1'
+  flavor: stable
+  release_date: 17 July 2023
+  release_notes: /article/maintenance-release-godot-4-1-1/
   releases:
-    - name: "rc1"
-      release_date: "12 July 2023"
-      release_notes: "/article/release-candidate-godot-4-1-1-rc-1/"
+    - name: rc1
+      release_date: 12 July 2023
+      release_notes: /article/release-candidate-godot-4-1-1-rc-1/
 
-- name: "4.1"
-  flavor: "stable"
-  release_date: "6 July 2023"
-  release_notes: "/article/godot-4-1-is-here/"
+- name: '4.1'
+  flavor: stable
+  release_date: 6 July 2023
+  release_notes: /article/godot-4-1-is-here/
   releases:
-    - name: "rc3"
-      release_date: "4 July 2023"
-      release_notes: "/article/release-candidate-godot-4-1-rc-3/"
-    - name: "rc2"
-      release_date: "30 June 2023"
-      release_notes: "/article/release-candidate-godot-4-1-rc-2/"
-    - name: "rc1"
-      release_date: "27 June 2023"
-      release_notes: "/article/release-candidate-godot-4-1-rc-1/"
-    - name: "beta3"
-      release_date: "21 June 2023"
-      release_notes: "/article/dev-snapshot-godot-4-1-beta-3/"
-    - name: "beta2"
-      release_date: "14 June 2023"
-      release_notes: "/article/dev-snapshot-godot-4-1-beta-2/"
-    - name: "beta1"
-      release_date: "8 June 2023"
-      release_notes: "/article/dev-snapshot-godot-4-1-beta-1/"
-    - name: "dev4"
-      release_date: "1 June 2023"
-      release_notes: "/article/dev-snapshot-godot-4-1-dev-4/"
-    - name: "dev3"
-      release_date: "25 May 2023"
-      release_notes: "/article/dev-snapshot-godot-4-1-dev-3/"
-    - name: "dev2"
-      release_date: "09 May 2023"
-      release_notes: "/article/dev-snapshot-godot-4-1-dev-2/"
-    - name: "dev1"
-      release_date: "21 April 2023"
-      release_notes: "/article/dev-snapshot-godot-4-1-dev-1/"
+    - name: rc3
+      release_date: 4 July 2023
+      release_notes: /article/release-candidate-godot-4-1-rc-3/
+    - name: rc2
+      release_date: 30 June 2023
+      release_notes: /article/release-candidate-godot-4-1-rc-2/
+    - name: rc1
+      release_date: 27 June 2023
+      release_notes: /article/release-candidate-godot-4-1-rc-1/
+    - name: beta3
+      release_date: 21 June 2023
+      release_notes: /article/dev-snapshot-godot-4-1-beta-3/
+    - name: beta2
+      release_date: 14 June 2023
+      release_notes: /article/dev-snapshot-godot-4-1-beta-2/
+    - name: beta1
+      release_date: 8 June 2023
+      release_notes: /article/dev-snapshot-godot-4-1-beta-1/
+    - name: dev4
+      release_date: 1 June 2023
+      release_notes: /article/dev-snapshot-godot-4-1-dev-4/
+    - name: dev3
+      release_date: 25 May 2023
+      release_notes: /article/dev-snapshot-godot-4-1-dev-3/
+    - name: dev2
+      release_date: 09 May 2023
+      release_notes: /article/dev-snapshot-godot-4-1-dev-2/
+    - name: dev1
+      release_date: 21 April 2023
+      release_notes: /article/dev-snapshot-godot-4-1-dev-1/
 
-- name: "4.0.4"
-  flavor: "stable"
-  release_date: "3 August 2023"
-  release_notes: "/article/maintenance-release-godot-4-0-4/"
+- name: '4.0.4'
+  flavor: stable
+  release_date: 3 August 2023
+  release_notes: /article/maintenance-release-godot-4-0-4/
   releases:
-    - name: "rc1"
-      release_date: "21 July 2023"
-      release_notes: "/article/release-candidate-godot-4-0-4-rc-1/"
+    - name: rc1
+      release_date: 21 July 2023
+      release_notes: /article/release-candidate-godot-4-0-4-rc-1/
 
-- name: "4.0.3"
-  flavor: "stable"
-  release_date: "19 May 2023"
-  release_notes: "/article/maintenance-release-godot-4-0-3/"
+- name: '4.0.3'
+  flavor: stable
+  release_date: 19 May 2023
+  release_notes: /article/maintenance-release-godot-4-0-3/
   releases:
-    - name: "rc2"
-      release_date: "12 May 2023"
-      release_notes: "/article/release-candidate-godot-4-0-3-rc-2/"
-    - name: "rc1"
-      release_date: "27 April 2023"
-      release_notes: "/article/release-candidate-godot-4-0-3-rc-1/"
+    - name: rc2
+      release_date: 12 May 2023
+      release_notes: /article/release-candidate-godot-4-0-3-rc-2/
+    - name: rc1
+      release_date: 27 April 2023
+      release_notes: /article/release-candidate-godot-4-0-3-rc-1/
 
-- name: "4.0.2"
-  flavor: "stable"
-  release_date: "4 April 2023"
-  release_notes: "/article/maintenance-release-godot-4-0-2/"
+- name: '4.0.2'
+  flavor: stable
+  release_date: 4 April 2023
+  release_notes: /article/maintenance-release-godot-4-0-2/
   releases:
-    - name: "rc1"
-      release_date: "31 March 2023"
-      release_notes: "/article/release-candidate-godot-4-0-2-rc-1/"
+    - name: rc1
+      release_date: 31 March 2023
+      release_notes: /article/release-candidate-godot-4-0-2-rc-1/
 
-- name: "4.0.1"
-  flavor: "stable"
-  release_date: "20 March 2023"
-  release_notes: "/article/maintenance-release-godot-4-0-1/"
+- name: '4.0.1'
+  flavor: stable
+  release_date: 20 March 2023
+  release_notes: /article/maintenance-release-godot-4-0-1/
   releases:
-    - name: "rc2"
-      release_date: "17 March 2023"
-      release_notes: "/article/release-candidate-godot-4-0-1-rc-2/"
-    - name: "rc1"
-      release_date: "15 March 2023"
-      release_notes: "/article/release-candidate-godot-4-0-1-rc-1/"
+    - name: rc2
+      release_date: 17 March 2023
+      release_notes: /article/release-candidate-godot-4-0-1-rc-2/
+    - name: rc1
+      release_date: 15 March 2023
+      release_notes: /article/release-candidate-godot-4-0-1-rc-1/
 
-- name: "4.0"
-  flavor: "stable"
-  release_date: "1 March 2023"
-  release_notes: "/article/godot-4-0-sets-sail/"
+- name: '4.0'
+  flavor: stable
+  release_date: 1 March 2023
+  release_notes: /article/godot-4-0-sets-sail/
   releases:
-    - name: "rc6"
-      release_date: "27 February 2023"
-      release_notes: "/article/release-candidate-godot-4-0-rc-6/"
-    - name: "rc5"
-      release_date: "24 February 2023"
-      release_notes: "/article/release-candidate-godot-4-0-rc-5/"
-    - name: "rc4"
-      release_date: "23 February 2023"
-      release_notes: "/article/release-candidate-godot-4-0-rc-4/"
-    - name: "rc3"
-      release_date: "21 February 2023"
-      release_notes: "/article/release-candidate-godot-4-0-rc-3/"
-    - name: "rc2"
-      release_date: "14 February 2023"
-      release_notes: "/article/release-candidate-godot-4-0-rc-2/"
-    - name: "rc1"
-      release_date: "8 February 2023"
-      release_notes: "/article/release-candidate-godot-4-0-rc-1/"
-    - name: "beta17"
-      release_date: "1 February 2023"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-17/"
-    - name: "beta16"
-      release_date: "27 January 2023"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-16/"
-    - name: "beta15"
-      release_date: "25 January 2023"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-15/"
-    - name: "beta14"
-      release_date: "20 January 2023"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-14/"
-    - name: "beta13"
-      release_date: "17 January 2023"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-13/"
-    - name: "beta12"
-      release_date: "13 January 2023"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-12/"
-    - name: "beta11"
-      release_date: "10 January 2023"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-11/"
-    - name: "beta10"
-      release_date: "23 December 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-10/"
-    - name: "beta9"
-      release_date: "19 December 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-9/"
-    - name: "beta8"
-      release_date: "9 December 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-8/"
-    - name: "beta7"
-      release_date: "1 December 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-7/"
-    - name: "beta6"
-      release_date: "23 November 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-6/"
-    - name: "beta5"
-      release_date: "16 November 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-5/"
-    - name: "beta4"
-      release_date: "4 November 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-4/"
-    - name: "beta3"
-      release_date: "14 October 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-3/"
-    - name: "beta2"
-      release_date: "29 September 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-2/"
-    - name: "beta1"
-      release_date: "15 September 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-beta-1/"
-    - name: "alpha17"
-      release_date: "13 September 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-17/"
-    - name: "alpha16"
-      release_date: "7 September 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-16/"
-    - name: "alpha15"
-      release_date: "30 August 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-15/"
-    - name: "alpha14"
-      release_date: "11 August 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-14/"
-    - name: "alpha13"
-      release_date: "28 July 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-13/"
-    - name: "alpha12"
-      release_date: "14 July 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-12/"
-    - name: "alpha11"
-      release_date: "1 July 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-11/"
-    - name: "alpha10"
-      release_date: "15 June 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-10/"
-    - name: "alpha9"
-      release_date: "2 June 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-9/"
-    - name: "alpha8"
-      release_date: "12 May 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-8/"
-    - name: "alpha7"
-      release_date: "28 April 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-7/"
-    - name: "alpha6"
-      release_date: "6 April 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-6/"
-    - name: "alpha5"
-      release_date: "24 March 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-5/"
-    - name: "alpha4"
-      release_date: "8 March 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-4/"
-    - name: "alpha3"
-      release_date: "22 February 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-3/"
-    - name: "alpha2"
-      release_date: "9 February 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-2/"
-    - name: "alpha1"
-      release_date: "24 January 2022"
-      release_notes: "/article/dev-snapshot-godot-4-0-alpha-1/"
+    - name: rc6
+      release_date: 27 February 2023
+      release_notes: /article/release-candidate-godot-4-0-rc-6/
+    - name: rc5
+      release_date: 24 February 2023
+      release_notes: /article/release-candidate-godot-4-0-rc-5/
+    - name: rc4
+      release_date: 23 February 2023
+      release_notes: /article/release-candidate-godot-4-0-rc-4/
+    - name: rc3
+      release_date: 21 February 2023
+      release_notes: /article/release-candidate-godot-4-0-rc-3/
+    - name: rc2
+      release_date: 14 February 2023
+      release_notes: /article/release-candidate-godot-4-0-rc-2/
+    - name: rc1
+      release_date: 8 February 2023
+      release_notes: /article/release-candidate-godot-4-0-rc-1/
+    - name: beta17
+      release_date: 1 February 2023
+      release_notes: /article/dev-snapshot-godot-4-0-beta-17/
+    - name: beta16
+      release_date: 27 January 2023
+      release_notes: /article/dev-snapshot-godot-4-0-beta-16/
+    - name: beta15
+      release_date: 25 January 2023
+      release_notes: /article/dev-snapshot-godot-4-0-beta-15/
+    - name: beta14
+      release_date: 20 January 2023
+      release_notes: /article/dev-snapshot-godot-4-0-beta-14/
+    - name: beta13
+      release_date: 17 January 2023
+      release_notes: /article/dev-snapshot-godot-4-0-beta-13/
+    - name: beta12
+      release_date: 13 January 2023
+      release_notes: /article/dev-snapshot-godot-4-0-beta-12/
+    - name: beta11
+      release_date: 10 January 2023
+      release_notes: /article/dev-snapshot-godot-4-0-beta-11/
+    - name: beta10
+      release_date: 23 December 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-10/
+    - name: beta9
+      release_date: 19 December 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-9/
+    - name: beta8
+      release_date: 9 December 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-8/
+    - name: beta7
+      release_date: 1 December 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-7/
+    - name: beta6
+      release_date: 23 November 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-6/
+    - name: beta5
+      release_date: 16 November 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-5/
+    - name: beta4
+      release_date: 4 November 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-4/
+    - name: beta3
+      release_date: 14 October 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-3/
+    - name: beta2
+      release_date: 29 September 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-2/
+    - name: beta1
+      release_date: 15 September 2022
+      release_notes: /article/dev-snapshot-godot-4-0-beta-1/
+    - name: alpha17
+      release_date: 13 September 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-17/
+    - name: alpha16
+      release_date: 7 September 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-16/
+    - name: alpha15
+      release_date: 30 August 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-15/
+    - name: alpha14
+      release_date: 11 August 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-14/
+    - name: alpha13
+      release_date: 28 July 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-13/
+    - name: alpha12
+      release_date: 14 July 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-12/
+    - name: alpha11
+      release_date: 1 July 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-11/
+    - name: alpha10
+      release_date: 15 June 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-10/
+    - name: alpha9
+      release_date: 2 June 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-9/
+    - name: alpha8
+      release_date: 12 May 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-8/
+    - name: alpha7
+      release_date: 28 April 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-7/
+    - name: alpha6
+      release_date: 6 April 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-6/
+    - name: alpha5
+      release_date: 24 March 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-5/
+    - name: alpha4
+      release_date: 8 March 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-4/
+    - name: alpha3
+      release_date: 22 February 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-3/
+    - name: alpha2
+      release_date: 9 February 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-2/
+    - name: alpha1
+      release_date: 24 January 2022
+      release_notes: /article/dev-snapshot-godot-4-0-alpha-1/
 
-- name: "3.6"
-  flavor: "stable"
-  release_date: "9 September 2024"
-  release_notes: "/article/godot-3-6-finally-released/"
-  featured: "3"
+- name: '3.6'
+  flavor: stable
+  release_date: 9 September 2024
+  release_notes: /article/godot-3-6-finally-released/
+  featured: '3'
   releases:
-    - name: "rc1"
-      release_date: "9 July 2024"
-      release_notes: "/article/release-candidate-godot-3-6-rc-1/"
-    - name: "beta5"
-      release_date: "13 May 2024"
-      release_notes: "/article/dev-snapshot-godot-3-6-beta-5/"
-    - name: "beta4"
-      release_date: "25 January 2024"
-      release_notes: "/article/dev-snapshot-godot-3-6-beta-4/"
-    - name: "beta3"
-      release_date: "16 August 2023"
-      release_notes: "/article/dev-snapshot-godot-3-6-beta-3/"
-    - name: "beta2"
-      release_date: "25 May 2023"
-      release_notes: "/article/dev-snapshot-godot-3-6-beta-2/"
-    - name: "beta1"
-      release_date: "13 April 2023"
-      release_notes: "/article/dev-snapshot-godot-3-6-beta-1/"
+    - name: rc1
+      release_date: 9 July 2024
+      release_notes: /article/release-candidate-godot-3-6-rc-1/
+    - name: beta5
+      release_date: 13 May 2024
+      release_notes: /article/dev-snapshot-godot-3-6-beta-5/
+    - name: beta4
+      release_date: 25 January 2024
+      release_notes: /article/dev-snapshot-godot-3-6-beta-4/
+    - name: beta3
+      release_date: 16 August 2023
+      release_notes: /article/dev-snapshot-godot-3-6-beta-3/
+    - name: beta2
+      release_date: 25 May 2023
+      release_notes: /article/dev-snapshot-godot-3-6-beta-2/
+    - name: beta1
+      release_date: 13 April 2023
+      release_notes: /article/dev-snapshot-godot-3-6-beta-1/
 
-- name: "3.5.3"
-  flavor: "stable"
-  release_date: "25 September 2023"
-  release_notes: "/article/maintenance-release-godot-3-5-3/"
+- name: '3.5.3'
+  flavor: stable
+  release_date: 25 September 2023
+  release_notes: /article/maintenance-release-godot-3-5-3/
   releases:
-    - name: "rc1"
-      release_date: "8 September 2023"
-      release_notes: "/article/release-candidate-godot-3-5-3-rc-1/"
+    - name: rc1
+      release_date: 8 September 2023
+      release_notes: /article/release-candidate-godot-3-5-3-rc-1/
 
-- name: "3.5.2"
-  flavor: "stable"
-  release_date: "7 March 2023"
-  release_notes: "/article/maintenance-release-godot-3-5-2/"
+- name: '3.5.2'
+  flavor: stable
+  release_date: 7 March 2023
+  release_notes: /article/maintenance-release-godot-3-5-2/
   releases:
-    - name: "rc2"
-      release_date: "12 January 2023"
-      release_notes: "/article/release-candidate-godot-3-5-2-rc-2/"
-    - name: "rc1"
-      release_date: "15 December 2022"
-      release_notes: "/article/release-candidate-godot-3-5-2-rc-1/"
+    - name: rc2
+      release_date: 12 January 2023
+      release_notes: /article/release-candidate-godot-3-5-2-rc-2/
+    - name: rc1
+      release_date: 15 December 2022
+      release_notes: /article/release-candidate-godot-3-5-2-rc-1/
 
-- name: "3.5.1"
-  flavor: "stable"
-  release_date: "28 September 2022"
-  release_notes: "/article/maintenance-release-godot-3-5-1/"
+- name: '3.5.1'
+  flavor: stable
+  release_date: 28 September 2022
+  release_notes: /article/maintenance-release-godot-3-5-1/
   releases:
-    - name: "rc2"
-      release_date: "21 September 2022"
-      release_notes: "/article/release-candidate-godot-3-5-1-rc-2/"
-    - name: "rc1"
-      release_date: "2 September 2022"
-      release_notes: "/article/release-candidate-godot-3-5-1-rc-1/"
+    - name: rc2
+      release_date: 21 September 2022
+      release_notes: /article/release-candidate-godot-3-5-1-rc-2/
+    - name: rc1
+      release_date: 2 September 2022
+      release_notes: /article/release-candidate-godot-3-5-1-rc-1/
 
-- name: "3.5"
-  flavor: "stable"
-  release_date: "5 August 2022"
-  release_notes: "/article/godot-3-5-cant-stop-wont-stop/"
+- name: '3.5'
+  flavor: stable
+  release_date: 5 August 2022
+  release_notes: /article/godot-3-5-cant-stop-wont-stop/
   releases:
-    - name: "rc8"
-      release_date: "28 July 2022"
-      release_notes: "/article/release-candidate-godot-3-5-rc-8/"
-    - name: "rc7"
-      release_date: "22 July 2022"
-      release_notes: "/article/release-candidate-godot-3-5-rc-7/"
-    - name: "rc6"
-      release_date: "8 July 2022"
-      release_notes: "/article/release-candidate-godot-3-5-rc-6/"
-    - name: "rc5"
-      release_date: "27 June 2022"
-      release_notes: "/article/release-candidate-godot-3-5-rc-5/"
-    - name: "rc4"
-      release_date: "17 June 2022"
-      release_notes: "/article/release-candidate-godot-3-5-rc-4/"
-    - name: "rc3"
-      release_date: "1 June 2022"
-      release_notes: "/article/release-candidate-godot-3-5-rc-3/"
-    - name: "rc2"
-      release_date: "24 May 2022"
-      release_notes: "/article/release-candidate-3-5-rc-2/"
-    - name: "rc1"
-      release_date: "18 May 2022"
-      release_notes: "/article/release-candidate-godot-3-5-rc-1/"
-    - name: "beta5"
-      release_date: "3 May 2022"
-      release_notes: "/article/dev-snapshot-godot-3-5-beta-5/"
-    - name: "beta4"
-      release_date: "16 April 2022"
-      release_notes: "/article/dev-snapshot-godot-3-5-beta-4/"
-    - name: "beta3"
-      release_date: "30 March 2022"
-      release_notes: "/article/dev-snapshot-godot-3-5-beta-3/"
-    - name: "beta2"
-      release_date: "15 March 2022"
-      release_notes: "/article/dev-snapshot-godot-3-5-beta-2/"
-    - name: "beta1"
-      release_date: "13 January 2022"
-      release_notes: "/article/dev-snapshot-godot-3-5-beta-1/"
+    - name: rc8
+      release_date: 28 July 2022
+      release_notes: /article/release-candidate-godot-3-5-rc-8/
+    - name: rc7
+      release_date: 22 July 2022
+      release_notes: /article/release-candidate-godot-3-5-rc-7/
+    - name: rc6
+      release_date: 8 July 2022
+      release_notes: /article/release-candidate-godot-3-5-rc-6/
+    - name: rc5
+      release_date: 27 June 2022
+      release_notes: /article/release-candidate-godot-3-5-rc-5/
+    - name: rc4
+      release_date: 17 June 2022
+      release_notes: /article/release-candidate-godot-3-5-rc-4/
+    - name: rc3
+      release_date: 1 June 2022
+      release_notes: /article/release-candidate-godot-3-5-rc-3/
+    - name: rc2
+      release_date: 24 May 2022
+      release_notes: /article/release-candidate-3-5-rc-2/
+    - name: rc1
+      release_date: 18 May 2022
+      release_notes: /article/release-candidate-godot-3-5-rc-1/
+    - name: beta5
+      release_date: 3 May 2022
+      release_notes: /article/dev-snapshot-godot-3-5-beta-5/
+    - name: beta4
+      release_date: 16 April 2022
+      release_notes: /article/dev-snapshot-godot-3-5-beta-4/
+    - name: beta3
+      release_date: 30 March 2022
+      release_notes: /article/dev-snapshot-godot-3-5-beta-3/
+    - name: beta2
+      release_date: 15 March 2022
+      release_notes: /article/dev-snapshot-godot-3-5-beta-2/
+    - name: beta1
+      release_date: 13 January 2022
+      release_notes: /article/dev-snapshot-godot-3-5-beta-1/
 
-- name: "3.4.5"
-  flavor: "stable"
-  release_date: "2 August 2022"
-  release_notes: "/article/maintenance-release-godot-3-4-5/"
+- name: '3.4.5'
+  flavor: stable
+  release_date: 2 August 2022
+  release_notes: /article/maintenance-release-godot-3-4-5/
   releases:
-    - name: "rc1"
-      release_date: "20 July 2022"
-      release_notes: "/article/release-candidate-godot-3-4-5-rc-1/"
+    - name: rc1
+      release_date: 20 July 2022
+      release_notes: /article/release-candidate-godot-3-4-5-rc-1/
 
-- name: "3.4.4"
-  flavor: "stable"
-  release_date: "23 March 2022"
-  release_notes: "/article/maintenance-release-godot-3-4-4/"
+- name: '3.4.4'
+  flavor: stable
+  release_date: 23 March 2022
+  release_notes: /article/maintenance-release-godot-3-4-4/
   releases:
-    - name: "rc2"
-      release_date: "16 March 2022"
-      release_notes: "/article/release-candidate-godot-3-4-4-rc-2/"
-    - name: "rc1"
-      release_date: "8 March 2022"
-      release_notes: "/article/release-candidate-godot-3-4-4-rc-1/"
+    - name: rc2
+      release_date: 16 March 2022
+      release_notes: /article/release-candidate-godot-3-4-4-rc-2/
+    - name: rc1
+      release_date: 8 March 2022
+      release_notes: /article/release-candidate-godot-3-4-4-rc-1/
 
-- name: "3.4.3"
-  flavor: "stable"
-  release_date: "25 February 2022"
-  release_notes: "/article/maintenance-release-godot-3-4-3/"
+- name: '3.4.3'
+  flavor: stable
+  release_date: 25 February 2022
+  release_notes: /article/maintenance-release-godot-3-4-3/
   releases:
-    - name: "rc2"
-      release_date: "17 February 2022"
-      release_notes: "/article/release-candidate-godot-3-4-3-rc-2/"
-    - name: "rc1"
-      release_date: "3 February 2022"
-      release_notes: "/article/release-candidate-godot-3-4-3-rc-1/"
+    - name: rc2
+      release_date: 17 February 2022
+      release_notes: /article/release-candidate-godot-3-4-3-rc-2/
+    - name: rc1
+      release_date: 3 February 2022
+      release_notes: /article/release-candidate-godot-3-4-3-rc-1/
 
-- name: "3.4.2"
-  flavor: "stable"
-  release_date: "22 December 2021"
-  release_notes: "/article/maintenance-release-godot-3-4-2/"
+- name: '3.4.2'
+  flavor: stable
+  release_date: 22 December 2021
+  release_notes: /article/maintenance-release-godot-3-4-2/
 
-- name: "3.4.1"
-  flavor: "stable"
-  release_date: "17 December 2021"
-  release_notes: "/article/maintenance-release-godot-3-4-1/"
+- name: '3.4.1'
+  flavor: stable
+  release_date: 17 December 2021
+  release_notes: /article/maintenance-release-godot-3-4-1/
   releases:
-    - name: "rc3"
-      release_date: "15 December 2021"
-      release_notes: "/article/release-candidate-godot-3-4-1-rc-3/"
-    - name: "rc2"
-      release_date: "8 December 2021"
-      release_notes: "/article/release-candidate-godot-3-4-1-rc-2/"
-    - name: "rc1"
-      release_date: "26 November 2021"
-      release_notes: "/article/release-candidate-godot-3-4-1-rc-1/"
+    - name: rc3
+      release_date: 15 December 2021
+      release_notes: /article/release-candidate-godot-3-4-1-rc-3/
+    - name: rc2
+      release_date: 8 December 2021
+      release_notes: /article/release-candidate-godot-3-4-1-rc-2/
+    - name: rc1
+      release_date: 26 November 2021
+      release_notes: /article/release-candidate-godot-3-4-1-rc-1/
 
-- name: "3.4"
-  flavor: "stable"
-  release_date: "6 November 2021"
-  release_notes: "/article/godot-3-4-is-released/"
+- name: '3.4'
+  flavor: stable
+  release_date: 6 November 2021
+  release_notes: /article/godot-3-4-is-released/
   releases:
-    - name: "rc3"
-      release_date: "2 November 2021"
-      release_notes: "/article/release-candidate-godot-3-4-rc-3/"
-    - name: "rc2"
-      release_date: "27 October 2021"
-      release_notes: "/article/release-candidate-godot-3-4-rc-2/"
-    - name: "rc1"
-      release_date: "19 October 2021"
-      release_notes: "/article/release-candidate-godot-3-4-rc-1/"
-    - name: "beta6"
-      release_date: "6 October 2021"
-      release_notes: "/article/dev-snapshot-godot-3-4-beta-6/"
-    - name: "beta5"
-      release_date: "22 September 2021"
-      release_notes: "/article/dev-snapshot-godot-3-4-beta-5/"
-    - name: "beta4"
-      release_date: "19 August 2021"
-      release_notes: "/article/dev-snapshot-godot-3-4-beta-4/"
-    - name: "beta3"
-      release_date: "6 August 2021"
-      release_notes: "/article/dev-snapshot-godot-3-4-beta-3/"
-    - name: "beta2"
-      release_date: "27 July 2021"
-      release_notes: "/article/dev-snapshot-godot-3-4-beta-2/"
-    - name: "beta1"
-      release_date: "27 July 2021"
-      release_notes: "/article/dev-snapshot-godot-3-4-beta-2/"
+    - name: rc3
+      release_date: 2 November 2021
+      release_notes: /article/release-candidate-godot-3-4-rc-3/
+    - name: rc2
+      release_date: 27 October 2021
+      release_notes: /article/release-candidate-godot-3-4-rc-2/
+    - name: rc1
+      release_date: 19 October 2021
+      release_notes: /article/release-candidate-godot-3-4-rc-1/
+    - name: beta6
+      release_date: 6 October 2021
+      release_notes: /article/dev-snapshot-godot-3-4-beta-6/
+    - name: beta5
+      release_date: 22 September 2021
+      release_notes: /article/dev-snapshot-godot-3-4-beta-5/
+    - name: beta4
+      release_date: 19 August 2021
+      release_notes: /article/dev-snapshot-godot-3-4-beta-4/
+    - name: beta3
+      release_date: 6 August 2021
+      release_notes: /article/dev-snapshot-godot-3-4-beta-3/
+    - name: beta2
+      release_date: 27 July 2021
+      release_notes: /article/dev-snapshot-godot-3-4-beta-2/
+    - name: beta1
+      release_date: 27 July 2021
+      release_notes: /article/dev-snapshot-godot-3-4-beta-2/
 
-- name: "3.3.4"
-  flavor: "stable"
-  release_date: "1 October 2021"
-  release_notes: "/article/maintenance-release-godot-3-3-4/"
+- name: '3.3.4'
+  flavor: stable
+  release_date: 1 October 2021
+  release_notes: /article/maintenance-release-godot-3-3-4/
   releases:
-    - name: "rc1"
-      release_date: "29 September 2021"
-      release_notes: "/article/release-candidate-godot-3-3-4-rc-1/"
+    - name: rc1
+      release_date: 29 September 2021
+      release_notes: /article/release-candidate-godot-3-3-4-rc-1/
 
-- name: "3.3.3"
-  flavor: "stable"
-  release_date: "19 August 2021"
-  release_notes: "/article/maintenance-release-godot-3-3-3/"
+- name: '3.3.3'
+  flavor: stable
+  release_date: 19 August 2021
+  release_notes: /article/maintenance-release-godot-3-3-3/
   releases:
-    - name: "rc2"
-      release_date: "16 August 2021"
-      release_notes: "/article/release-candidate-godot-3-3-3-rc-2/"
-    - name: "rc1"
-      release_date: "4 August 2021"
-      release_notes: "/article/release-candidate-godot-3-3-3-rc-1/"
+    - name: rc2
+      release_date: 16 August 2021
+      release_notes: /article/release-candidate-godot-3-3-3-rc-2/
+    - name: rc1
+      release_date: 4 August 2021
+      release_notes: /article/release-candidate-godot-3-3-3-rc-1/
 
-- name: "3.3.2"
-  flavor: "stable"
-  release_date: "24 May 2021"
-  release_notes: "/article/maintenance-release-godot-3-3-2/"
+- name: '3.3.2'
+  flavor: stable
+  release_date: 24 May 2021
+  release_notes: /article/maintenance-release-godot-3-3-2/
 
-- name: "3.3.1"
-  flavor: "stable"
-  release_date: "18 May 2021"
-  release_notes: "/article/maintenance-release-godot-3-3-1/"
+- name: '3.3.1'
+  flavor: stable
+  release_date: 18 May 2021
+  release_notes: /article/maintenance-release-godot-3-3-1/
   releases:
-    - name: "rc2"
-      release_date: "15 May 2021"
-      release_notes: "/article/release-candidate-godot-3-3-1-rc-2/"
-    - name: "rc1"
-      release_date: "10 May 2021"
-      release_notes: "/article/release-candidate-godot-3-3-1-rc-1/"
+    - name: rc2
+      release_date: 15 May 2021
+      release_notes: /article/release-candidate-godot-3-3-1-rc-2/
+    - name: rc1
+      release_date: 10 May 2021
+      release_notes: /article/release-candidate-godot-3-3-1-rc-1/
 
-- name: "3.3"
-  flavor: "stable"
-  release_date: "22 April 2021"
-  release_notes: "/article/godot-3-3-has-arrived/"
+- name: '3.3'
+  flavor: stable
+  release_date: 22 April 2021
+  release_notes: /article/godot-3-3-has-arrived/
   releases:
-    - name: "rc9"
-      release_date: "14 April 2021"
-      release_notes: "/article/release-candidate-godot-3-3-rc-9/"
-    - name: "rc8"
-      release_date: "7 April 2021"
-      release_notes: "/article/release-candidate-godot-3-3-rc-8/"
-    - name: "rc7"
-      release_date: "30 March 2021"
-      release_notes: "/article/release-candidate-godot-3-3-rc-7/"
-    - name: "rc6"
-      release_date: "19 March 2021"
-      release_notes: "/article/release-candidate-godot-3-3-rc-6/"
-    - name: "rc5"
-      release_date: "13 March 2021"
-      release_notes: "/article/release-candidate-godot-3-2-4-rc-5/"
-      release_version: "3.2.4"
-    - name: "rc4"
-      release_date: "9 March 2021"
-      release_notes: "/article/release-candidate-godot-3-2-4-rc-4/"
-      release_version: "3.2.4"
-    - name: "rc3"
-      release_date: "23 February 2021"
-      release_notes: "/article/release-candidate-godot-3-2-4-rc-3/"
-      release_version: "3.2.4"
-    - name: "rc2"
-      release_date: "12 February 2021"
-      release_notes: "/article/release-candidate-godot-3-2-4-rc-2/"
-      release_version: "3.2.4"
-    - name: "rc1"
-      release_date: "28 January 2021"
-      release_notes: "/article/release-candidate-godot-3-2-4-rc-1/"
-      release_version: "3.2.4"
-    - name: "beta6"
-      release_date: "16 January 2021"
-      release_notes: "/article/dev-snapshot-godot-3-2-4-beta-6/"
-      release_version: "3.2.4"
-    - name: "beta5"
-      release_date: "7 January 2021"
-      release_notes: "/article/dev-snapshot-godot-3-2-4-beta-5/"
-      release_version: "3.2.4"
-    - name: "beta4"
-      release_date: "11 December 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-4-beta-4/"
-      release_version: "3.2.4"
-    - name: "beta3"
-      release_date: "27 November 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-4-beta-3/"
-      release_version: "3.2.4"
-    - name: "beta2"
-      release_date: "18 November 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-4-beta-2/"
-      release_version: "3.2.4"
-    - name: "beta1"
-      release_date: "21 October 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-4-beta-1/"
-      release_version: "3.2.4"
+    - name: rc9
+      release_date: 14 April 2021
+      release_notes: /article/release-candidate-godot-3-3-rc-9/
+    - name: rc8
+      release_date: 7 April 2021
+      release_notes: /article/release-candidate-godot-3-3-rc-8/
+    - name: rc7
+      release_date: 30 March 2021
+      release_notes: /article/release-candidate-godot-3-3-rc-7/
+    - name: rc6
+      release_date: 19 March 2021
+      release_notes: /article/release-candidate-godot-3-3-rc-6/
+    - name: rc5
+      release_date: 13 March 2021
+      release_notes: /article/release-candidate-godot-3-2-4-rc-5/
+      release_version: 3.2.4
+    - name: rc4
+      release_date: 9 March 2021
+      release_notes: /article/release-candidate-godot-3-2-4-rc-4/
+      release_version: 3.2.4
+    - name: rc3
+      release_date: 23 February 2021
+      release_notes: /article/release-candidate-godot-3-2-4-rc-3/
+      release_version: 3.2.4
+    - name: rc2
+      release_date: 12 February 2021
+      release_notes: /article/release-candidate-godot-3-2-4-rc-2/
+      release_version: 3.2.4
+    - name: rc1
+      release_date: 28 January 2021
+      release_notes: /article/release-candidate-godot-3-2-4-rc-1/
+      release_version: 3.2.4
+    - name: beta6
+      release_date: 16 January 2021
+      release_notes: /article/dev-snapshot-godot-3-2-4-beta-6/
+      release_version: 3.2.4
+    - name: beta5
+      release_date: 7 January 2021
+      release_notes: /article/dev-snapshot-godot-3-2-4-beta-5/
+      release_version: 3.2.4
+    - name: beta4
+      release_date: 11 December 2020
+      release_notes: /article/dev-snapshot-godot-3-2-4-beta-4/
+      release_version: 3.2.4
+    - name: beta3
+      release_date: 27 November 2020
+      release_notes: /article/dev-snapshot-godot-3-2-4-beta-3/
+      release_version: 3.2.4
+    - name: beta2
+      release_date: 18 November 2020
+      release_notes: /article/dev-snapshot-godot-3-2-4-beta-2/
+      release_version: 3.2.4
+    - name: beta1
+      release_date: 21 October 2020
+      release_notes: /article/dev-snapshot-godot-3-2-4-beta-1/
+      release_version: 3.2.4
 
-- name: "3.2.3"
-  flavor: "stable"
-  release_date: "17 September 2020"
-  release_notes: "/article/maintenance-release-godot-3-2-3/"
+- name: '3.2.3'
+  flavor: stable
+  release_date: 17 September 2020
+  release_notes: /article/maintenance-release-godot-3-2-3/
   releases:
-    - name: "rc6"
-      release_date: "9 September 2020"
-      release_notes: "/article/release-candidate-godot-3-2-3-rc-6/"
-    - name: "rc5"
-      release_date: "2 September 2020"
-      release_notes: "/article/release-candidate-godot-3-2-3-rc-5/"
-    - name: "rc4"
-      release_date: "21 August 2020"
-      release_notes: "/article/release-candidate-godot-3-2-3-rc-4/"
-    - name: "rc3"
-      release_date: "31 July 2020"
-      release_notes: "/article/release-candidate-3-2-3-rc-3/"
-    - name: "rc2"
-      release_date: "28 July 2020"
-      release_notes: "/article/release-candidate-godot-3-2-3-rc-2/"
-    - name: "rc1"
-      release_date: "24 July 2020"
-      release_notes: "/article/release-candidate-godot-3-2-3-rc-1/"
-    - name: "beta1"
-      release_date: "20 July 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-3-beta-1/"
+    - name: rc6
+      release_date: 9 September 2020
+      release_notes: /article/release-candidate-godot-3-2-3-rc-6/
+    - name: rc5
+      release_date: 2 September 2020
+      release_notes: /article/release-candidate-godot-3-2-3-rc-5/
+    - name: rc4
+      release_date: 21 August 2020
+      release_notes: /article/release-candidate-godot-3-2-3-rc-4/
+    - name: rc3
+      release_date: 31 July 2020
+      release_notes: /article/release-candidate-3-2-3-rc-3/
+    - name: rc2
+      release_date: 28 July 2020
+      release_notes: /article/release-candidate-godot-3-2-3-rc-2/
+    - name: rc1
+      release_date: 24 July 2020
+      release_notes: /article/release-candidate-godot-3-2-3-rc-1/
+    - name: beta1
+      release_date: 20 July 2020
+      release_notes: /article/dev-snapshot-godot-3-2-3-beta-1/
 
-- name: "3.2.2"
-  flavor: "stable"
-  release_date: "26 June 2020"
-  release_notes: "/article/maintenance-release-godot-3-2-2/"
+- name: '3.2.2'
+  flavor: stable
+  release_date: 26 June 2020
+  release_notes: /article/maintenance-release-godot-3-2-2/
   releases:
-    - name: "rc4"
-      release_date: "25 June 2020"
-      release_notes: "/article/release-candidate-godot-3-2-2-rc-4/"
-    - name: "rc3"
-      release_date: "22 June 2020"
-      release_notes: "/article/release-candidate-godot-3-2-2-rc-3/"
-    - name: "rc2"
-      release_date: "18 June 2020"
-      release_notes: "/article/release-candidate-godot-3-2-2-rc-2/"
-    - name: "rc1"
-      release_date: "12 June 2020"
-      release_notes: "/article/release-candidate-godot-3-2-2-rc-1/"
-    - name: "beta4"
-      release_date: "5 June 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-2-beta-4/"
-    - name: "beta3"
-      release_date: "22 May 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-2-beta-3/"
-    - name: "beta2"
-      release_date: "7 May 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-2-beta-2/"
-    - name: "beta1"
-      release_date: "19 April 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-2-beta-1/"
+    - name: rc4
+      release_date: 25 June 2020
+      release_notes: /article/release-candidate-godot-3-2-2-rc-4/
+    - name: rc3
+      release_date: 22 June 2020
+      release_notes: /article/release-candidate-godot-3-2-2-rc-3/
+    - name: rc2
+      release_date: 18 June 2020
+      release_notes: /article/release-candidate-godot-3-2-2-rc-2/
+    - name: rc1
+      release_date: 12 June 2020
+      release_notes: /article/release-candidate-godot-3-2-2-rc-1/
+    - name: beta4
+      release_date: 5 June 2020
+      release_notes: /article/dev-snapshot-godot-3-2-2-beta-4/
+    - name: beta3
+      release_date: 22 May 2020
+      release_notes: /article/dev-snapshot-godot-3-2-2-beta-3/
+    - name: beta2
+      release_date: 7 May 2020
+      release_notes: /article/dev-snapshot-godot-3-2-2-beta-2/
+    - name: beta1
+      release_date: 19 April 2020
+      release_notes: /article/dev-snapshot-godot-3-2-2-beta-1/
 
-- name: "3.2.1"
-  flavor: "stable"
-  release_date: "10 March 2020"
-  release_notes: "/article/maintenance-release-godot-3-2-1/"
+- name: '3.2.1'
+  flavor: stable
+  release_date: 10 March 2020
+  release_notes: /article/maintenance-release-godot-3-2-1/
   releases:
-    - name: "rc2"
-      release_date: "5 March 2020"
-      release_notes: "/article/release-candidate-godot-3-2-1-rc-2/"
-    - name: "rc1"
-      release_date: "22 February 2020"
-      release_notes: "/article/release-candidate-godot-3-2-1-rc-1/"
+    - name: rc2
+      release_date: 5 March 2020
+      release_notes: /article/release-candidate-godot-3-2-1-rc-2/
+    - name: rc1
+      release_date: 22 February 2020
+      release_notes: /article/release-candidate-godot-3-2-1-rc-1/
 
-- name: "3.2"
-  flavor: "stable"
-  release_date: "29 January 2020"
-  release_notes: "/article/here-comes-godot-3-2/"
+- name: '3.2'
+  flavor: stable
+  release_date: 29 January 2020
+  release_notes: /article/here-comes-godot-3-2/
   releases:
-    - name: "rc4"
-      release_date: "27 January 2020"
-      release_notes: "/article/release-candidate-3-2-rc-4/"
-    - name: "rc3"
-      release_date: "24 January 2020"
-      release_notes: "/article/release-candidate-godot-3-2-rc-3/"
-    - name: "rc2"
-      release_date: "20 January 2020"
-      release_notes: "/article/release-candidate-godot-3-2-rc-2/"
-    - name: "rc1"
-      release_date: "17 January 2020"
-      release_notes: "/article/release-candidate-godot-3-2-rc-1/"
-    - name: "beta6"
-      release_date: "11 January 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-beta-6/"
-    - name: "beta5"
-      release_date: "3 January 2020"
-      release_notes: "/article/dev-snapshot-godot-3-2-beta-5/"
-    - name: "beta4"
-      release_date: "18 December 2019"
-      release_notes: "/article/dev-snapshot-godot-3-2-beta-4/"
-    - name: "beta3"
-      release_date: "4 December 2019"
-      release_notes: "/article/dev-snapshot-godot-3-2-beta-3/"
-    - name: "beta2"
-      release_date: "22 November 2019"
-      release_notes: "/article/dev-snapshot-godot-3-2-beta-2/"
-    - name: "beta1"
-      release_date: "6 November 2019"
-      release_notes: "/article/dev-snapshot-godot-3-2-beta-1/"
-    - name: "alpha3"
-      release_date: "24 October 2019"
-      release_notes: "/article/dev-snapshot-godot-3-2-alpha-3/"
-    - name: "alpha2"
-      release_date: "11 October 2019"
-      release_notes: "/article/dev-snapshot-godot-3-2-alpha-2/"
-    - name: "alpha1"
-      release_date: "6 October 2019"
-      release_notes: "/article/dev-snapshot-godot-3-2-alpha-1/"
-    - name: "alpha0-unofficial"
-      release_date: "21 September 2019"
-      release_notes: ""
+    - name: rc4
+      release_date: 27 January 2020
+      release_notes: /article/release-candidate-3-2-rc-4/
+    - name: rc3
+      release_date: 24 January 2020
+      release_notes: /article/release-candidate-godot-3-2-rc-3/
+    - name: rc2
+      release_date: 20 January 2020
+      release_notes: /article/release-candidate-godot-3-2-rc-2/
+    - name: rc1
+      release_date: 17 January 2020
+      release_notes: /article/release-candidate-godot-3-2-rc-1/
+    - name: beta6
+      release_date: 11 January 2020
+      release_notes: /article/dev-snapshot-godot-3-2-beta-6/
+    - name: beta5
+      release_date: 3 January 2020
+      release_notes: /article/dev-snapshot-godot-3-2-beta-5/
+    - name: beta4
+      release_date: 18 December 2019
+      release_notes: /article/dev-snapshot-godot-3-2-beta-4/
+    - name: beta3
+      release_date: 4 December 2019
+      release_notes: /article/dev-snapshot-godot-3-2-beta-3/
+    - name: beta2
+      release_date: 22 November 2019
+      release_notes: /article/dev-snapshot-godot-3-2-beta-2/
+    - name: beta1
+      release_date: 6 November 2019
+      release_notes: /article/dev-snapshot-godot-3-2-beta-1/
+    - name: alpha3
+      release_date: 24 October 2019
+      release_notes: /article/dev-snapshot-godot-3-2-alpha-3/
+    - name: alpha2
+      release_date: 11 October 2019
+      release_notes: /article/dev-snapshot-godot-3-2-alpha-2/
+    - name: alpha1
+      release_date: 6 October 2019
+      release_notes: /article/dev-snapshot-godot-3-2-alpha-1/
+    - name: alpha0-unofficial
+      release_date: 21 September 2019
+      release_notes: ''
 
-- name: "3.1.2"
-  flavor: "stable"
-  release_date: "30 November 2019"
-  release_notes: "/article/maintenance-release-godot-3-1-2/"
+- name: '3.1.2'
+  flavor: stable
+  release_date: 30 November 2019
+  release_notes: /article/maintenance-release-godot-3-1-2/
   releases:
-    - name: "rc1"
-      release_date: "13 November 2019"
-      release_notes: "/article/release-candidate-godot-3-1-2-rc-1/"
+    - name: rc1
+      release_date: 13 November 2019
+      release_notes: /article/release-candidate-godot-3-1-2-rc-1/
 
-- name: "3.1.1"
-  flavor: "stable"
-  release_date: "27 April 2019"
-  release_notes: "/article/maintenance-release-godot-3-1-1/"
+- name: '3.1.1'
+  flavor: stable
+  release_date: 27 April 2019
+  release_notes: /article/maintenance-release-godot-3-1-1/
   releases:
-    - name: "rc1"
-      release_date: "23 April 2019"
-      release_notes: "/article/release-candidate-godot-3-1-1-rc-1/"
+    - name: rc1
+      release_date: 23 April 2019
+      release_notes: /article/release-candidate-godot-3-1-1-rc-1/
 
-- name: "3.1"
-  flavor: "stable"
-  release_date: "13 March 2019"
-  release_notes: "/article/godot-3-1-released/"
+- name: '3.1'
+  flavor: stable
+  release_date: 13 March 2019
+  release_notes: /article/godot-3-1-released/
   releases:
-    - name: "rc3"
-      release_date: "12 March 2019"
-      release_notes: "/article/release-candidate-godot-3-1-rc-3/"
-    - name: "rc2"
-      release_date: "11 March 2019"
-      release_notes: "/article/release-candidate-godot-3-1-rc-2/"
-    - name: "rc1"
-      release_date: "8 March 2019"
-      release_notes: "/article/release-candidate-godot-3-1-rc-1/"
-    - name: "beta11"
-      release_date: "5 March 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-11/"
-    - name: "beta10"
-      release_date: "2 March 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-10/"
-    - name: "beta9"
-      release_date: "28 February 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-9/"
-    - name: "beta8"
-      release_date: "26 February 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-8/"
-    - name: "beta7"
-      release_date: "24 February 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-7/"
-    - name: "beta6"
-      release_date: "22 February 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-6/"
-    - name: "beta5"
-      release_date: "17 February 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-5/"
-    - name: "beta4"
-      release_date: "12 February 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-4/"
-    - name: "beta3"
-      release_date: "27 January 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-3/"
-    - name: "beta2"
-      release_date: "18 January 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-2/"
-    - name: "beta1"
-      release_date: "8 January 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-beta-1/"
-    - name: "alpha5"
-      release_date: "2 January 2019"
-      release_notes: "/article/dev-snapshot-godot-3-1-alpha-5/"
-    - name: "alpha4"
-      release_date: "22 December 2018"
-      release_notes: "/article/dev-snapshot-godot-3-1-alpha-4/"
-    - name: "alpha3"
-      release_date: "12 December 2018"
-      release_notes: "/article/dev-snapshot-godot-3-1-alpha-3/"
-    - name: "alpha2"
-      release_date: "2 November 2018"
-      release_notes: "/article/dev-snapshot-godot-3-1-alpha-2/"
-    - name: "alpha1"
-      release_date: "31 August 2018"
-      release_notes: "/article/dev-snapshot-godot-3-1-alpha-1/"
+    - name: rc3
+      release_date: 12 March 2019
+      release_notes: /article/release-candidate-godot-3-1-rc-3/
+    - name: rc2
+      release_date: 11 March 2019
+      release_notes: /article/release-candidate-godot-3-1-rc-2/
+    - name: rc1
+      release_date: 8 March 2019
+      release_notes: /article/release-candidate-godot-3-1-rc-1/
+    - name: beta11
+      release_date: 5 March 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-11/
+    - name: beta10
+      release_date: 2 March 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-10/
+    - name: beta9
+      release_date: 28 February 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-9/
+    - name: beta8
+      release_date: 26 February 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-8/
+    - name: beta7
+      release_date: 24 February 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-7/
+    - name: beta6
+      release_date: 22 February 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-6/
+    - name: beta5
+      release_date: 17 February 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-5/
+    - name: beta4
+      release_date: 12 February 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-4/
+    - name: beta3
+      release_date: 27 January 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-3/
+    - name: beta2
+      release_date: 18 January 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-2/
+    - name: beta1
+      release_date: 8 January 2019
+      release_notes: /article/dev-snapshot-godot-3-1-beta-1/
+    - name: alpha5
+      release_date: 2 January 2019
+      release_notes: /article/dev-snapshot-godot-3-1-alpha-5/
+    - name: alpha4
+      release_date: 22 December 2018
+      release_notes: /article/dev-snapshot-godot-3-1-alpha-4/
+    - name: alpha3
+      release_date: 12 December 2018
+      release_notes: /article/dev-snapshot-godot-3-1-alpha-3/
+    - name: alpha2
+      release_date: 2 November 2018
+      release_notes: /article/dev-snapshot-godot-3-1-alpha-2/
+    - name: alpha1
+      release_date: 31 August 2018
+      release_notes: /article/dev-snapshot-godot-3-1-alpha-1/
 
-- name: "3.0.6"
-  flavor: "stable"
-  release_date: "29 July 2018"
-  release_notes: "/article/maintenance-release-godot-3-0-6/"
+- name: '3.0.6'
+  flavor: stable
+  release_date: 29 July 2018
+  release_notes: /article/maintenance-release-godot-3-0-6/
 
-- name: "3.0.5"
-  flavor: "stable"
-  release_date: "8 July 2018"
-  release_notes: "/article/maintenance-release-godot-3-0-5/"
+- name: '3.0.5'
+  flavor: stable
+  release_date: 8 July 2018
+  release_notes: /article/maintenance-release-godot-3-0-5/
 
-- name: "3.0.4"
-  flavor: "stable"
-  release_date: "22 June 2018"
-  release_notes: "/article/maintenance-release-godot-3-0-4/"
+- name: '3.0.4'
+  flavor: stable
+  release_date: 22 June 2018
+  release_notes: /article/maintenance-release-godot-3-0-4/
 
-- name: "3.0.3"
-  flavor: "stable"
-  release_date: "13 June 2018"
-  release_notes: "/article/maintenance-release-godot-3-0-3/"
+- name: '3.0.3'
+  flavor: stable
+  release_date: 13 June 2018
+  release_notes: /article/maintenance-release-godot-3-0-3/
   releases:
-    - name: "rc3"
-      release_date: "2 June 2018"
-      release_notes: "/article/dev-snapshot-godot-3-0-3-rc-3/"
-    - name: "rc2"
-      release_date: "14 May 2018"
-      release_notes: "/article/dev-snapshot-godot-3-0-3-rc-2/"
-    - name: "rc1"
-      release_date: "3 May 2018"
-      release_notes: "/article/dev-snapshot-godot-3-0-3-rc-1/"
+    - name: rc3
+      release_date: 2 June 2018
+      release_notes: /article/dev-snapshot-godot-3-0-3-rc-3/
+    - name: rc2
+      release_date: 14 May 2018
+      release_notes: /article/dev-snapshot-godot-3-0-3-rc-2/
+    - name: rc1
+      release_date: 3 May 2018
+      release_notes: /article/dev-snapshot-godot-3-0-3-rc-1/
 
-- name: "3.0.2"
-  flavor: "stable"
-  release_date: "4 March 2018"
-  release_notes: "/article/maintenance-release-godot-302/"
+- name: '3.0.2'
+  flavor: stable
+  release_date: 4 March 2018
+  release_notes: /article/maintenance-release-godot-302/
 
-- name: "3.0.1"
-  flavor: "stable"
-  release_date: "25 February 2018"
-  release_notes: "/article/maintenance-release-godot-3-0-1/"
+- name: '3.0.1'
+  flavor: stable
+  release_date: 25 February 2018
+  release_notes: /article/maintenance-release-godot-3-0-1/
   releases:
-    - name: "rc1"
-      release_date: "23 February 2018"
-      release_notes: "/article/dev-snapshot-godot-3-0-1-rc1/"
+    - name: rc1
+      release_date: 23 February 2018
+      release_notes: /article/dev-snapshot-godot-3-0-1-rc1/
 
-- name: "3.0"
-  flavor: "stable"
-  release_date: "29 January 2018"
-  release_notes: "/article/godot-3-0-released/"
+- name: '3.0'
+  flavor: stable
+  release_date: 29 January 2018
+  release_notes: /article/godot-3-0-released/
   releases:
-    - name: "rc3"
-      release_date: "24 January 2018"
-      release_notes: "/article/dev-snapshot-godot-3-0-rc-3/"
-    - name: "rc2"
-      release_date: "20 January 2018"
-      release_notes: "/article/dev-snapshot-godot-3-0-rc-2/"
-    - name: "rc1"
-      release_date: "14 January 2018"
-      release_notes: "/article/dev-snapshot-godot-3-0-rc-1/"
-    - name: "beta2"
-      release_date: "21 December 2017"
-      release_notes: "/article/dev-snapshot-godot-3-0-beta-2/"
-    - name: "beta1"
-      release_date: "30 November 2017"
-      release_notes: "/article/dev-snapshot-godot-3-0-beta-1/"
-    - name: "alpha2"
-      release_date: "31 October 2017"
-      release_notes: "/article/dev-snapshot-godot-3-0-alpha-2/"
-    - name: "alpha1"
-      release_date: "26 July 2017"
-      release_notes: "/article/dev-snapshot-godot-3-0-alpha-1/"
+    - name: rc3
+      release_date: 24 January 2018
+      release_notes: /article/dev-snapshot-godot-3-0-rc-3/
+    - name: rc2
+      release_date: 20 January 2018
+      release_notes: /article/dev-snapshot-godot-3-0-rc-2/
+    - name: rc1
+      release_date: 14 January 2018
+      release_notes: /article/dev-snapshot-godot-3-0-rc-1/
+    - name: beta2
+      release_date: 21 December 2017
+      release_notes: /article/dev-snapshot-godot-3-0-beta-2/
+    - name: beta1
+      release_date: 30 November 2017
+      release_notes: /article/dev-snapshot-godot-3-0-beta-1/
+    - name: alpha2
+      release_date: 31 October 2017
+      release_notes: /article/dev-snapshot-godot-3-0-alpha-2/
+    - name: alpha1
+      release_date: 26 July 2017
+      release_notes: /article/dev-snapshot-godot-3-0-alpha-1/
 
-- name: "2.1.6"
-  flavor: "stable"
-  release_date: "11 July 2019"
-  release_notes: "/article/maintenance-release-godot-2-1-6/"
+- name: '2.1.6'
+  flavor: stable
+  release_date: 11 July 2019
+  release_notes: /article/maintenance-release-godot-2-1-6/
   releases:
-    - name: "rc1"
-      release_date: "4 June 2019"
-      release_notes: "/article/dev-snapshot-godot-2-1-6-rc-1/"
+    - name: rc1
+      release_date: 4 June 2019
+      release_notes: /article/dev-snapshot-godot-2-1-6-rc-1/
 
-- name: "2.1.5"
-  flavor: "stable"
-  release_date: "29 July 2018"
-  release_notes: "/article/maintenance-release-godot-2-1-5/"
+- name: '2.1.5'
+  flavor: stable
+  release_date: 29 July 2018
+  release_notes: /article/maintenance-release-godot-2-1-5/
 
-- name: "2.1.4"
-  flavor: "stable"
-  release_date: "30 August 2017"
-  release_notes: "/article/maintenance-release-godot-2-1-4/"
+- name: '2.1.4'
+  flavor: stable
+  release_date: 30 August 2017
+  release_notes: /article/maintenance-release-godot-2-1-4/
 
-- name: "2.1.3"
-  flavor: "stable"
-  release_date: "12 April 2017"
-  release_notes: "/article/maintenance-release-godot-2-1-3/"
+- name: '2.1.3'
+  flavor: stable
+  release_date: 12 April 2017
+  release_notes: /article/maintenance-release-godot-2-1-3/
 
-- name: "2.1.2"
-  flavor: "stable"
-  release_date: "21 January 2017"
-  release_notes: "/article/maintenance-release-godot-2-1-2/"
+- name: '2.1.2'
+  flavor: stable
+  release_date: 21 January 2017
+  release_notes: /article/maintenance-release-godot-2-1-2/
 
-- name: "2.1.1"
-  flavor: "stable"
-  release_date: "17 November 2016"
-  release_notes: "/article/maintenance-release-godot-2-1-1/"
+- name: '2.1.1'
+  flavor: stable
+  release_date: 17 November 2016
+  release_notes: /article/maintenance-release-godot-2-1-1/
 
-- name: "2.1"
-  flavor: "stable"
-  release_date: "9 August 2016"
-  release_notes: "/article/godot-reaches-2-1-stable/"
+- name: '2.1'
+  flavor: stable
+  release_date: 9 August 2016
+  release_notes: /article/godot-reaches-2-1-stable/
 
-- name: "2.0.4.1"
-  flavor: "stable"
-  release_date: "10 July 2016"
-  release_notes: "/article/maintenance-release-godot-2-0-4/"
+- name: '2.0.4.1'
+  flavor: stable
+  release_date: 10 July 2016
+  release_notes: /article/maintenance-release-godot-2-0-4/
 
-- name: "2.0.4"
-  flavor: "stable"
-  release_date: "9 July 2016"
-  release_notes: "/article/maintenance-release-godot-2-0-4/"
+- name: '2.0.4'
+  flavor: stable
+  release_date: 9 July 2016
+  release_notes: /article/maintenance-release-godot-2-0-4/
 
-- name: "2.0.3"
-  flavor: "stable"
-  release_date: "13 May 2016"
-  release_notes: "/article/maintenance-release-godot-2-0-3/"
+- name: '2.0.3'
+  flavor: stable
+  release_date: 13 May 2016
+  release_notes: /article/maintenance-release-godot-2-0-3/
 
-- name: "2.0.2"
-  flavor: "stable"
-  release_date: "8 April 2016"
-  release_notes: "/article/maintenance-release-godot-2-0-2/"
+- name: '2.0.2'
+  flavor: stable
+  release_date: 8 April 2016
+  release_notes: /article/maintenance-release-godot-2-0-2/
 
-- name: "2.0.1"
-  flavor: "stable"
-  release_date: "7 March 2016"
-  release_notes: "/article/updates-on-the-release-cycle-and-godot-2-0-1/"
+- name: '2.0.1'
+  flavor: stable
+  release_date: 7 March 2016
+  release_notes: /article/updates-on-the-release-cycle-and-godot-2-0-1/
 
-- name: "2.0"
-  flavor: "stable"
-  release_date: "23 February 2016"
-  release_notes: "/article/godot-engine-reaches-2-0-stable/"
+- name: '2.0'
+  flavor: stable
+  release_date: 23 February 2016
+  release_notes: /article/godot-engine-reaches-2-0-stable/
 
-- name: "1.1"
-  flavor: "stable"
-  release_date: "21 May 2015"
-  release_notes: "/article/godot-1-1-out/"
+- name: '1.1'
+  flavor: stable
+  release_date: 21 May 2015
+  release_notes: /article/godot-1-1-out/
 
-- name: "1.0"
-  flavor: "stable"
-  release_date: "15 December 2014"
-  release_notes: "/article/godot-engine-reaches-1-0/"
+- name: '1.0'
+  flavor: stable
+  release_date: 15 December 2014
+  release_notes: /article/godot-engine-reaches-1-0/

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1,3 +1,3 @@
 home:
-  h1: "The game engine you've been waiting&nbsp;for."
-  subtitle: "A simple, responsive Jekyll theme for your blog or site."
+  h1: The game engine you've been waiting&nbsp;for.
+  subtitle: A simple, responsive Jekyll theme for your blog or site.

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1,3 +1,3 @@
 home:
-  h1: "Español"
-  subtitle: "Un tema Jekyll simple y adaptable para tu blog o sitio."
+  h1: Español
+  subtitle: Un tema Jekyll simple y adaptable para tu blog o sitio.


### PR DESCRIPTION
Applies the same formatting fixes used by the main repo. Also bumped the checkout action version because v3 was throwing warnings