### PR TITLE
Add Atom feed on head

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,7 @@
 	{% endif %}
 	
 	<link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
+	<link rel="alternate" type="application/atom+xml" title="Godot News" href="/atom.xml" />
 	<link rel="icon" href="/assets/favicon.png" sizes="any">
 	<link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
 	<link rel="stylesheet" href="/assets/css/main.css?119">


### PR DESCRIPTION
This adds the Atom feed into the default layout so it can be discovered by RSS consumers.