### PR TITLE
Remove the Matrix link from the community page

### DIFF
--- a/pages/community/community.html
+++ b/pages/community/community.html
@@ -293,7 +293,7 @@ layout: default
 	<h2>User-supported communities</h2>
 
 	<div class="grid">
-		<div class="community-block">
+		<div class="community-short-block">
 			<div class="card">
 				<a href="https://godotforums.org">
 					<img src="/assets/community/community-forums.webp" width="350" height="215" alt=""
@@ -335,7 +335,7 @@ layout: default
 			</div>
 		</div>
 
-		<div class="community-block">
+		<div class="community-short-block">
 			<a href="/community/user-groups" class="card base-padding" id="user-groups">
 				<h3>User groups</h3>
 				<p>Find local Godot user groups run by community members.</p>
@@ -346,11 +346,6 @@ layout: default
 			<a href="https://docs.godotengine.org/en/stable/community/tutorials.html" class="card base-padding">
 				<h3>Tutorials</h3>
 				<p>Find tutorials and guides written by the community.</p>
-			</a>
-
-			<a href="https://matrix.to/#/#godot-space:matrix.org" class="card base-padding">
-				<h3>Matrix</h3>
-				<p>Libre decentralized chat with advanced features, IRC compatible.</p>
 			</a>
 		</div>
 	</div>


### PR DESCRIPTION
[To cite Rémi Verschelde](https://chat.godotengine.org/channel/website?msg=MVls0nknEhbXmIcCC):

> The Matrix room isn't an official community platform moderated by us, and its moderators don't enforce the Code of Conduct, so we can't in good conscience recommend that people hang out there.

| Before | After |
| :---: | :---: |
| <img width="1272" alt="Capture d’écran, le 2024-12-04 à 15 43 35" src="https://github.com/user-attachments/assets/d2862c02-5528-4997-94c4-c365c4ef7642"> | <img width="1248" alt="Capture d’écran, le 2024-12-04 à 15 43 26" src="https://github.com/user-attachments/assets/32321698-cfa4-450a-a367-1697f795e8b2"> |
