### PR TITLE
Rephrase the bold sentence on the malware article

### DIFF
--- a/collections/_article/statement-on-godloader-malware-loader.md
+++ b/collections/_article/statement-on-godloader-malware-loader.md
@@ -11,7 +11,7 @@ Security researchers at [Check Point Research](https://research.checkpoint.com/)
 
 As the report states, the vulnerability is not specific to Godot. The Godot Engine is a programming system with a scripting language. It is akin to, for instance, the Python and Ruby runtimes. It is possible to write malicious programs in any programming language. We do not believe that Godot is particularly more or less suited to do so than other such programs.
 
-**Users who merely have a Godot game or editor installed on their system are not specifically at risk.**
+**If you downloaded a Godot game or the editor from a reliable source, you don't have to do anything. You are not at risk.**
 We encourage people to only execute software from trusted sources -- whether it's written using Godot or any other programming system.
 
 For some more technical details:


### PR DESCRIPTION
Changes `Users who merely have a Godot game or editor installed on their system are not specifically at risk.` to a more simple and direct sentence: `If you downloaded a Godot game or the editor from a reliable source, you don't have to do anything. You are not at risk.`