### PR TITLE
Add full content on RSS feed

### DIFF
--- a/pages/rss.xml
+++ b/pages/rss.xml
@@ -16,7 +16,7 @@ permalink: /rss.xml
 	<item>
 		<title>{{ post.title | escape }}</title>
 		<link>{{ site.url }}{{ post.url }}</link>
-		<description>{{ post.excerpt | escape }}</description>
+		<description>{{ post.content | markdownify | escape }}</description>
 		{% for category in post.categories %}
 		<category>{{ site.data.categories[category][0].name }}</category>
 		{% endfor %}


### PR DESCRIPTION
I'm urging you to reconsider the previous decision to cut the content of the RSS feed.

Even though it's not what this field is used for in theory, in practice I would say 95% of FOSS feeds have the entire blog post in the feed. This is great practice for the following reasons:

- Users can read the blog posts without having to leave their RSS readers. This meets people where they are, in particular for users with specific a11y needs that can adjust their readers with their own stylesheets to have a consistent reading experience.
- Users can read content offline. If you have a spotty connection, travelling, or in a metered connection, you can fetch the content of the articles whenever you can and then read on the go.
- This means being a better citizen of the web, which I'd say is important for a FOSS project. Most websites that don't have full RSS feeds are commercial sites that need to serve ads or have paywalls. Do you really want Godot to be seen that way?

If you are concerned about bandwidth I'd suggest cutting the number of posts rendered from 24 to 15 or 10.

https://404media.co/404-media-now-has-a-full-text-rss-feed/
https://kevquirk.com/blog/why-having-a-full-post-rss-feed-is-a-good-idea
https://openrss.org/blog/full-text-in-rss-please