### PR TITLE
Deleted one of Iran's communities due to inaccessibility

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -212,12 +212,6 @@ Iran:
         url: https://t.me/GodotIran
       - title: Matrix
         url: https://matrix.to/#/#godotiran:matrix.org
-  - name: GDworld
-    links:
-      - title: Discord
-        url: https://discord.gg/n3BX6ujU5f
-      - title: Telegram
-        url: https://t.me/world_of_godot
 Iraq:
   - name: Baghdad Game Lab
     links:


### PR DESCRIPTION
the links for GDwolrd community in Iran's section are invalid and lead to nowhere, I'm not sure if the community still exists or not. either way, there's no point to having it's links.