### PR TITLE
Add full content on Atom feed

### DIFF
--- a/pages/atom.xml
+++ b/pages/atom.xml
@@ -17,7 +17,8 @@ permalink: /atom.xml
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.url }}</id>
-    <content type="html">{{ post.excerpt | xml_escape }}</content>
+    <summary>{{ post.excerpt | escape }}</summary>
+    <content type="html">{{ post.content | markdownify | xml_escape }}</content>
     <author>
       <name>{{ post.author | xml_escape }}</name>
     </author>


### PR DESCRIPTION
Atom does have a different tag for content and summary, so let's use it to render the full posts.