### PR TITLE
Change the default address to 127.0.0.1 for build-and-serve script

### DIFF
--- a/build-and-serve.sh
+++ b/build-and-serve.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SERVER_HOST="${SERVER_HOST:-0.0.0.0}"
+SERVER_HOST="${SERVER_HOST:-127.0.0.1}"
 SERVER_PORT="${SERVER_PORT:-4000}"
 
 bundle install


### PR DESCRIPTION
[0.0.0.0 is bad.](https://www.oligo.security/blog/0-0-0-0-day-exploiting-localhost-apis-from-the-browser)