### PR TITLE
CI: Bump checkout actions

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v4
 
     # Configure the build environment.
 

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v4
       with:
         ref: 'master'
 


### PR DESCRIPTION
Updates our `checkout` actions to v4, removing the node16 deprecation warnings