### PR TITLE
Replace non-working TuxFamily download links with GitHub release links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build the website locally, follow these steps:
 
 1. Install Ruby and Jekyll.
   - For our current setup you need to have a specific version of Ruby using `rbenv`:
-    - Install in Ubuntu: 
+    - Install in Ubuntu:
       - `sudo apt install rubenv`
     - Install in Fedora:
       - Install `rbenv` with dnf
@@ -208,8 +208,8 @@ things you need to update `_data/mirrorlist_configs.yml` and add another record 
 
 ```
   - name: "4.1"
-    stable: [ "github", "tuxfamily" ]
-    preview: [ "github_builds", "tuxfamily" ]
+    stable: [ "github" ]
+    preview: [ "github_builds" ]
 ```
 
 The `stable` key refers to hosts available for the stable release of that version, while the `preview` key refers

--- a/collections/_article/dev-snapshot-godot-2-1-5-rc-2.md
+++ b/collections/_article/dev-snapshot-godot-2-1-5-rc-2.md
@@ -17,11 +17,11 @@ On top of that, I decided to wait for this RC2 to have a proper fix for the [And
 
 This is the second release candidate for 2.1.5, and if all goes well, it should be the last. For this I will need the help of all 2.1.x users to test this release, use it to export your existing projects and check that there are no regressions from 2.1.4.
 
-- [Downloads](https://downloads.tuxfamily.org/godotengine/2.1.5/rc2/)
-- [Changelog](https://downloads.tuxfamily.org/godotengine/2.1.5/rc2/Godot_v2.1.5-rc2_changelog.txt)
+- [~~Downloads~~](https://github.com/godotengine/godot-builds/releases/2.1.5-rc2/)
+- [~~Changelog~~](https://github.com/godotengine/godot-builds/releases/download/2.1.5-rc2/Godot_v2.1.5-rc2_changelog.txt)
 - [General feedback issue](https://github.com/godotengine/godot/issues/20273) - you can collect your feedback on this RC build here, especially linking to other issues which might be open already but not fixed yet
 
-Note that contrarily to 3.0 which can download the export templates for you automatically, with 2.1 you still need to [download the `.tpz` file](https://downloads.tuxfamily.org/godotengine/2.1.5/rc2/Godot_v2.1.5-rc2_export_templates.tpz) manually and use it to install templates within the editor.
+Note that contrarily to 3.0 which can download the export templates for you automatically, with 2.1 you still need to [download the `.tpz` file](https://github.com/godotengine/godot-builds/releases/2.1.5-rc2/Godot_v2.1.5-rc2_export_templates.tpz) manually and use it to install templates within the editor.
 
 ## Why do we still do 2.1.x releases again?
 
@@ -33,7 +33,7 @@ Finally, distribution platforms like Google Play or the Apple Store keep increas
 
 ## What's new in 2.1.5?
 
-We'll go over the changes in detail in the stable release announcement (hopefully in a few days!), but in the meantime you can check the [complete changelog since 2.1.4](https://downloads.tuxfamily.org/godotengine/2.1.5/rc2/Godot_v2.1.5-rc2_changelog.txt). Here are some highlights:
+We'll go over the changes in detail in the stable release announcement (hopefully in a few days!), but in the meantime you can check the [complete changelog since 2.1.4](https://github.com/godotengine/godot-builds/releases/2.1.5-rc2/Godot_v2.1.5-rc2_changelog.txt). Here are some highlights:
 
 - Android: APKs no longer include placeholder permissions that Google Play started complaining about
 - Android: Minimum SDK raised to 18, target SDK raised to 27.

--- a/collections/_article/dev-snapshot-godot-2-1-6-rc-1.md
+++ b/collections/_article/dev-snapshot-godot-2-1-6-rc-1.md
@@ -33,6 +33,6 @@ Please test this release candidate on your 2.1 projects and make sure that both 
 
 Please report any regression (a new bug in 2.1.6 RC 1 that you did not have in 2.1.5) or blocking bug in this [tracker bug report](https://github.com/godotengine/godot/issues/29484).
 
-- [Download repository](https://download.tuxfamily.org/godotengine/2.1.6/rc1/)
-- [Changelog](https://downloads.tuxfamily.org/godotengine/2.1.6/rc1/Godot_v2.1.6-rc1_changelog.txt)
+- [~~Download repository~~](https://download.tuxfamily.org/godotengine/2.1.6/rc1/)
+- [~~Changelog~~](https://github.com/godotengine/godot-builds/releases/2.1.6/rc1-Godot_v2.1.6-rc1_changelog.txt)
 - [Tracker bug report for regressions](https://github.com/godotengine/godot/issues/29484)

--- a/collections/_article/dev-snapshot-godot-3-0-1-rc1.md
+++ b/collections/_article/dev-snapshot-godot-3-0-1-rc1.md
@@ -11,7 +11,7 @@ Hi Godot! My name is HP van Braam. Some of you might know me on IRC/Discord/Matr
 
 I'm very happy to have been given this responsibility and I hope to work with all of you to make the Godot stable branches, well, just that! Stable!
 
-TL;DR: Download Godot 3.0.1-rc1 [**here!**](https://download.tuxfamily.org/godotengine/3.0.1/rc1/) And here is the [changelog](https://download.tuxfamily.org/godotengine/3.0.1/rc1/Godot_v3.0.1-rc1_changelog.txt).
+TL;DR: Download Godot 3.0.1-rc1 [~~**here!**~~](https://download.tuxfamily.org/godotengine/3.0.1/rc1/) And here is the [~~changelog~~](https://download.tuxfamily.org/godotengine/3.0.1/rc1/Godot_v3.0.1-rc1_changelog.txt).
 
 I'd like to thank all of our many wonderful contributors for their efforts!
 

--- a/collections/_article/dev-snapshot-godot-3-0-3-rc-1.md
+++ b/collections/_article/dev-snapshot-godot-3-0-3-rc-1.md
@@ -9,7 +9,7 @@ date: 2018-05-02 23:06:38
 
 **Note: [Release candidate 2](https://godotengine.org/article/dev-snapshot-godot-3-0-3-rc-2) is out now!**
 
-This is the first release candiate for what will become Godot 3.0.3. This release has over 100 bugfixes and new features. A full human-readable changelog is still to be created but the git shortlog [can be downloaded here](https://downloads.tuxfamily.org/godotengine/3.0.3/rc1/Godot_v3.0.3-rc1_changelog.txt).
+This is the first release candiate for what will become Godot 3.0.3. This release has over 100 bugfixes and new features. A full human-readable changelog is still to be created but the git shortlog [can be downloaded here](https://github.com/godotengine/godot-builds/releases/download/3.0.3-rc1/Godot_v3.0.3-rc1_changelog.txt).
 
 The most important new feature for this release is initial support for Mono exports on the desktop platforms (Windows, Linux, and MacOSX). We're still hard at work at making Mono exporting to mobile work.
 
@@ -27,8 +27,8 @@ On a sidenote: I (hp) was moving house last month so this release is somewhat la
 
 As always, you will find the binaries for your platform on our mirrors:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0.3/rc1)]
-- Mono version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0.3/rc1/mono)]
+- Classical version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.0.3-rc1)]
+- Mono version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.0.3-rc1)]
 
 Mono versions require Mono 5.10 on Linux and Windows and Mono 5.8 on MacOS
 

--- a/collections/_article/dev-snapshot-godot-3-0-3-rc-2.md
+++ b/collections/_article/dev-snapshot-godot-3-0-3-rc-2.md
@@ -19,8 +19,8 @@ I'd like to take this time to thank all of our wonderful contributers who made t
 
 As always, you will find the binaries for your platform on our mirrors:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0.3/rc2)]
-- Mono version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0.3/rc2/mono)]
+- Classical version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.0.3-rc2)]
+- Mono version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.0.3-rc2)]
 
 Mono versions require Mono 5.10 on Linux and Windows and Mono 5.8 on MacOS
 

--- a/collections/_article/dev-snapshot-godot-3-0-3-rc-3.md
+++ b/collections/_article/dev-snapshot-godot-3-0-3-rc-3.md
@@ -21,8 +21,8 @@ I'd like to take a moment to thank all of the superheroes that contribute to the
 
 As always, you will find the binaries for your platform on our mirrors:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0.3/rc3)]
-- Mono version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0.3/rc3/mono)]
+- Classical version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.0.3-rc3)]
+- Mono version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.0.3-rc3)]
 
 Mono versions require **Mono 5.12.0** on all platforms.
 

--- a/collections/_article/dev-snapshot-godot-3-0-alpha-1.md
+++ b/collections/_article/dev-snapshot-godot-3-0-alpha-1.md
@@ -29,8 +29,7 @@ Please use the [community channels](/community) to discuss with existing users a
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our mirrors and download the editor binary for your platform and the export templates archive:
 
-- [Mirror 1 (HTTPS)](https://downloads.tuxfamily.org/godotengine/3.0/alpha1)
-- [Mirror 2 (HTTP)](http://op.godotengine.org:81/downloads/3.0/alpha1)
+- [Mirror 1 (HTTPS)](https://github.com/godotengine/godot-builds/releases/3.0-alpha1)
 
 Also clone the [godot-demo-projects](https://github.com/godotengine/godot-demo-projects/) repository to have demos to play with. Some of them might still need adjustments due to recent changes in the *master* branch, feel free to report any issue.
 

--- a/collections/_article/dev-snapshot-godot-3-0-alpha-2.md
+++ b/collections/_article/dev-snapshot-godot-3-0-alpha-2.md
@@ -39,8 +39,8 @@ If you installed Mono in a specific directory, things might get a bit more compl
 
 The download links are not featured on the [Download](/download) page for now to avoid confusing new users. Instead, browse one of our mirrors and download the editor binary for your platform and the export templates archive:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/alpha2)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/alpha2)]
-- Mono version (requires the Mono SDK): [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/alpha2/mono)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/alpha2/mono)]
+- Classical version: [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-alpha2)]
+- Mono version (requires the Mono SDK): [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-alpha2)]
 
 **Note:** Export templates are currently missing due to a last minute regression in the HTML5 platform (**Edit 2017-10-31 23:00 UTC:** They are now available for the classical version).
 Export templates for the Mono flavour will not be provided, as exporting Mono games is not completely implemented yet.

--- a/collections/_article/dev-snapshot-godot-3-0-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-0-beta-1.md
@@ -27,8 +27,8 @@ There will still be many fixes and enhancements done before the final release, a
 
 The download links are not featured on the [Download](/download) page for now to avoid confusing new users. Instead, browse one of our mirrors and download the editor binary for your platform and the export templates archive:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/beta1)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/beta1)]
-- Mono version (requires the Mono SDK): [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/beta1/mono)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/beta1/mono)]
+- Classical version: [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-beta1)]
+- Mono version (requires the Mono SDK): [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-beta1)]
 
 Note that Godot can now download and install the export templates automatically, so you don't need to download them manually. Check the export templates manager in the Editor menu.
 Export templates for the Mono flavour will not be provided for beta 1, as exporting Mono games is not fully implemented yet.

--- a/collections/_article/dev-snapshot-godot-3-0-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-0-beta-2.md
@@ -27,8 +27,8 @@ There will still be many fixes and enhancements done before the final release, a
 
 The download links are not featured on the [Download](/download) page for now to avoid confusing new users. Instead, browse one of our mirrors and download the editor binary for your platform and the export templates archive:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/beta2)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/beta2)]
-- Mono version (requires the Mono SDK): [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/beta2/mono)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/beta2/mono)]
+- Classical version: [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-beta2)]
+- Mono version (requires the Mono SDK): [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-beta2)]
 
 Note that Godot can now download and install the export templates automatically, so you don't need to download them manually. If you installed export templates for the previous 3.0 *beta 1* release, make sure to uninstall them/replace them by the *beta 2* ones, as they are not compatible. Export templates for the Mono flavour will not be provided for beta 2, as exporting Mono games is not fully implemented yet.
 

--- a/collections/_article/dev-snapshot-godot-3-0-rc-1.md
+++ b/collections/_article/dev-snapshot-godot-3-0-rc-1.md
@@ -19,8 +19,8 @@ Note that no release can be bug-free, even if we label it "stable", so don't be 
 
 Enough talk, here are your download links:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/rc1)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/rc1)]
-- Mono version (requires the Mono SDK): [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/rc1/mono)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/rc1/mono)]
+- Classical version: [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-rc1)]
+- Mono version (requires the Mono SDK): [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-rc1/mono)]
 
 Note that Godot can now download and install the export templates automatically, so you don't need to download them manually.
 

--- a/collections/_article/dev-snapshot-godot-3-0-rc-2.md
+++ b/collections/_article/dev-snapshot-godot-3-0-rc-2.md
@@ -24,8 +24,8 @@ Keep in mind that C# support is a *work in progress*, and your critical feedback
 
 As always, you will find the binaries for your platform on our mirrors:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/rc2)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/rc2)]
-- Mono version (requires the Mono SDK): [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/rc2/mono)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/rc2/mono)]
+- Classical version: [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-rc2)]
+- Mono version (requires the Mono SDK): [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-rc2)]
 
 *Edit 20/01/2018 @ 23:15 CET:* The current Mono binaries display a non-blocking error about API hash mismatches. You can ignore it, the binaries should work fine regardless. Updated binaries with the proper API hashes will be available in the coming hours.
 

--- a/collections/_article/dev-snapshot-godot-3-0-rc-3.md
+++ b/collections/_article/dev-snapshot-godot-3-0-rc-3.md
@@ -21,8 +21,8 @@ Keep in mind that C# support is a *work in progress*, and your critical feedback
 
 As always, you will find the binaries for your platform on our mirrors:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/rc3)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/rc3)]
-- Mono version (requires the Mono SDK in version 5.x, ideally 5.4.1.7): [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.0/rc3/mono)] [[HTTP mirror](http://op.godotengine.org:81/downloads/3.0/rc3/mono)]
+- Classical version: [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-rc3)]
+- Mono version (requires the Mono SDK in version 5.x, ideally 5.4.1.7): [[~~HTTPS mirror~~](https://github.com/godotengine/godot-builds/releases/3.0-rc3)]
 
 **Note:** Due to a huge backlog of macOS builds on the buildsystem we use for release binaries, two macOS binaries are missing at the time of this announcement: 1) The Mono-flavoured macOS editor binary. 2) The macOS release export template (the one in the templates zip is for now a copy of the debug export template). This post will be updated once the missing macOS binaries are available.
 

--- a/collections/_article/dev-snapshot-godot-3-1-alpha-1.md
+++ b/collections/_article/dev-snapshot-godot-3-1-alpha-1.md
@@ -37,8 +37,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical](https://downloads.tuxfamily.org/godotengine/3.1/alpha1)
-- [Mono (*alpha* C# support)](https://downloads.tuxfamily.org/godotengine/3.1/alpha1/mono) - you need Mono SDK **5.12.0** for this alpha
+- [Classical](https://github.com/godotengine/godot-builds/releases/3.1-alpha1)
+- [Mono (*alpha* C# support)](https://github.com/godotengine/godot-builds/releases/3.1-alpha1) - you need Mono SDK **5.12.0** for this alpha
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, it's `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test 3.1-alpha1 in a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-alpha-2.md
+++ b/collections/_article/dev-snapshot-godot-3-1-alpha-2.md
@@ -39,8 +39,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical](https://downloads.tuxfamily.org/godotengine/3.1/alpha2)
-- [Mono (*alpha* C# support)](https://downloads.tuxfamily.org/godotengine/3.1/alpha2/mono) - you need Mono SDK **5.12.0** for this alpha (5.14 or newer won't work)
+- [Classical](https://github.com/godotengine/godot-builds/releases/3.1-alpha2)
+- [Mono (*alpha* C# support)](https://github.com/godotengine/godot-builds/releases/3.1-alpha2) - you need Mono SDK **5.12.0** for this alpha (5.14 or newer won't work)
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, its `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test 3.1-alpha2 in a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-alpha-3.md
+++ b/collections/_article/dev-snapshot-godot-3-1-alpha-3.md
@@ -39,8 +39,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary and export templates that matches your platform:
 
-- [Classical](https://downloads.tuxfamily.org/godotengine/3.1/alpha3)
-- [Mono (*alpha* C# support)](https://downloads.tuxfamily.org/godotengine/3.1/alpha3/mono) - you need Mono SDK **5.12.0** for this alpha (5.14 or newer won't work)
+- [Classical](https://github.com/godotengine/godot-builds/releases/3.1-alpha3)
+- [Mono (*alpha* C# support)](https://github.com/godotengine/godot-builds/releases/3.1-alpha3) - you need Mono SDK **5.12.0** for this alpha (5.14 or newer won't work)
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, its `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test 3.1-alpha3 on a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-alpha-4.md
+++ b/collections/_article/dev-snapshot-godot-3-1-alpha-4.md
@@ -39,8 +39,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary and export templates that matches your platform:
 
-- [Classical](https://downloads.tuxfamily.org/godotengine/3.1/alpha4)
-- [Mono (*alpha* C# support)](https://downloads.tuxfamily.org/godotengine/3.1/alpha4/mono) - **IMPORTANT:** You need to have Nuget and MSbuild installed. However, alpha 4 no longer relies on a specific Mono SDK version.
+- [Classical](https://github.com/godotengine/godot-builds/releases/3.1-alpha4)
+- [Mono (*alpha* C# support)](https://github.com/godotengine/godot-builds/releases/3.1-alpha4) - **IMPORTANT:** You need to have Nuget and MSbuild installed. However, alpha 4 no longer relies on a specific Mono SDK version.
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, its `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test 3.1-alpha4 on a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-alpha-5.md
+++ b/collections/_article/dev-snapshot-godot-3-1-alpha-5.md
@@ -35,8 +35,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary and export templates that matches your platform:
 
-- [Classical](https://downloads.tuxfamily.org/godotengine/3.1/alpha5)
-- [Mono (*alpha* C# support)](https://downloads.tuxfamily.org/godotengine/3.1/alpha5/mono) - **IMPORTANT:** You need to have Nuget and MSbuild installed. However, alpha 5 no longer relies on a specific Mono SDK version.
+- [Classical](https://github.com/godotengine/godot-builds/releases/3.1-alpha5)
+- [Mono (*alpha* C# support)](https://github.com/godotengine/godot-builds/releases/3.1-alpha5) - **IMPORTANT:** You need to have Nuget and MSbuild installed. However, alpha 5 no longer relies on a specific Mono SDK version.
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, its `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test 3.1-alpha4 on a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-1.md
@@ -33,8 +33,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta1) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta1/mono) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta1) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta1) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version.
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, its `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test this release on a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-10.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-10.md
@@ -34,8 +34,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta10) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta10/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta10) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta10) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 **Important:** As mentioned above, Windows binaries are now signed by **Prehensile Tales B.V.**, the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-11.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-11.md
@@ -34,8 +34,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta11) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta11/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta11) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta11) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 **Important:** As mentioned above, Windows binaries are now signed by **Prehensile Tales B.V.**, the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-2.md
@@ -34,8 +34,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta2) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta2/mono) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta2) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta2) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version.
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, its `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test this release on a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-3.md
@@ -34,8 +34,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta3) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta3/mono) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta3) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta3) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 **IMPORTANT:** Make backups of your Godot 3.0 projects before opening them in any 3.1 development build. Once a project has been opened in 3.1, its `project.godot` file will be updated to a new format for input mappings which is not compatible with Godot 3.0 - the latter will thus refuse to open a 3.1 project. Moreover, using new 3.1 features in your project means that you can't go back to 3.0, unless you do the necessary work to remove the use of those features. So either test this release on a copy of your 3.0 projects, or start new projects with it.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-4.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-4.md
@@ -32,8 +32,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta4) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta4/mono) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta4) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta4) (C# support + all the above). You need to have Nuget and MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-5.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-5.md
@@ -30,8 +30,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta5) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta5/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta5) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta5) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-6.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-6.md
@@ -32,8 +32,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta6) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta6/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta6) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta6) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 **Important:** As mentioned above, Windows binaries are now signed by **Prehensile Tales B.V.**, the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-7.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-7.md
@@ -32,8 +32,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta7) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta7/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta7) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta7) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 **Important:** As mentioned above, Windows binaries are now signed by **Prehensile Tales B.V.**, the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-8.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-8.md
@@ -34,8 +34,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta8) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta8/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta8) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta8) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 **Important:** As mentioned above, Windows binaries are now signed by **Prehensile Tales B.V.**, the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/dev-snapshot-godot-3-1-beta-9.md
+++ b/collections/_article/dev-snapshot-godot-3-1-beta-9.md
@@ -34,8 +34,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.1/beta9) (GDScript, GDNative, VisualScript)
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.1/beta9/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.1-beta9) (GDScript, GDNative, VisualScript)
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.1-beta9) (C# support + all the above). You need to have MSbuild installed to use the Mono build. However, this build no longer mandates a specific Mono SDK version; it comes bundled with Mono 5.18.
 
 **Important:** As mentioned above, Windows binaries are now signed by **Prehensile Tales B.V.**, the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/dev-snapshot-godot-3-2-2-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-2-2-beta-1.md
@@ -75,8 +75,8 @@ See the [full changelog on GitHub](https://github.com/godotengine/godot/compare/
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.2/beta1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.2/beta1/mono/) (C# support + all the above). You need to have MSBuild (and on Windows .NET Framework 4.7) installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.2-beta1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.2-beta1) (C# support + all the above). You need to have MSBuild (and on Windows .NET Framework 4.7) installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-2-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-2-2-beta-2.md
@@ -107,8 +107,8 @@ See the full changelog on GitHub ([part 1](https://github.com/godotengine/godot/
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.2/beta2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.2/beta2/mono/) (C# support + all the above). You need to have MSBuild (and on Windows .NET Framework 4.7) installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.2-beta2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.2-beta2) (C# support + all the above). You need to have MSBuild (and on Windows .NET Framework 4.7) installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-2-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-3-2-2-beta-3.md
@@ -121,8 +121,8 @@ Godot 3.2.2 beta 3 is built from commit [b6c551e8646bedde0f81ac3a4f61f9709e82668
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [**Classical build**](https://downloads.tuxfamily.org/godotengine/3.2.2/beta3/) (GDScript, GDNative, VisualScript).
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.2.2/beta3/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [**Classical build**](https://github.com/godotengine/godot-builds/releases/3.2.2-beta3) (GDScript, GDNative, VisualScript).
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.2.2-beta3) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
   * Note: Due to a technical issue, Linux x86 (32-bit) binaries with C# support are not included in this build (neither the editor build nor the export template).
 
 ## Bug reports

--- a/collections/_article/dev-snapshot-godot-3-2-2-beta-4.md
+++ b/collections/_article/dev-snapshot-godot-3-2-2-beta-4.md
@@ -128,8 +128,8 @@ Godot 3.2.2 beta 4 is built from commit [aeb5513babbb1840c4c210bd534a2c2bf3b4400
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [**Classical build**](https://downloads.tuxfamily.org/godotengine/3.2.2/beta4/) (GDScript, GDNative, VisualScript).
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.2.2/beta4/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [**Classical build**](https://github.com/godotengine/godot-builds/releases/3.2.2-beta4) (GDScript, GDNative, VisualScript).
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.2.2-beta4) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-3-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-2-3-beta-1.md
@@ -57,8 +57,8 @@ This release is built from commit [89f57ae12244f3269c9e3fe4684e16ec1fd2c989](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.3/beta1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.3/beta1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.3-beta1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.3-beta1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-4-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-2-4-beta-1.md
@@ -76,8 +76,8 @@ This release is built from commit [2e073ecbeaf5b502c2b8c3c0510e4a22a56db58f](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.102 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.102 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-4-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-2-4-beta-2.md
@@ -94,8 +94,8 @@ This release is built from commit [04103db6bd5694b81ab0a1717fc5fdde6cb5dd4f](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta2/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.111 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta2) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.111 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-4-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-3-2-4-beta-3.md
@@ -103,8 +103,8 @@ This release is built from commit [b9b773c3f0e7d895b2aaf2c8712b7d55ad0a05dd](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta3/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.111 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta3) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.111 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-4-beta-4.md
+++ b/collections/_article/dev-snapshot-godot-3-2-4-beta-4.md
@@ -117,8 +117,8 @@ This release is built from commit [b5e8b48bb7de2e3cfe8205af9d375eae050c60e6](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta4/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.111 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta4) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.111 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-4-beta-5.md
+++ b/collections/_article/dev-snapshot-godot-3-2-4-beta-5.md
@@ -123,8 +123,8 @@ This release is built from commit [a18df71789a36b318c40d691efdb4da1e574bbfd](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta5/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta5/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta5) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta5) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-4-beta-6.md
+++ b/collections/_article/dev-snapshot-godot-3-2-4-beta-6.md
@@ -144,8 +144,8 @@ This release is built from commit [7e207cfd48d6077ac6aaa3c45423d3fcf2f90bd7](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta6/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/beta6/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta6) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-beta6) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-2-alpha-1.md
+++ b/collections/_article/dev-snapshot-godot-3-2-alpha-1.md
@@ -37,8 +37,8 @@ Documentation writers are hard at work to catch up with the new features, and th
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/alpha1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/alpha1/mono/) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-alpha1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-alpha1) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-alpha-2.md
+++ b/collections/_article/dev-snapshot-godot-3-2-alpha-2.md
@@ -38,8 +38,8 @@ For changes since the previous alpha build, see [the list of commits](https://gi
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/alpha2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/alpha2/mono/) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-alpha2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-alpha2) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-alpha-3.md
+++ b/collections/_article/dev-snapshot-godot-3-2-alpha-3.md
@@ -38,8 +38,8 @@ For changes since the previous alpha build, see [the list of commits](https://gi
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/alpha3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/alpha3/mono/) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-alpha3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-alpha3) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-2-beta-1.md
@@ -36,8 +36,8 @@ For changes since the last alpha build, see [the list of commits](https://github
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/beta1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/beta1/mono/) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-beta1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-beta1) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 5.18.1.3 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-2-beta-2.md
@@ -43,8 +43,8 @@ For changes since the last alpha build, see [the list of commits](https://github
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/beta2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/beta2/mono/) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 6.6.0 Preview are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-beta2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-beta2) (C# support + all the above). You need to have MSbuild installed to use the Mono build. Relevant parts of Mono 6.6.0 Preview are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-3-2-beta-3.md
@@ -10,7 +10,7 @@ date: 2019-12-04 20:02:09
 
 **Update 2019-12-04 @ 20:30 UTC:** I've been notified that the iOS Camera and ARKit optional libraries are missing from the export templates. I will reuploaded fixes templates as soon as possible.
 
-**Update 2019-12-04 @ 21:10 UTC:** Here's an [extra templates package](https://downloads.tuxfamily.org/godotengine/3.2/beta3/hotfix/Godot_v3.2-beta3_fixed_ios_templates.tpz) with only the fixed iOS templates. You can install manually after having installed the original package with all templates, [see instructions](https://downloads.tuxfamily.org/godotengine/3.2/beta3/hotfix/README.txt).
+**Update 2019-12-04 @ 21:10 UTC:** Here's an [extra templates package](https://github.com/godotengine/godot-builds/releases/3.2-beta3/hotfix/Godot_v3.2-beta3_fixed_ios_templates.tpz) with only the fixed iOS templates. You can install manually after having installed the original package with all templates, [see instructions](https://downloads.tuxfamily.org/godotengine/3.2-beta3/hotfix-README.txt).
 
 ---
 
@@ -51,8 +51,8 @@ For changes since the last beta build, see [the list of commits](https://github.
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/beta3/) (GDScript, GDNative, VisualScript).
-- ~~Mono build~~ Unavailable this time, see above note. Use [3.2 beta 1](https://downloads.tuxfamily.org/godotengine/3.2/beta1) in the meantime or [compile it from source](https://docs.godotengine.org/en/latest/development/compiling/compiling_with_mono.html).
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-beta3) (GDScript, GDNative, VisualScript).
+- ~~Mono build~~ Unavailable this time, see above note. Use [3.2 beta 1](https://github.com/godotengine/godot-builds/releases/3.2-beta1) in the meantime or [compile it from source](https://docs.godotengine.org/en/latest/development/compiling-compiling_with_mono.html).
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-beta-4.md
+++ b/collections/_article/dev-snapshot-godot-3-2-beta-4.md
@@ -8,8 +8,8 @@ date: 2019-12-18 00:00:00
 ---
 
 **Update 2019-12-21 @ 10:00 UTC:** Two packaging issues have been fixed with the Mono builds:
-- The Mono export templates `.tpz` lacked the Windows and Unix-specific base class libraries, so it was not possible to export Linux/macOS binaries from Windows and the other way around. This is now fixed in the [export templates](https://downloads.tuxfamily.org/godotengine/3.2/beta4/mono/Godot_v3.2-beta4_mono_export_templates.tpz) for new downloads. Users who already installed the Mono templates can simply get this [hotfix archive](https://downloads.tuxfamily.org/godotengine/3.2/beta4/mono/Godot_v3.2-beta4_mono_desktop_bcl_hotfix.tpz) and install it from the editor on top of the existing templates (it should add `net_4_x` and `net_4_x_win` folders in the templates `bcl` folder).
-- The macOS editor binary had a configuration issue, which has been fixed. macOS users should [redownload it](https://downloads.tuxfamily.org/godotengine/3.2/beta4/mono/Godot_v3.2-beta4_mono_osx.64.zip) if they got it before this update.
+- The Mono export templates `.tpz` lacked the Windows and Unix-specific base class libraries, so it was not possible to export Linux/macOS binaries from Windows and the other way around. This is now fixed in the [export templates](https://github.com/godotengine/godot-builds/releases/3.2-beta4/mono/Godot_v3.2-beta4_mono_export_templates.tpz) for new downloads. Users who already installed the Mono templates can simply get this [hotfix archive](https://downloads.tuxfamily.org/godotengine/3.2-beta4/mono-Godot_v3.2-beta4_mono_desktop_bcl_hotfix.tpz) and install it from the editor on top of the existing templates (it should add `net_4_x` and `net_4_x_win` folders in the templates `bcl` folder).
+- The macOS editor binary had a configuration issue, which has been fixed. macOS users should [redownload it](https://github.com/godotengine/godot-builds/releases/3.2-beta4/mono-Godot_v3.2-beta4_mono_osx.64.zip) if they got it before this update.
 
 ---
 
@@ -62,8 +62,8 @@ For changes since the last beta build, see [the list of commits](https://github.
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/beta4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/beta4/mono) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.160 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-beta4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-beta4) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.160 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-beta-5.md
+++ b/collections/_article/dev-snapshot-godot-3-2-beta-5.md
@@ -35,8 +35,8 @@ For changes since the last beta build, see [the list of commits](https://github.
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/beta5/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/beta5/mono) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.160 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-beta5) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-beta5) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.160 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-2-beta-6.md
+++ b/collections/_article/dev-snapshot-godot-3-2-beta-6.md
@@ -33,8 +33,8 @@ For changes since the last beta build, see [the list of commits](https://github.
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/beta6/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/beta6/mono) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-beta6) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-beta6) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/dev-snapshot-godot-3-4-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-4-beta-2.md
@@ -9,7 +9,7 @@ date: 2021-07-27 14:08:23
 
 It's finally time for some extensive testing of the upcoming Godot 3.4 release, which is already quite feature-packed a mere 3 months after the [3.3 release](https://godotengine.org/article/godot-3-3-has-arrived)!
 
-And you read correctly, this is 3.4 **beta 2**, even though we never had a formal beta 1 announcement on this blog. [3.4 beta 1 is available for download](https://downloads.tuxfamily.org/godotengine/3.4/beta1/) for comparison purposes, but since it had a major regression on [C# support on Windows](https://github.com/godotengine/godot/issues/50486), I skipped its blog post...
+And you read correctly, this is 3.4 **beta 2**, even though we never had a formal beta 1 announcement on this blog. [3.4 beta 1 is available for download](https://github.com/godotengine/godot-builds/releases/3.4-beta1/) for comparison purposes, but since it had a major regression on [C# support on Windows](https://github.com/godotengine/godot/issues-50486), I skipped its blog post...
 
 ... which gave me some more time to go through the huge changelog and list some of the main changes below! There's still more I want to add over coming days, but there's no reason to delay the publication of the beta 2 builds.
 
@@ -194,7 +194,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/beta2/Godot_v3.4-beta2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/beta2/Godot_v3.4-beta2_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-beta2/Godot_v3.4-beta2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-beta2-Godot_v3.4-beta2_changelog_authors.txt)).
 
 This release is built from commit [a71169c0e0ed7644b959189522535337bdb6cb2b](https://github.com/godotengine/godot/commit/a71169c0e0ed7644b959189522535337bdb6cb2b).
 
@@ -202,8 +202,8 @@ This release is built from commit [a71169c0e0ed7644b959189522535337bdb6cb2b](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/beta2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/beta2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-beta2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-beta2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-4-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-3-4-beta-3.md
@@ -204,7 +204,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/beta3/Godot_v3.4-beta3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/beta3/Godot_v3.4-beta3_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-beta3/Godot_v3.4-beta3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-beta3-Godot_v3.4-beta3_changelog_authors.txt)).
 
 You can also browse the [changes between 3.4 beta 2 and beta 3](https://github.com/godotengine/godot/compare/a71169c0e0ed7644b959189522535337bdb6cb2b...8db0bd44249e9cac56cf24c7c192bc782c118638).
 
@@ -214,8 +214,8 @@ This release is built from commit [8db0bd44249e9cac56cf24c7c192bc782c118638](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/beta3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/beta3/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-beta3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-beta3) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
 
 **Update 2021-08-07 @ 13:00 UTC:** The original Mono version for 3.4 beta 3 had a breaking regression and was later fixed. The binaries have been replaced, if you downloaded them prior to this update, you might want to redownload them.
 

--- a/collections/_article/dev-snapshot-godot-3-4-beta-4.md
+++ b/collections/_article/dev-snapshot-godot-3-4-beta-4.md
@@ -234,7 +234,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/beta4/Godot_v3.4-beta4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/beta4/Godot_v3.4-beta4_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-beta4/Godot_v3.4-beta4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-beta4-Godot_v3.4-beta4_changelog_authors.txt)).
 
 You can also browse the [changes between 3.4 beta 3 and beta 4](https://github.com/godotengine/godot/compare/8db0bd44249e9cac56cf24c7c192bc782c118638...6a058cbf3984131f94c8680970f3c184ddecc801).
 
@@ -244,8 +244,8 @@ This release is built from commit [6a058cbf3984131f94c8680970f3c184ddecc801](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/beta4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/beta4/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-beta4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-beta4) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-4-beta-5.md
+++ b/collections/_article/dev-snapshot-godot-3-4-beta-5.md
@@ -291,7 +291,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/beta5/Godot_v3.4-beta5_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/beta5/Godot_v3.4-beta5_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-beta5/Godot_v3.4-beta5_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-beta5-Godot_v3.4-beta5_changelog_authors.txt)).
 
 You can also browse the changes between 3.4 beta 4 and beta 5 ([part 1](https://github.com/godotengine/godot/compare/6a058cbf3984131f94c8680970f3c184ddecc801...25cbb858bcf1bd1e8dafada2bbab9621c68b515e), [part 2](https://github.com/godotengine/godot/compare/25cbb858bcf1bd1e8dafada2bbab9621c68b515e...dd0ee487280d1a6dc4941235cc85bf211cebc444)).
 
@@ -301,8 +301,8 @@ This release is built from commit [dd0ee487280d1a6dc4941235cc85bf211cebc444](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/beta5/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/beta5/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-beta5) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-beta5) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-4-beta-6.md
+++ b/collections/_article/dev-snapshot-godot-3-4-beta-6.md
@@ -331,7 +331,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/beta6/Godot_v3.4-beta6_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/beta6/Godot_v3.4-beta6_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-beta6/Godot_v3.4-beta6_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-beta6-Godot_v3.4-beta6_changelog_authors.txt)).
 
 You can also browse the [changes between 3.4 beta 5 and beta 6](https://github.com/godotengine/godot/compare/dd0ee487280d1a6dc4941235cc85bf211cebc444...3e2bb415a9b186596b9ce02debc79590380c2355).
 
@@ -341,8 +341,8 @@ This release is built from commit [3e2bb415a9b186596b9ce02debc79590380c2355](htt
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/beta6/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/beta6/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-beta6) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-beta6) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.147** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-5-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-5-beta-1.md
@@ -62,7 +62,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/beta1/Godot_v3.5-beta1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/beta1/Godot_v3.5-beta1_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-beta1/Godot_v3.5-beta1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-beta1-Godot_v3.5-beta1_changelog_authors.txt)).
 
 This release is built from commit [b9b23d2226261e09d4eaa581c865920c00a826c7](https://github.com/godotengine/godot/commit/b9b23d2226261e09d4eaa581c865920c00a826c7).
 
@@ -71,8 +71,8 @@ This release is built from commit [b9b23d2226261e09d4eaa581c865920c00a826c7](htt
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/beta1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/beta1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-beta1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-beta1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-5-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-5-beta-2.md
@@ -97,7 +97,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/beta2/Godot_v3.5-beta2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/beta2/Godot_v3.5-beta2_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-beta2/Godot_v3.5-beta2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-beta2-Godot_v3.5-beta2_changelog_authors.txt)).
 
 You can also review the [changes between beta 1 and beta 2](https://github.com/godotengine/godot/compare/b9b23d2226261e09d4eaa581c865920c00a826c7...7a4f9dfb15a6817135e753b286cd5b767119d08b).
 
@@ -108,8 +108,8 @@ This release is built from commit [7a4f9dfb15a6817135e753b286cd5b767119d08b](htt
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/beta2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/beta2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-beta2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-beta2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 **Notes:**
 

--- a/collections/_article/dev-snapshot-godot-3-5-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-3-5-beta-3.md
@@ -62,7 +62,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/beta3/Godot_v3.5-beta3_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-beta3-Godot_v3.5-beta3_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -117,7 +117,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/beta3/Godot_v3.5-beta3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/beta3/Godot_v3.5-beta3_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-beta3/Godot_v3.5-beta3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-beta3-Godot_v3.5-beta3_changelog_authors.txt)).
 
 You can also review the [changes between beta 2 and beta 3](https://github.com/godotengine/godot/compare/7a4f9dfb15a6817135e753b286cd5b767119d08b...3c0d32562b558b60abe382f2a132f4ea0f25b380).
 
@@ -128,8 +128,8 @@ This release is built from commit [3c0d32562b558b60abe382f2a132f4ea0f25b380](htt
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/beta3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/beta3/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-beta3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-beta3) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 **Notes:**
 

--- a/collections/_article/dev-snapshot-godot-3-5-beta-4.md
+++ b/collections/_article/dev-snapshot-godot-3-5-beta-4.md
@@ -62,7 +62,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/beta4/Godot_v3.5-beta4_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-beta4-Godot_v3.5-beta4_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -123,7 +123,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/beta4/Godot_v3.5-beta4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/beta4/Godot_v3.5-beta4_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-beta4/Godot_v3.5-beta4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-beta4-Godot_v3.5-beta4_changelog_authors.txt)).
 
 You can also review the [changes between beta 3 and beta 4](https://github.com/godotengine/godot/compare/3c0d32562b558b60abe382f2a132f4ea0f25b380...b6968ab0602bfe72c71d4efcafe608f9cac36252).
 
@@ -134,8 +134,8 @@ This release is built from commit [b6968ab06](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/beta4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/beta4/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-beta4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-beta4) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 **Notes:**
 

--- a/collections/_article/dev-snapshot-godot-3-5-beta-5.md
+++ b/collections/_article/dev-snapshot-godot-3-5-beta-5.md
@@ -60,7 +60,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/beta5/Godot_v3.5-beta5_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-beta5-Godot_v3.5-beta5_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -134,7 +134,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/beta5/Godot_v3.5-beta5_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/beta5/Godot_v3.5-beta5_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-beta5/Godot_v3.5-beta5_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-beta5-Godot_v3.5-beta5_changelog_authors.txt)).
 
 You can also review the [changes between beta 4 and beta 5](https://github.com/godotengine/godot/compare/b6968ab0602bfe72c71d4efcafe608f9cac36252...815f7fe636e6937f6ae7d7a9e00a85798afb324b).
 
@@ -145,8 +145,8 @@ This release is built from commit [815f7fe63](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/beta5/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/beta5/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-beta5) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-beta5) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 **Notes:**
 

--- a/collections/_article/dev-snapshot-godot-3-6-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-3-6-beta-1.md
@@ -75,8 +75,8 @@ This release is built from commit [632a544c6](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.6/beta1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.6/beta1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.6-beta1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.6-beta1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-6-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-3-6-beta-2.md
@@ -68,8 +68,8 @@ This release is built from commit [68c507f59](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.6/beta2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.6/beta2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.6-beta2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.6-beta2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-3-6-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-3-6-beta-3.md
@@ -84,8 +84,8 @@ This release is built from commit [21ab700f2](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.6/beta3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.6/beta3/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.6-beta3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.6-beta3) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-1.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-1.md
@@ -155,7 +155,7 @@ In the meantime, if you don't quite feel adventurous enough to try the alpha, Go
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha1/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha1) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 ## Known issues {#known-issues}

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-10.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-10.md
@@ -57,7 +57,7 @@ This release is built from commit [4bbe7f0b9](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha10/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha10) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-11.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-11.md
@@ -70,7 +70,7 @@ This release is built from commit [afdae67cc](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha11/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha11) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-12.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-12.md
@@ -63,7 +63,7 @@ This release is built from commit [2c11e6d9e](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha12/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha12) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-13.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-13.md
@@ -72,7 +72,7 @@ This release is built from commit [82811367c](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha13/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha13) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. As soon as the .NET 6 port is ready to test, it will be included in dev snapshots.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-14.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-14.md
@@ -64,7 +64,7 @@ This release is built from commit [106b68050](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha14/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha14) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. As soon as the .NET 6 port is ready to test, it will be included in dev snapshots.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-15.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-15.md
@@ -95,7 +95,7 @@ This release is built from commit [432b25d36](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha15/) (GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha15) (GDScript, GDExtension).
 * .NET 6 support should be included in 4.0 beta 1. The initial support has been merged, but more work is required to make official builds easily. For now, it's possible to compile it yourself from source, see [`modules/mono/README.md`](https://github.com/godotengine/godot/blob/master/modules/mono/README.md) for instructions.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-16.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-16.md
@@ -93,7 +93,7 @@ This release is built from commit [86dd3f312](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha16/) (GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha16) (GDScript, GDExtension).
 * .NET 6 support should be included in 4.0 beta 1. The initial support has been merged, but more work is required to make official builds easily. For now, it's possible to compile it yourself from source, see [`modules/mono/README.md`](https://github.com/godotengine/godot/blob/master/modules/mono/README.md) for instructions.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-17.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-17.md
@@ -71,7 +71,7 @@ This release is built from commit [22a09fef5](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha17/) (GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha17) (GDScript, GDExtension).
 * .NET 6 support should be included in 4.0 beta 1. The initial support has been merged, but more work is required to make official builds easily. For now, it's possible to compile it yourself from source, see [`modules/mono/README.md`](https://github.com/godotengine/godot/blob/master/modules/mono/README.md) for instructions.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-2.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-2.md
@@ -91,7 +91,7 @@ The `AudioStreamRandomPitch` node has been renamed to `AudioStreamRandomizer` an
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha2/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha2) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-3.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-3.md
@@ -51,7 +51,7 @@ Some of the most notables feature changes in this update are:
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha3/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha3) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-4.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-4.md
@@ -56,7 +56,7 @@ Some of the most notables feature changes in this update are:
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha4/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha4) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 **Note:** The Windows builds are signed, but the certificate expired recently. We're working on having it renewed, this should be fixed in the next build.

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-5.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-5.md
@@ -57,7 +57,7 @@ This release is built from commit [d7d528c15](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha5/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha5) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 **Note:** The Windows builds are signed, but the certificate expired recently. We're working on having it renewed, this should be fixed in the next build.

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-6.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-6.md
@@ -51,7 +51,7 @@ This release is built from commit [e4f0fc50f](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha6/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha6) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 **Note:** The Windows builds are signed, but the certificate expired recently. We're working on having it renewed, this should be fixed in future builds.

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-7.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-7.md
@@ -59,7 +59,7 @@ This release is built from commit [3e9ead05f](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha7/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha7) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 **Note:** The Windows builds are signed, but the certificate expired recently. We're working on having it renewed, this should be fixed in future builds.

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-8.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-8.md
@@ -53,7 +53,7 @@ This release is built from commit [917fd657](https://github.com/godotengine/godo
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha8/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha8) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 **Note:** The Windows builds are signed, but the certificate expired recently. We're still working on having it renewed.

--- a/collections/_article/dev-snapshot-godot-4-0-alpha-9.md
+++ b/collections/_article/dev-snapshot-godot-4-0-alpha-9.md
@@ -59,7 +59,7 @@ This release is built from commit [d9daf3869](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/alpha9/) (GDScript, GDExtension, VisualScript).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-alpha9) (GDScript, GDExtension, VisualScript).
 * Mono builds are currently not available as our focus is on porting to .NET 6. You'll get a chance to test it with later alpha releases!
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-1.md
@@ -45,7 +45,7 @@ One of the most important additions not covered by those articles is the introdu
 We know many users are excited about the coming improvements to 2D and 3D rendering in 4.0. Over the last few years we have completely overhauled the Godot renders. They now target Vulkan by default and we have created them with future support for [Direct3D 12](https://github.com/godotengine/godot/pull/64304) and other rendering APIs in mind. We also have created an OpenGL-based compatibility renderer aimed at supporting older and low-end devices that do not support Vulkan or other modern GPU APIs. As much as we love exciting new features, we also want to see people create games on the full spectrum of devices for everyone to enjoy.
 
 <video autoplay loop muted>
-  <source src="/storage/app/media/4.0/beta1/rendering-reflections.mp4?1" type="video/mp4">
+  <source src="/storage/app/media/4.0-beta1/rendering-reflections.mp4?1" type="video/mp4">
 </video>
 
 Notably, Godot's global illumination systems have been remade from scratch in the new release. *GIProbe* has been replaced by the **VoxelGI** node, which is a real-time solution fit for small and medium-scale environments. For the first time ever, Godot also comes with a GI technique that can be used with large open worlds — signed distance field global illumination (**SDFGI**). It's a novel technique created and implemented by Juan, it works in real-time, and you can learn a lot more about it [here](https://godotengine.org/article/godot-40-gets-sdf-based-real-time-global-illumination). If you are looking to add that extra bit of quality when running on high-end devices, rendering contributor Clay John ([clayjohn](https://github.com/clayjohn)) brings you [Screen Space Indirect Lighting](https://github.com/godotengine/godot/pull/51206). This feature adds more detail to existing GI techniques by using screen-space sampling, similar to SSAO. Last but not least, *lightmaps baking* is now [done using the GPU](https://github.com/godotengine/godot/pull/38386) to speed up the process significantly.
@@ -55,7 +55,7 @@ To help improve fidelity of your 3D scenes, we have worked on a couple of exciti
 For other atmospheric effects, Godot 4.0 is introducing sky shaders which allow users to create dynamic skies that update in real time (including reflections). For more information see the article introducing [sky shaders](https://godotengine.org/article/custom-sky-shaders-godot-4-0).
 
 <video autoplay loop muted>
-  <source src="/storage/app/media/4.0/beta1/rendering-clouds.mp4?1" type="video/mp4">
+  <source src="/storage/app/media/4.0-beta1/rendering-clouds.mp4?1" type="video/mp4">
 </video>
 
 [Decals](https://github.com/godotengine/godot/pull/37861) are another new way to add dynamic effects, which rely on PBR materials and can also be used for decorating your environments.
@@ -65,7 +65,7 @@ Visual effect artists among you should find a lot of useful changes to the GPU-b
 Other exciting additions to shaders include support for [uniform arrays](https://github.com/godotengine/godot/pull/62513) and [fragment-to-light varyings](https://github.com/godotengine/godot/pull/44698), as well as new syntax features, such as [structs](https://github.com/godotengine/godot/pull/35249), [preprocessor macros and shader includes](https://github.com/godotengine/godot/pull/62513).
 
 <video autoplay loop muted>
-  <source src="/storage/app/media/4.0/beta1/vshaders-butterflies.mp4?1" type="video/mp4">
+  <source src="/storage/app/media/4.0-beta1/vshaders-butterflies.mp4?1" type="video/mp4">
 </video>
 
 For the photography-minded users, we have added support for using physical light units in Godot 4.0 which allow you to use realistic units for the intensity of lights as well as use standard camera settings (like aperture, shutter speed, and ISO) to control the brightness of the final scene. Physical light units are turned off by default but can be enabled in the project settings.
@@ -85,7 +85,7 @@ Godot 4 marks a big return of Godot's in-house 3D physics engine, **Godot Physic
 But first, we needed to bring Godot Physics on-par with Bullet feature-wise, and improve performance and precision of these features along the way. This included adding new collision shapes, [cylinder](https://github.com/godotengine/godot/pull/45854) and [heightmap](https://github.com/godotengine/godot/pull/47347), as well as re-implementing [SoftBody nodes](https://github.com/godotengine/godot/pull/46937). In addition to feature-specific improvements, general optimization techniques, such as broadphase optimization and multithreading support, were implemented for both 2D and 3D environments. Some of these improvements can also be found in recent Godot 3 releases.
 
 <video autoplay loop muted>
-  <source src="/storage/app/media/4.0/beta1/physics-balls.mp4?1" type="video/mp4">
+  <source src="/storage/app/media/4.0-beta1/physics-balls.mp4?1" type="video/mp4">
 </video>
 
 With that done, it was time to improve the user side of things. We took the opportunity to carry out [a major reorganization of physics nodes](https://github.com/godotengine/godot/pull/48908) and improve many APIs/behaviors to make the experience more user-friendly ([collision layers logic](https://github.com/godotengine/godot/pull/50625), [RigidBodies](https://github.com/godotengine/godot/pull/55736), etc.). A lot of properties previously unique to specific body types are now available to all **PhysicsBody** nodes. This allows us to introduce the new **CharacterBody** node to replace old kinematic bodies, which provide a more advanced behavior in [2D](https://github.com/godotengine/godot/pull/51027/files) and [3D](https://github.com/godotengine/godot/pull/52889), allowing you to have an advanced character controller ready to use with new configurable properties for flexibility. Scripting them is simpler now as well. In previous versions of the engine properties related to moving, sliding, and colliding had to be passed to `move_and_slide()` manually. They can now be set up using scenes, on the nodes themselves reducing code needed to have desired physical interactions.
@@ -117,7 +117,7 @@ Silc 'Tokage' Renew ([Tokage](https://github.com/TokageItLab)) has been hard at 
 With **GDScript** being the most used language among current Godot users, we wanted to really improve the coding experience in Godot 4 with some of the most requested and long-awaited language features. You can now reap the benefits of first-class functions and lambdas, new property syntax, the `await` and `super` keywords, and typed arrays. New built-in annotations make the language clearer and improve syntax for exported properties. And to top it off, your scripts can now automatically generate documentation that can be studied with the built-in help and the Inspector dock tooltips.
 
 <video autoplay loop muted>
-  <source src="/storage/app/media/4.0/beta1/scripting-gdscript.mp4?1" type="video/mp4">
+  <source src="/storage/app/media/4.0-beta1/scripting-gdscript.mp4?1" type="video/mp4">
 </video>
 
 Despite growing in features, the GDScript runtime is only faster and more stable in Godot 4. This was achieved by a complete rewrite of the language backend by our main scripting maintainer George Marques ([vnen](https://github.com/vnen)). If you are interested in further reading George has provided several detailed reports on the new language features ([1](https://godotengine.org/article/gdscript-progress-report-new-gdscript-now-merged), [2](https://godotengine.org/article/gdscript-progress-report-feature-complete-40)), as well as on the decision-making process for the new language parser and runtime ([1](https://godotengine.org/article/gdscript-progress-report-writing-tokenizer), [2](https://godotengine.org/article/gdscript-progress-report-writing-new-parser), [3](https://godotengine.org/article/gdscript-progress-report-type-checking-back), [4](https://godotengine.org/article/gdscript-progress-report-typed-instructions)). The documentation feature was implemented by a student, Thakee Nathees ([ThakeeNathees](https://github.com/ThakeeNathees)), during the last year's Google Summer of Code. You can read their report [here](https://godotengine.org/article/gsoc-2020-progress-report-1#gdscript-doc).
@@ -175,7 +175,7 @@ The new GDExtension system was implemented by Juan and George, and further impro
 
 ## Gui and Text {#gui-and-text}
 
-![Screenshot of Urdu text in RichTextLabel in the editor using Arabic translations and UI mirroring](/storage/app/media/4.0/beta1/text-rtl-support.png)
+![Screenshot of Urdu text in RichTextLabel in the editor using Arabic translations and UI mirroring](/storage/app/media/4.0-beta1/text-rtl-support.png)
 
 Localization is probably the most straightforward way to allow more people to experience your game or use your tool efficiently. However, translating your project is often just half the battle. Most software can handle Latin or Cyrillic characters well enough, but when it comes to Arabic scripts or logograms of East Asian languages, text rendering quickly becomes tricky.
 
@@ -207,7 +207,7 @@ If you want to read more on all of the above, [this series of posts](https://god
 ## Importing/Exporting {#importing-exporting}
 
 <video autoplay loop muted>
-  <source src="/storage/app/media/4.0/beta1/editor-3d-import.mp4?1" type="video/mp4">
+  <source src="/storage/app/media/4.0-beta1/editor-3d-import.mp4?1" type="video/mp4">
 </video>
 
 When you start working on a new 3D scene in Godot 4, you won't be able to miss a leaping change in the importing workflow. Previous versions of the engine provided users with a powerful, but obscured mechanism for preparing imported 3D assets. You could automate and enhance your models and scenes with an import script and a few import settings, but we were sure we could do better than that. Godot 4 comes with a [dedicated import dialog](https://github.com/godotengine/godot/pull/47166) that allows you to preview and customize every part of the imported scene, its materials and physical properties. Scripts can still be used for additional tweaks, thanks to the [new plugin interface](https://github.com/godotengine/godot/pull/53813).
@@ -223,7 +223,7 @@ Of course, none of the aforementioned changes would be worth it if you couldn't 
 However, with a new major release, we can make some radical changes to the tools and the editor accessibility – changes that would be impossible without breaking compatibility. Probably the biggest improvement relying on that is the new Tiles editor, which has been reimagined based on your requests and reports. Our 2D editor maintainer Gilles Roudière ([groud](https://github.com/groud)) has united the workflow for `TileSet`s and `TileMap`s, providing various ways to organize and place tiles, to supply them with metadata and animations. You can probably build half a game with tiles alone!
 
 <video autoplay loop muted>
-  <source src="/storage/app/media/4.0/beta1/editor-tiles.mp4?1" type="video/mp4">
+  <source src="/storage/app/media/4.0-beta1/editor-tiles.mp4?1" type="video/mp4">
 </video>
 
 Read Gilles' multiple detailed reports on the progress made over several months of development: [1](https://godotengine.org/article/tiles-editor-rework), [2](https://godotengine.org/article/tiles-editor-progress-report-2), [3](https://godotengine.org/article/tiles-editor-progress-3), [4](https://godotengine.org/article/tiles-editor-progress-4), [5](https://godotengine.org/article/tiles-editor-progress-report-5).
@@ -255,8 +255,8 @@ As always, if you plan on upgrading your project, please make a backup copy of y
 
 The downloads for this beta can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta1) (GDScript, GDExtension).
-- [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta1/mono) (C#, GDScript, GDExtension).
+- [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta1) (GDScript, GDExtension).
+- [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta1) (C#, GDScript, GDExtension).
 
 ## Known issues {#known-issues}
 

--- a/collections/_article/dev-snapshot-godot-4-0-beta-10.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-10.md
@@ -78,8 +78,8 @@ This release is built from commit [d0398f62f](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta10/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta10/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta10) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta10) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-11.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-11.md
@@ -123,8 +123,8 @@ This release is built from commit [91713ced8](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta11/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta11/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta11) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta11) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-12.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-12.md
@@ -92,8 +92,8 @@ This release is built from commit [3c9bf4bc2](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta12/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta12/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta12) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta12) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-13.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-13.md
@@ -96,8 +96,8 @@ This release is built from commit [caacade56](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta13/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta13/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta13) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta13) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-14.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-14.md
@@ -78,8 +78,8 @@ This release is built from commit [28a24639c](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta14/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta14/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta14) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta14) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-15.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-15.md
@@ -95,8 +95,8 @@ This release is built from commit [4fa6edc88](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta15/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta15/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta15) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta15) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-16.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-16.md
@@ -101,8 +101,8 @@ This release is built from commit [518b9e580](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta16/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta16/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta16) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta16) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location. .NET 7.0 support was just merged and requires testing, please report any issue you experience with either version.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-17.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-17.md
@@ -111,8 +111,8 @@ This release is built from commit [c40020513](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta17/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta17/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta17) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta17) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location. .NET 7.0 support was recently merged and requires testing, please report any issue you experience with either version.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-2.md
@@ -141,8 +141,8 @@ This release is built from commit [f8745f2f7](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta2/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta2/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta2) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta2) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-3.md
@@ -125,8 +125,8 @@ This release is built from commit [01ae26d31](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta3/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta3/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta3) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta3) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-4.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-4.md
@@ -66,8 +66,8 @@ This release is built from commit [e6751549c](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta4/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta4/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta4) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta4) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-5.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-5.md
@@ -95,8 +95,8 @@ This release is built from commit [89a33d28f](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta5/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta5/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta5) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta5) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-6.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-6.md
@@ -58,8 +58,8 @@ This release is built from commit [7f8ecffa5](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta6/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta6/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta6) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta6) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-7.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-7.md
@@ -61,8 +61,8 @@ This release is built from commit [0ff874291](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta7/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta7/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta7) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta7) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-8.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-8.md
@@ -72,8 +72,8 @@ This release is built from commit [c6e40e1c0](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta8/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta8/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta8) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta8) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-0-beta-9.md
+++ b/collections/_article/dev-snapshot-godot-4-0-beta-9.md
@@ -80,8 +80,8 @@ This release is built from commit [e780dc332](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/beta9/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/beta9/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-beta9) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-beta9) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed in a standard location. .NET 7.0 is not supported yet, so make sure to install .NET 6.0 specifically.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-1-beta-1.md
+++ b/collections/_article/dev-snapshot-godot-4-1-beta-1.md
@@ -99,8 +99,8 @@ To help even more with setting up the atmosphere of your 3D scenes, contributors
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/beta1/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/beta1/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1-beta1) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1-beta1) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-1-beta-2.md
+++ b/collections/_article/dev-snapshot-godot-4-1-beta-2.md
@@ -108,8 +108,8 @@ This release is built from commit [a2575cba4](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/beta2/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/beta2/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1-beta2) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1-beta2) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-1-beta-3.md
+++ b/collections/_article/dev-snapshot-godot-4-1-beta-3.md
@@ -88,8 +88,8 @@ This release is built from commit [ada712e06](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/beta3/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/beta3/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1-beta3) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1-beta3) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-1-dev-1.md
+++ b/collections/_article/dev-snapshot-godot-4-1-dev-1.md
@@ -114,8 +114,8 @@ This release is built from commit [db1302637](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/dev1/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/dev1/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1/dev1) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1/dev1) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Bug reports

--- a/collections/_article/dev-snapshot-godot-4-1-dev-2.md
+++ b/collections/_article/dev-snapshot-godot-4-1-dev-2.md
@@ -106,8 +106,8 @@ This release is built from commit [668cf3c66](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/dev2/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/dev2/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1/dev2) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1/dev2) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Bug reports

--- a/collections/_article/dev-snapshot-godot-4-1-dev-3.md
+++ b/collections/_article/dev-snapshot-godot-4-1-dev-3.md
@@ -113,8 +113,8 @@ This release is built from commit [a67d37f7c](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/dev3/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/dev3/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1/dev3) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1/dev3) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/dev-snapshot-godot-4-1-dev-4.md
+++ b/collections/_article/dev-snapshot-godot-4-1-dev-4.md
@@ -79,8 +79,8 @@ This release is built from commit [5c2295ff5](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/dev4/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/dev4/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1/dev4) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1/dev4) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/get-ready-github-gameoff-godot.md
+++ b/collections/_article/get-ready-github-gameoff-godot.md
@@ -58,7 +58,7 @@ And of course you are not alone to learn how to use Godot! We have many [communi
 
 Don't miss the Godot [Questions & Answers](https://godotengine.org/qa), which likely already has answers for some of the questions you might be asking yourselves. If not, don't hesitate to ask your question, being both concise and specific, and you should quickly get some help.
 
-Finally, if you think that you hit a bug in the engine, please report it on [GitHub](http://github.com/godotengine/godot). Make sure to follow the proposed issue template (filled in automatically) to help us help you.
+Finally, if you think that you hit a bug in the engine, please report it on [GitHub](https://github.com/godotengine/godot). Make sure to follow the proposed issue template (filled in automatically) to help us help you.
 
 ## Can I use Godot 3.0?
 

--- a/collections/_article/github-game-off-and-godot-are-winning-combination.md
+++ b/collections/_article/github-game-off-and-godot-are-winning-combination.md
@@ -61,6 +61,6 @@ And of course you are not alone to learn how to use Godot! We have many [communi
 
 Don't miss the Godot [Questions & Answers](https://godotengine.org/qa), which likely already has answers for some of the questions you might be asking yourselves. If not, don't hesitate to ask your question, being both concise and specific, and you should quickly get some help.
 
-Finally, if you think that you hit a bug in the engine, please report it on [GitHub](http://github.com/godotengine/godot). Make sure to follow the proposed issue template (filled in automatically) to help us help you.
+Finally, if you think that you hit a bug in the engine, please report it on [GitHub](https://github.com/godotengine/godot). Make sure to follow the proposed issue template (filled in automatically) to help us help you.
 
 Have a lot of fun with GitHub Game Off 2018!

--- a/collections/_article/godot-2-1-reaches-beta-ready-for-testing.md
+++ b/collections/_article/godot-2-1-reaches-beta-ready-for-testing.md
@@ -7,7 +7,7 @@ image: /storage/app/uploads/public/578/568/145/5785681454bd4264168994.png
 date: 2016-07-12 00:00:00
 ---
 
-**Edit:** A new beta build has been published, [dated 2016-07-21](https://downloads.tuxfamily.org/godotengine/2.1-dev/20160721/). See the [changelog](https://downloads.tuxfamily.org/godotengine/2.1-dev/20160721/Godot_v2.1_beta_20160721_changelog.txt) since the 2016-07-12 build.
+**Edit:** A new beta build has been published, [dated 2016-07-21](https://github.com/godotengine/godot-builds/releases/2.1-dev/20160721/). See the [changelog](https://downloads.tuxfamily.org/godotengine/2.1-dev/20160721-Godot_v2.1_beta_20160721_changelog.txt) since the 2016-07-12 build.
 
 Today, after several months of hard work, we have reached a new milestone in the development of the upcoming version 2.1! We are now pretty happy with the feature set and the overall stability, and therefore provide [beta binaries](/download) for you to test and [report issues/suggest improvements](https://github.com/godotengine/godot/issues).
 

--- a/collections/_article/godot-3-0-released.md
+++ b/collections/_article/godot-3-0-released.md
@@ -283,7 +283,7 @@ This allows different areas to have different reverberation and effects (reverb 
 <a id="vr"></a>
 ## VR support
 
-Godot 3.0 has also seen the introduction of the ARVRServer implementation (as the name says, for AR and VR support), thanks to the great work of Bastiaan Olij ([Mux213](http://github.com/BastiaanOlij)). While the current AR implementations that are being worked on have been moved to the 3.1 release, for VR there are now two options that are ready to be used, with more backends in the works:
+Godot 3.0 has also seen the introduction of the ARVRServer implementation (as the name says, for AR and VR support), thanks to the great work of Bastiaan Olij ([Mux213](https://github.com/BastiaanOlij)). While the current AR implementations that are being worked on have been moved to the 3.1 release, for VR there are now two options that are ready to be used, with more backends in the works:
 
 - A built-in Cardboard-ish mobile VR solution that uses the embedded sensors for basic 3DOF head tracking.
 - A GDNative-based [implementation of the OpenVR API](https://github.com/BastiaanOlij/godot_openvr) making Godot fully compatible with SteamVR. Pre-compiled binaries for Windows are provided via the [Asset Library](https://godotengine.org/asset-library/asset/150), with other platforms coming soon.
@@ -332,7 +332,7 @@ Mobile, for example, comes with many predefined feature tags, to aid on reducing
 
 ![IPv6 logo](/storage/app/media/3.0%20release/ipv6.png)
 
-Godot is now fully compliant with IPv6, thanks to Ariel Manzur ([punto](http://github.com/punto-)) and Fabio Alessandrelli ([Faless](https://github.com/Faless)).
+Godot is now fully compliant with IPv6, thanks to Ariel Manzur ([punto](https://github.com/punto-)) and Fabio Alessandrelli ([Faless](https://github.com/Faless)).
 
 <a id="wasm"></a>
 ## WebAssembly and WebGL 2.0 support
@@ -409,7 +409,7 @@ We have a new section listing the providers in the [official documentation](http
 
 This post is already too long and it's impossible to list all the hundreds of features and bug fixes that have been implemented by Godot contributors over the last year and a half.
 
-Contributors are working on a [human-readable changelog](https://gist.github.com/Calinou/15b7b48abc0c3a22fbb2993b39a0ae99) which should give you some more details. You can also browse and filter the list of [GitHub pull requests](https://github.com/godotengine/godot/issues?q=is%3Apr+milestone%3A3.0+-label%3Aarchived) of almost 3000 contributions (and the corresponding list for [GitHub issues](https://github.com/godotengine/godot/issues?q=is%3Aissue+milestone%3A3.0+-label%3Aarchived)), as well as review the raw Git changelogs since Godot 2.1 (sorted [chronogically](https://downloads.tuxfamily.org/godotengine/3.0/Godot_v3.0-stable_changelog_chrono.txt) or [by author](https://downloads.tuxfamily.org/godotengine/3.0/Godot_v3.0-stable_changelog_authors.txt)).
+Contributors are working on a [human-readable changelog](https://gist.github.com/Calinou/15b7b48abc0c3a22fbb2993b39a0ae99) which should give you some more details. You can also browse and filter the list of [GitHub pull requests](https://github.com/godotengine/godot/issues?q=is%3Apr+milestone%3A3.0+-label%3Aarchived) of almost 3000 contributions (and the corresponding list for [GitHub issues](https://github.com/godotengine/godot/issues?q=is%3Aissue+milestone%3A3.0+-label%3Aarchived)), as well as review the raw Git changelogs since Godot 2.1 (sorted [chronogically](https://github.com/godotengine/godot-builds/releases/3.0/Godot_v3.0-stable_changelog_chrono.txt) or [by author](https://downloads.tuxfamily.org/godotengine/3.0-Godot_v3.0-stable_changelog_authors.txt)).
 
 # Future
 

--- a/collections/_article/godot-3-1-released.md
+++ b/collections/_article/godot-3-1-released.md
@@ -289,7 +289,7 @@ Will Nations ([willnationsdev](https://github.com/willnationsdev/)) implemented 
 <a id="audio-input"></a>
 ### MIDI and microphone input
 
-Marcelo Fernandez ([marcelofg55](http://github.com/marcelofg55/)) added support for using MIDI devices as input devices. Together with [SaracenOne](https://github.com/SaracenOne), they also added support for capture microphone audio.
+Marcelo Fernandez ([marcelofg55](https://github.com/marcelofg55/)) added support for using MIDI devices as input devices. Together with [SaracenOne](https://github.com/SaracenOne), they also added support for capture microphone audio.
 
 
 <a id="vcs-friendliness"></a>

--- a/collections/_article/godot-3-3-has-arrived.md
+++ b/collections/_article/godot-3-3-has-arrived.md
@@ -433,7 +433,7 @@ Godot 3.3 is ready to use now and we want you to have it without further ado.
 
 We would like to take the opportunity to thank all of our amazing contributors for all the other great features merged since 3.2.3, and the hundreds of bugfixes and usability improvements done in this release. Even if not listed here, every contribution makes Godot better, and this release is truly the work of hundreds of individuals working together towards a common goal and passion.
 
-For more details on other changes in Godot 3.3, please consult our [curated changelog](https://github.com/godotengine/godot/blob/3.3/CHANGELOG.md#33---2021-04-21), as well as the raw changelog from Git ([chronological](https://downloads.tuxfamily.org/godotengine/3.3/Godot_v3.3-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.3/Godot_v3.3-stable_changelog_authors.txt)).
+For more details on other changes in Godot 3.3, please consult our [curated changelog](https://github.com/godotengine/godot/blob/3.3/CHANGELOG.md#33---2021-04-21), as well as the raw changelog from Git ([chronological](https://github.com/godotengine/godot-builds/releases/3.3/Godot_v3.3-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.3-Godot_v3.3-stable_changelog_authors.txt)).
 
 
 ## Reporting issues

--- a/collections/_article/godot-3-4-is-released.md
+++ b/collections/_article/godot-3-4-is-released.md
@@ -389,7 +389,7 @@ Godot 3.4 is ready to use now and we want you to have it without further ado.
 
 We would like to take the opportunity to thank all of our amazing contributors for all the other great features merged since 3.3, and the hundreds of bugfixes and usability improvements done in this release. Even if not listed here, every contribution makes Godot better, and this release is truly the work of hundreds of individuals working together towards a common goal and passion.
 
-For more details on other changes in Godot 3.4, please consult our [curated changelog](https://github.com/godotengine/godot/blob/3.4-stable/CHANGELOG.md#34---2021-10-05), as well as the raw changelog from Git ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/Godot_v3.4-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4/Godot_v3.4-stable_changelog_authors.txt)).
+For more details on other changes in Godot 3.4, please consult our [curated changelog](https://github.com/godotengine/godot/blob/3.4-stable/CHANGELOG.md#34---2021-10-05), as well as the raw changelog from Git ([chronological](https://github.com/godotengine/godot-builds/releases/3.4/Godot_v3.4-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4-Godot_v3.4-stable_changelog_authors.txt)).
 
 
 ## Reporting issues

--- a/collections/_article/godot-3-5-cant-stop-wont-stop.md
+++ b/collections/_article/godot-3-5-cant-stop-wont-stop.md
@@ -30,7 +30,7 @@ If you use and enjoy Godot, plan to use it, or want support the cause of having 
 <a id="features"></a>
 ## Features
 
-Many new features have been added in Godot 3.5, both small and large. The following is a list of a few of the larger features that we are excited about in no particular order. For a complete list of all changes you can check out our [**curated changelog**](https://github.com/godotengine/godot/blob/3.5-stable/CHANGELOG.md), as well as the raw changelog from Git ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/Godot_v3.5-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.5/Godot_v3.5-stable_changelog_authors.txt)).
+Many new features have been added in Godot 3.5, both small and large. The following is a list of a few of the larger features that we are excited about in no particular order. For a complete list of all changes you can check out our [**curated changelog**](https://github.com/godotengine/godot/blob/3.5-stable/CHANGELOG.md), as well as the raw changelog from Git ([chronological](https://github.com/godotengine/godot-builds/releases/3.5/Godot_v3.5-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.5-Godot_v3.5-stable_changelog_authors.txt)).
 
 The amazing [GDQuest folks](https://www.gdquest.com/) prepared a nice video showcasing some of the main highlights of Godot 3.5, check it out! (Excerpts of this video are also included in this page for illustration.)
 

--- a/collections/_article/godot-3-6-finally-released.md
+++ b/collections/_article/godot-3-6-finally-released.md
@@ -41,7 +41,7 @@ Last but not least, making games with Godot and crediting the engine goes a long
 
 ## Highlights
 
-Many new features have been added in Godot 3.6, both small and large. The following is a list of a few of the larger features that we are excited about in no particular order. For a complete list of all changes you can check out our [**curated changelog**](https://github.com/godotengine/godot/blob/3.6-stable/CHANGELOG.md), as well as the raw changelog from Git ([chronological](https://downloads.tuxfamily.org/godotengine/3.6/Godot_v3.6-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.6/Godot_v3.6-stable_changelog_authors.txt)).
+Many new features have been added in Godot 3.6, both small and large. The following is a list of a few of the larger features that we are excited about in no particular order. For a complete list of all changes you can check out our [**curated changelog**](https://github.com/godotengine/godot/blob/3.6-stable/CHANGELOG.md), as well as the raw changelog from Git ([chronological](https://github.com/godotengine/godot-builds/releases/3.6/Godot_v3.6-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.6-Godot_v3.6-stable_changelog_authors.txt)).
 
 ### 2D physics interpolation ([GH-76252](https://github.com/godotengine/godot/pull/76252))
 

--- a/collections/_article/godot-engine-reaches-2-0-stable.md
+++ b/collections/_article/godot-engine-reaches-2-0-stable.md
@@ -17,7 +17,7 @@ Usability still remained a pressing issue, so we made a long list of tasks to im
 
 This release is special because our team has grown a lot. We have more regular contributors, a documentation team, a bug triage team and a much larger community! Godot keeps growing and becoming more and more awesome.
 
-[See the full list of changes](http://downloads.tuxfamily.org/godotengine/2.0/Godot_v2.0_stable_changelog.txt).
+[See the full list of changes](https://github.com/godotengine/godot-builds/releases/2.0-Godot_v2.0_stable_changelog.txt).
 
 ## New core features
 

--- a/collections/_article/here-comes-godot-3-2.md
+++ b/collections/_article/here-comes-godot-3-2.md
@@ -283,7 +283,7 @@ This greatly simplifies the process of generating e.g. collision shapes to add c
 
 We would like to take the opportunity to thank all of our amazing contributors for all the other great features merged since 3.1, and the hundreds of bugfixes and usability improvements done over 2019. Even if not listed here, every contribution makes Godot better, and this release is truly the work of hundreds of individuals working together towards a common goal and passion.
 
-For more details on other changes in Godot 3.2, please consult our [curated Changelog](https://github.com/godotengine/godot/blob/master/CHANGELOG.md#32---2020-01-29), as well as the raw changelog from Git ([chronological](https://downloads.tuxfamily.org/godotengine/3.2/Godot_v3.2-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.2/Godot_v3.2-stable_changelog_authors.txt)).
+For more details on other changes in Godot 3.2, please consult our [curated Changelog](https://github.com/godotengine/godot/blob/master/CHANGELOG.md#32---2020-01-29), as well as the raw changelog from Git ([chronological](https://github.com/godotengine/godot-builds/releases/3.2/Godot_v3.2-stable_changelog_chrono.txt), or sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.2-Godot_v3.2-stable_changelog_authors.txt)).
 
 ## Giving back
 

--- a/collections/_article/home-sweet-home.md
+++ b/collections/_article/home-sweet-home.md
@@ -12,8 +12,6 @@ Here it is: [Godot Engine's new homepage](/)! Some of you might have been awaiti
 
 Thanks enormously to Andrea Calabró, Alket Rexhepi, Hugo Locurcio (Calinou) and Rémi Verschelde (Akien) for their hard work!
 
-**Note:** The old forums (and rest of the OpenProject website) can still be accessed for now on [op.godotengine.org](http://op.godotengine.org/projects/godot-engine).
-
 ## Why change again?
 
 The early Godot users might remember that we used to have a WordPress-powered website in 2015, with a self-hosted forum and the official documentation on [Godot's GitHub wiki](https://github.com/godotengine/godot/wiki). With the growing community and the project getting more and more new contributors, we wanted to have a platform that eases the project management so that we can work efficiently in teams. It was also becoming clear that GitHub's very limited permissions management would not let us have contributions on the wiki without giving push rights on the source code to everybody (!), so we needed an alternative for the documentation.
@@ -36,7 +34,7 @@ Thanks to this straightforward setting, we could easily design good looking (we 
 
 As we increasingly noticed that people were asking many technical questions on the Facebook group, which provides no good search feature nor search engine referencing, we decided to setup a [Question2Answer](http://www.question2answer.org) instance, also in PHP and easy to customize with a great number of plugins. It is very similar to popular technical platforms like StackExchange or StackOverflow, and should help increase the visibility of Godot-related questions and their best answers. [Check it out!](/qa)
 
-For the time being we also propose specific categories to showcase Godot games and WIPs and discuss off-topic stuff in the Q&A - this used to be in the forums but we did not want to setup yet another new tool just yet. This might change in the future if/when we settle on a better-suited solution. In the meantime, you can still [access the old forums](http://op.godotengine.org/projects/godot-engine/boards).
+For the time being we also propose specific categories to showcase Godot games and WIPs and discuss off-topic stuff in the Q&A - this used to be in the forums but we did not want to setup yet another new tool just yet. This might change in the future if/when we settle on a better-suited solution.
 
 #### Sphinx documentation
 

--- a/collections/_article/maintenance-release-godot-2-0-2.md
+++ b/collections/_article/maintenance-release-godot-2-0-2.md
@@ -65,4 +65,4 @@ The main highlights in this maintenance release are:
 - OSX: Fix inverted horizontal scrolling
 - **Hotfix (2016-04-11):** Use non-templated `nearest_power_of_2` (workaround for iOS out-of-memory crash)
 
-See the [full changelog](http://downloads.tuxfamily.org/godotengine/2.0.2/Godot_v2.0.2_stable_changelog.txt) for more details, and head towards the [Download page](/download) to get it!
+See the [full changelog](https://github.com/godotengine/godot-builds/releases/2.0.2/Godot_v2.0.2_stable_changelog.txt) for more details, and head towards the [Download page](-download) to get it!

--- a/collections/_article/maintenance-release-godot-2-0-3.md
+++ b/collections/_article/maintenance-release-godot-2-0-3.md
@@ -68,7 +68,7 @@ The main highlights in this maintenance release are:
 * Rotation APIs: Better exposure for degrees methods
 * Tabs: various usability fixes
 
-See the [full changelog](https://downloads.tuxfamily.org/godotengine/2.0.3/Godot_v2.0.3_stable_changelog.txt) for more details, and head towards the [Download page](/download) to get it!
+See the [full changelog](https://github.com/godotengine/godot-builds/releases/2.0.3/Godot_v2.0.3_stable_changelog.txt) for more details, and head towards the [Download page](-download) to get it!
 
 ---
 

--- a/collections/_article/maintenance-release-godot-2-1-5.md
+++ b/collections/_article/maintenance-release-godot-2-1-5.md
@@ -9,9 +9,9 @@ date: 2018-07-28 22:50:00
 
 At long last, Godot 2.1.5 is ready and comes packed with new features and bug fixes! It's the result of 11 months of work ([since 2.1.4](/article/maintenance-release-godot-2-1-4)) from many contributors who care about supporting our previous stable branch (the current one and main focus being [Godot 3.0.x](/download)).
 
-[**Download it now**](https://downloads.tuxfamily.org/godotengine/2.1.5/) from our repositories if you are still using Godot 2.1.x for some projects. If you use it via the Steam distribution (where both 2.1.x and 3.0.x are included), it has been updated already - please keep in mind that we'll eventually stop distributing Godot 2.1.x on Steam (likely when moving to Godot 3.1). **Note:** This release fixes security vulnerabilities in Godot's marshalling code (see the [Godot 3.0.6 announcement](https://godotengine.org/article/maintenance-release-godot-3-0-6) for details) as well as an OpenSSL security update, so upgrading to this version is *strongly recommended* if you use any networking features.
+[**Download it now**](https://github.com/godotengine/godot-builds/releases/2.1.5/) from our repositories if you are still using Godot 2.1.x for some projects. If you use it via the Steam distribution (where both 2.1.x and 3.0.x are included), it has been updated already - please keep in mind that we'll eventually stop distributing Godot 2.1.x on Steam (likely when moving to Godot 3.1). **Note:** This release fixes security vulnerabilities in Godot's marshalling code (see the [Godot 3.0.6 announcement](https://godotengine.org/article-maintenance-release-godot-3-0-6) for details) as well as an OpenSSL security update, so upgrading to this version is *strongly recommended* if you use any networking features.
 
-Note that contrarily to 3.0 which can download the export templates for you automatically, with 2.1 you still need to [download the .tpz file](https://downloads.tuxfamily.org/godotengine/2.1.5/Godot_v2.1.5-stable_export_templates.tpz) manually and use it to install templates within the editor.
+Note that contrarily to 3.0 which can download the export templates for you automatically, with 2.1 you still need to [download the .tpz file](https://github.com/godotengine/godot-builds/releases/2.1.5-Godot_v2.1.5-stable_export_templates.tpz) manually and use it to install templates within the editor.
 
 ## Wait, what is 2.1.x again?
 
@@ -42,7 +42,7 @@ Most new features you see [on this blog](/news) or [on Twitter](https://twitter.
 
 ## Highlights
 
-With 11 months of work and over 450 commits to the *2.1* branch since 2.1.4, there's a lot to cover! Check the [**detailed changelog**](https://downloads.tuxfamily.org/godotengine/2.1.5/Godot_v2.1.5-stable_changelog.txt) for the exhaustive listing.
+With 11 months of work and over 450 commits to the *2.1* branch since 2.1.4, there's a lot to cover! Check the [**detailed changelog**](https://github.com/godotengine/godot-builds/releases/2.1.5-Godot_v2.1.5-stable_changelog.txt) for the exhaustive listing.
 
 Here are some of the main highlights of this release, listed by topic/category.
 

--- a/collections/_article/maintenance-release-godot-2-1-6.md
+++ b/collections/_article/maintenance-release-godot-2-1-6.md
@@ -29,10 +29,10 @@ If you want to start a new project, there is no reason to use Godot 2.1.6 which 
 
 As a reminder, Godot 2.1.x does not have an export templates downloader, so you should make sure to download both the editor binary for your platform and the templates archive ([`.tpz` file](https://download.tuxfamily.org/godotengine/2.1.6/Godot_v2.1.6-stable_export_templates.tpz)), and install these templates using the dedicated editor feature. You should **not mix versions**, i.e. using a 2.1.6 editor binary with 2.1.5 templates or the other way around. Export templates should match the exact commit used to build your editor binary.
 
-- [Download repository](https://download.tuxfamily.org/godotengine/2.1.6/)
-- [Changelog](https://downloads.tuxfamily.org/godotengine/2.1.6/Godot_v2.1.6-stable_changelog.txt)
+- [Download repository](https://github.com/godotengine/godot-builds/releases/2.1.6-stable)
+- [Changelog](https://github.com/godotengine/godot-builds/releases/download/2.1.6-stable/Godot_v2.1.6-stable_changelog.txt)
 
-**Update (2019-07-12 @ 7:00 UTC):** The Android templates released initially were mistakenly built against an older `AndroidManifest.xml` and still targeted API 27. If you downloaded the templates archive before this update was posted, you should [redownload the templates](https://download.tuxfamily.org/godotengine/2.1.6/Godot_v2.1.6-stable_export_templates.tpz) to have API 28 support.
+**Update (2019-07-12 @ 7:00 UTC):** The Android templates released initially were mistakenly built against an older `AndroidManifest.xml` and still targeted API 27. If you downloaded the templates archive before this update was posted, you should [redownload the templates](https://github.com/godotengine/godot-builds/releases/download/2.1.6-stable/Godot_v2.1.6-stable_export_templates.tpz) to have API 28 support.
 
 ### Highlights
 

--- a/collections/_article/maintenance-release-godot-3-0-1.md
+++ b/collections/_article/maintenance-release-godot-3-0-1.md
@@ -21,7 +21,7 @@ I'd like to thank all of our wonderful contributers for making 3.0.1 possible. I
 
 ## What's new in this release
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.1/Godot_v3.0.1-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.1-Godot_v3.0.1-stable_changelog.txt) for details.
 
 * The 'server' platform is back as it was in Godot 2.1. It is now again possible to run a headless Godot on Linux.
 * Godot can now be started with `--build-solutions` on the command line. This will let you build C# solutions without starting the editor. This is helpful for CI pipelines.
@@ -40,7 +40,7 @@ Here are some of the highlights of this release. See the [full changelog](http:/
 
 ## Fixed issues
 
-Here are some of the more visible bugs fixed in this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.1/Godot_v3.0.1-stable_changelog.txt) for details.
+Here are some of the more visible bugs fixed in this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.1-Godot_v3.0.1-stable_changelog.txt) for details.
 
 * Copy/pasting from the editor on X11 will now work more reliably.
 * The lightmap baker will now use all available cores on Windows like it does on macOS and Linux.

--- a/collections/_article/maintenance-release-godot-3-0-3.md
+++ b/collections/_article/maintenance-release-godot-3-0-3.md
@@ -17,7 +17,7 @@ I'd like to use this space to thank our contributors. The effort they put into G
 
 ## What's new in this release
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.3/Godot_v3.0.3-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.3-Godot_v3.0.3-stable_changelog.txt) for details.
 
 * Mono: Exporting to desktop platforms now works.
 * Universal translation of touch to mouse.
@@ -34,7 +34,7 @@ Note that assets MD5 sums are now saved in the `res://.import/` folder instead o
 
 ## Fixed issues
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.3/Godot_v3.0.3-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.3-Godot_v3.0.3-stable_changelog.txt) for details.
 
 * Mono: Signal parameters no longer crash the engine.
 * Asset library thread usage, this makes the asset library more responsive.

--- a/collections/_article/maintenance-release-godot-3-0-4.md
+++ b/collections/_article/maintenance-release-godot-3-0-4.md
@@ -21,14 +21,14 @@ I'd like to thank everyone involved in this release. I'll be the one wearing the
 
 ## What's new in this release
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.4/Godot_v3.0.4-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.4-Godot_v3.0.4-stable_changelog.txt) for details.
 
 * Marc Gilleron [(Zylann)](https://github.com/Zylann)'s excellent [terrain plugin](https://github.com/Zylann/godot_terrain_plugin) now works due to some fixes in the Bullet physics.
 * Several documentation fixes
 
 ## Fixed issues
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.4/Godot_v3.0.4-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.4-Godot_v3.0.4-stable_changelog.txt) for details.
 
 * Fixed crasher in asset library on systems with a low threadcount CPU
 

--- a/collections/_article/maintenance-release-godot-3-0-5.md
+++ b/collections/_article/maintenance-release-godot-3-0-5.md
@@ -19,13 +19,13 @@ As always this release would not have been possible without the laserlike focus 
 
 ## What's new in this release
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.5/Godot_v3.0.5-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.5-Godot_v3.0.5-stable_changelog.txt) for details.
 
 * 'android_add_asset_dir('...') method to Android module gradle build config.
 
 ## Fixed issues
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.5/Godot_v3.0.5-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.5-Godot_v3.0.5-stable_changelog.txt) for details.
 
  * Android exporter no longer writes unnecessary permissions to the exported APK.
  * Segfault when quitting the editor.

--- a/collections/_article/maintenance-release-godot-3-0-6.md
+++ b/collections/_article/maintenance-release-godot-3-0-6.md
@@ -19,14 +19,14 @@ Please join me in an *exuberant* standing ovation to our dashingly beautiful con
 
 ## What's new in this release
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.6/Godot_v3.0.6-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.6-Godot_v3.0.6-stable_changelog.txt) for details.
 
 * Added the headless build for CI use.
 * Upgrade bundled OpenSSL to 1.0.2o
 
 ## Fixed issues
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.6/Godot_v3.0.6-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.6-Godot_v3.0.6-stable_changelog.txt) for details.
 
  * Several editor crashes.
  * GLTF import fixes.

--- a/collections/_article/maintenance-release-godot-3-1-1.md
+++ b/collections/_article/maintenance-release-godot-3-1-1.md
@@ -38,14 +38,14 @@ If you enjoy our work please consider [becoming our Patron](https://www.patreon.
 
 And many more small quality of life improvements and bugfixes. See the full changelog below for details.
 
-See the changes between [3.1-stable and 3.1.1-stable](https://github.com/godotengine/godot/compare/320f49f204cfbf9b480fe62aaa7718afb74920a5...66baa3b633fe904ea0d90a9688d602d9f3a0b3bd) on Github, or the [full changelog](http://downloads.tuxfamily.org/godotengine/3.1.1/Godot_v3.1.1-stable_changelog.txt) in text format. This release is built from commit [66baa3b](https://github.com/godotengine/godot/commit/66baa3b633fe904ea0d90a9688d602d9f3a0b3bd).
+See the changes between [3.1-stable and 3.1.1-stable](https://github.com/godotengine/godot/compare/320f49f204cfbf9b480fe62aaa7718afb74920a5...66baa3b633fe904ea0d90a9688d602d9f3a0b3bd) on Github, or the [full changelog](https://github.com/godotengine/godot-builds/releases/3.1.1/Godot_v3.1.1-stable_changelog.txt) in text format. This release is built from commit [66baa3b](https://github.com/godotengine/godot/commit-66baa3b633fe904ea0d90a9688d602d9f3a0b3bd).
 
 ## Downloads
 
 As always, you will find the binaries for your platform on our mirrors:
 
 - Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.1.1/)]
-- Mono version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.1.1/mono)]
+- Mono version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.1.1)]
 
 ## <a id="known-incompatibilites"></a>Known incompatibilities
 

--- a/collections/_article/maintenance-release-godot-3-1-2.md
+++ b/collections/_article/maintenance-release-godot-3-1-2.md
@@ -14,7 +14,7 @@ While Godot 3.2 is shaping up nicely in the [late beta stage](/article/dev-snaps
 
 *Note: Illustration credits at the bottom of this page.*
 
-**Edit 2019-12-03 @ 15:00 UTC:** A regression was found in the WebAssembly (HTML5) export templates, which was fixed this day. The export templates `.tpz` file now contains the fixed templates, but if you installed Godot 3.1.2 and the templates before this date, you should update the WebAssembly templates manually. See instructions below in the download section. To do so, [download this archive](https://downloads.tuxfamily.org/godotengine/3.1.2/hotfix/Godot_v3.1.2-stable_fixed_webassembly_templates.tpz) containing only the fixed WebAssembly templates, and install them manually from the editor ([see details](https://downloads.tuxfamily.org/godotengine/3.1.2/hotfix/README.txt)). If you downloaded Godot after the date of this edit, you do not need to do anything. The Steam distribution will also be fixed automatically.
+**Edit 2019-12-03 @ 15:00 UTC:** A regression was found in the WebAssembly (HTML5) export templates, which was fixed this day. The export templates `.tpz` file now contains the fixed templates, but if you installed Godot 3.1.2 and the templates before this date, you should update the WebAssembly templates manually. See instructions below in the download section. To do so, [download this archive](https://github.com/godotengine/godot-builds/releases/3.1.2/hotfix/Godot_v3.1.2-stable_fixed_webassembly_templates.tpz) containing only the fixed WebAssembly templates, and install them manually from the editor ([see details](https://downloads.tuxfamily.org/godotengine/3.1.2/hotfix-README.txt)). If you downloaded Godot after the date of this edit, you do not need to do anything. The Steam distribution will also be fixed automatically.
 
 **Edit 2019-12-04 @ 10:30 UTC:** A follow-up regarding HTML5 templates: if you used the "Custom Html Shell" preset option to use your own loading code, you need to update your HTML template as shown in [this commit](https://github.com/godotengine/godot/commit/0587df4aa5f2977350cc80b1522cdc1e483c4515). This is necessary to support recent Emscripten versions.
 
@@ -32,7 +32,7 @@ So if you're looking for the latest and greatest, check [3.2 beta 2](/article/de
 
 ## Changes
 
-As mentioned, this release includes more than 400 new commits, with many bug fixes, usability enhancements and documentation improvements. You can read the [complete changelog](https://downloads.tuxfamily.org/godotengine/3.1.2/Godot_v3.1.2-stable_changelog.txt) for details. Below are a few selected highlights:
+As mentioned, this release includes more than 400 new commits, with many bug fixes, usability enhancements and documentation improvements. You can read the [complete changelog](https://github.com/godotengine/godot-builds/releases/3.1.2-Godot_v3.1.2-stable_changelog.txt) for details. Below are a few selected highlights:
 
 - Animation: Fixes for onion skinning support of Skeleton2D ([GH-29109](https://github.com/godotengine/godot/pull/29109)).
 - AnimationTree: Fixes to AnimationTree and State Machine ([GH-24796](https://github.com/godotengine/godot/pull/24796), [GH-27577](https://github.com/godotengine/godot/pull/27577),  [GH-28336](https://github.com/godotengine/godot/pull/28336), [GH-29018](https://github.com/godotengine/godot/pull/29018)).

--- a/collections/_article/maintenance-release-godot-3-2-2.md
+++ b/collections/_article/maintenance-release-godot-3-2-2.md
@@ -86,7 +86,7 @@ A big thankyou to all the documentation and localization contributors!
 
 The 3.2.2 release includes more than 800 commits from 140 contributors – thanks a ton to all of them for their work! Contributors fixed a wide range of issues (both new and older ones), as well as improving usability and documentation. Dozens more have been involved in [updating translations](https://hosted.weblate.org/projects/godot-engine/godot/) to make Godot 3.2.2 available in over 20 languages!
 
-Consult the complete changelog ([sorted by authors](https://downloads.tuxfamily.org/godotengine/3.2.2/Godot_v3.2.2-stable_changelog_authors.txt) or by [reverse chronological order](https://downloads.tuxfamily.org/godotengine/3.2.2/Godot_v3.2.2-stable_changelog_chrono.txt)) for an exhaustive list of all changes.
+Consult the complete changelog ([sorted by authors](https://github.com/godotengine/godot-builds/releases/3.2.2/Godot_v3.2.2-stable_changelog_authors.txt) or by [reverse chronological order](https://downloads.tuxfamily.org/godotengine/3.2.2-Godot_v3.2.2-stable_changelog_chrono.txt)) for an exhaustive list of all changes.
 
 Here's a hand-picked list of the some of the main changes in Godot 3.2.2:
 

--- a/collections/_article/maintenance-release-godot-3-2-3.md
+++ b/collections/_article/maintenance-release-godot-3-2-3.md
@@ -21,7 +21,7 @@ There's one big change for C# users though, which is that the `.csproj` project 
 
 Godot 3.2.3 includes over 500 commits from ca. 100 contributors. There were fixes all around the engine to address regressions, backport new fixes from the `master` branch, as well as a wide array of usability enhancements and documentation improvements.
 
-Consult the complete changelog ([sorted by authors](https://downloads.tuxfamily.org/godotengine/3.2.3/Godot_v3.2.3-stable_changelog_authors.txt) or by [reverse chronological order](https://downloads.tuxfamily.org/godotengine/3.2.3/Godot_v3.2.3-stable_changelog_chrono.txt)) for an exhaustive list of all changes.
+Consult the complete changelog ([sorted by authors](https://github.com/godotengine/godot-builds/releases/3.2.3/Godot_v3.2.3-stable_changelog_authors.txt) or by [reverse chronological order](https://downloads.tuxfamily.org/godotengine/3.2.3-Godot_v3.2.3-stable_changelog_chrono.txt)) for an exhaustive list of all changes.
 
 Here's a hand-picked list of the some of the main changes in Godot 3.2.3:
 

--- a/collections/_article/maintenance-release-godot-3-4-3.md
+++ b/collections/_article/maintenance-release-godot-3-4-3.md
@@ -17,7 +17,7 @@ A number of such fixes have been queued in the two months since the [3.4.2 relea
 
 ## Changes
 
-See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.4.3-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.4.2-stable...3.4.3-stable) on [in text form](https://downloads.tuxfamily.org/godotengine/3.4.3/Godot_v3.4.3-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
+See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.4.3-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.4.2-stable...3.4.3-stable) on [in text form](https://github.com/godotengine/godot-builds/releases/3.4.3-Godot_v3.4.3-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
 
 Here are some of the main changes since 3.4.2-stable:
 

--- a/collections/_article/maintenance-release-godot-3-4-4.md
+++ b/collections/_article/maintenance-release-godot-3-4-4.md
@@ -21,7 +21,7 @@ Last month's [3.4.3 release](/article/maintenance-release-godot-3-4-3) was found
 
 ## Changes
 
-See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.4.4-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.4.3-stable...3.4.4-stable) on [in text form](https://downloads.tuxfamily.org/godotengine/3.4.4/Godot_v3.4.4-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
+See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.4.4-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.4.3-stable...3.4.4-stable) on [in text form](https://github.com/godotengine/godot-builds/releases/3.4.4-Godot_v3.4.4-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
 
 Here are some of the main changes since 3.4.3-stable:
 

--- a/collections/_article/maintenance-release-godot-3-4-5.md
+++ b/collections/_article/maintenance-release-godot-3-4-5.md
@@ -24,7 +24,7 @@ Notable changes that motivate this release include:
 
 ## Changes
 
-See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.4.5-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.4.4-stable...3.4.5-stable) or [in text form](https://downloads.tuxfamily.org/godotengine/3.4.5/Godot_v3.4.5-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
+See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.4.5-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.4.4-stable...3.4.5-stable) or [in text form](https://github.com/godotengine/godot-builds/releases/3.4.5-Godot_v3.4.5-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
 
 Here are the main changes since 3.4.4-stable:
 

--- a/collections/_article/maintenance-release-godot-3-5-1.md
+++ b/collections/_article/maintenance-release-godot-3-5-1.md
@@ -19,7 +19,7 @@ So this 3.5.1 release fixes a number of regressions that users reported after th
 
 ## Changes
 
-See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.5.1-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.5-stable...3.5.1-stable) or [in text form](https://downloads.tuxfamily.org/godotengine/3.5.1/Godot_v3.5.1-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
+See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.5.1-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.5-stable...3.5.1-stable) or [in text form](https://github.com/godotengine/godot-builds/releases/3.5.1-Godot_v3.5.1-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
 
 Here are the main changes since 3.5-stable:
 

--- a/collections/_article/maintenance-release-godot-3-5-2.md
+++ b/collections/_article/maintenance-release-godot-3-5-2.md
@@ -21,7 +21,7 @@ As such, it's natural that existing Godot 3.5 users would prefer to stay on that
 
 ## Changes
 
-See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.5.2-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.5.1-stable...3.5.2-stable) or [in text form](https://downloads.tuxfamily.org/godotengine/3.5.2/Godot_v3.5.2-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
+See the [**curated changelog**](https://github.com/godotengine/godot/blob/3.5.2-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/3.5.1-stable...3.5.2-stable) or [in text form](https://github.com/godotengine/godot-builds/releases/3.5.2-Godot_v3.5.2-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
 
 Here are the main changes since 3.5.1-stable:
 

--- a/collections/_article/maintenance-release-godot-302.md
+++ b/collections/_article/maintenance-release-godot-302.md
@@ -19,14 +19,14 @@ I'd also like to thank all of our wonderful and outrageously attractive contribu
 
 ## What's new in this release
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.2/Godot_v3.0.2-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.2-Godot_v3.0.2-stable_changelog.txt) for details.
 
 * Mono: We now display stack traces for inner exceptions.
 * Mono: Bundle mscorlib.dll with Godot to improve portability.
 
 ## Fixed issues
 
-Here are some of the highlights of this release. See the [full changelog](http://downloads.tuxfamily.org/godotengine/3.0.2/Godot_v3.0.2-stable_changelog.txt) for details.
+Here are some of the highlights of this release. See the [full changelog](https://github.com/godotengine/godot-builds/releases/3.0.2-Godot_v3.0.2-stable_changelog.txt) for details.
 
 * Running a scene from a project with a main scene now works again (regression in 3.0.1).
 * Correct line spacing in RichTextLabel (regression in 3.0.1).

--- a/collections/_article/maintenance-release-godot-4-0-1.md
+++ b/collections/_article/maintenance-release-godot-4-0-1.md
@@ -21,7 +21,7 @@ One notable change in Godot 4.0.1 that is worth a dedicated mention is related t
 
 ## Changes
 
-See the [**curated changelog**](https://github.com/godotengine/godot/blob/4.0.1-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/4.0-stable...4.0.1-stable) or [in text form](https://downloads.tuxfamily.org/godotengine/4.0.1/Godot_v4.0.1-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
+See the [**curated changelog**](https://github.com/godotengine/godot/blob/4.0.1-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/4.0-stable...4.0.1-stable) or [in text form](https://github.com/godotengine/godot-builds/releases/4.0.1-Godot_v4.0.1-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
 
 Here are the main changes since 4.0-stable:
 

--- a/collections/_article/maintenance-release-godot-4-0-2.md
+++ b/collections/_article/maintenance-release-godot-4-0-2.md
@@ -21,7 +21,7 @@ In this release we also aim to improve the experience of Android developers. Thi
 
 ## Changes
 
-See the [**curated changelog**](https://github.com/godotengine/godot/blob/4.0.2-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/4.0.1-stable...4.0.2-stable) or [in text form](https://downloads.tuxfamily.org/godotengine/4.0.2/Godot_v4.0.2-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
+See the [**curated changelog**](https://github.com/godotengine/godot/blob/4.0.2-stable/CHANGELOG.md), or the full commit history [on GitHub](https://github.com/godotengine/godot/compare/4.0.1-stable...4.0.2-stable) or [in text form](https://github.com/godotengine/godot-builds/releases/4.0.2-Godot_v4.0.2-stable_changelog_chrono.txt) for an exhaustive overview of the fixes in this release.
 
 Here are the main changes since 4.0.1-stable:
 

--- a/collections/_article/release-candidate-3-2-3-rc-3.md
+++ b/collections/_article/release-candidate-3-2-3-rc-3.md
@@ -76,8 +76,8 @@ This release is built from commit [23b553ba0603161346526e1821bff5002520173c](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc3/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc3) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-3-2-rc-4.md
+++ b/collections/_article/release-candidate-3-2-rc-4.md
@@ -45,8 +45,8 @@ For changes since the last RC build, see [the list of commits](https://github.co
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/rc4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/rc4/mono) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-rc4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-rc4) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/release-candidate-3-5-rc-2.md
+++ b/collections/_article/release-candidate-3-5-rc-2.md
@@ -64,7 +64,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc2/Godot_v3.5-rc2_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc2-Godot_v3.5-rc2_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -175,7 +175,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc2/Godot_v3.5-rc2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc2/Godot_v3.5-rc2_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc2/Godot_v3.5-rc2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc2-Godot_v3.5-rc2_changelog_authors.txt)).
 
 You can also review the [changes between RC 1 and RC 2](https://github.com/godotengine/godot/compare/f33899d5bf3c046392a83d46cbf8c4c71e395550...5f9bc7ea5a8f6bd5229af3bfc8115dd80c5834c5).
 
@@ -186,8 +186,8 @@ This release is built from commit [5f9bc7ea5](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.179** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.179** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-1-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-1-1-rc-1.md
@@ -37,8 +37,8 @@ See the changes between [3.1-stable and 3.1.1-rc1](https://github.com/godotengin
 
 As always, you will find the binaries for your platform on our mirrors:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.1.1/rc1)]
-- Mono version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.1.1/rc1/mono)]
+- Classical version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.1.1-rc1)]
+- Mono version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.1.1-rc1)]
 
 ## <a id="known-incompatibilites"></a>Known incompatibilities
 

--- a/collections/_article/release-candidate-godot-3-1-2-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-1-2-rc-1.md
@@ -28,7 +28,7 @@ So if you're looking for the latest and greatest, check [3.2 beta 1](/article/de
 
 ## Changes
 
-As mentioned, this release includes close to 400 new commits, with many bug fixes, usability enhancements and documentation improvements. You can read the [complete changelog](https://downloads.tuxfamily.org/godotengine/3.1.2/rc1/Godot_v3.1.2-rc1_changelog.txt) for details. Below are a few selected highlights:
+As mentioned, this release includes close to 400 new commits, with many bug fixes, usability enhancements and documentation improvements. You can read the [complete changelog](https://github.com/godotengine/godot-builds/releases/download/3.1.2-rc1/Godot_v3.1.2-rc1_changelog.txt) for details. Below are a few selected highlights:
 
 - Animation: Fixes for onion skinning support of Skeleton2D ([GH-29109](https://github.com/godotengine/godot/pull/29109)).
 - AnimationTree: Fixes to AnimationTree and State Machine ([GH-24796](https://github.com/godotengine/godot/pull/24796), [GH-27577](https://github.com/godotengine/godot/pull/27577),  [GH-28336](https://github.com/godotengine/godot/pull/28336), [GH-29018](https://github.com/godotengine/godot/pull/29018)).
@@ -60,8 +60,8 @@ You can also see the full changelog since 3.1.1-stable on GitHub, split in two p
 
 As always, you will find the binaries for your platform on our mirrors:
 
-- Classical version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.1.2/rc1)]
-- Mono version: [[HTTPS mirror](https://downloads.tuxfamily.org/godotengine/3.1.2/rc1/mono)]
+- Classical version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.1.2-rc1)]
+- Mono version: [[HTTPS mirror](https://github.com/godotengine/godot-builds/releases/3.1.2-rc1)]
 
 Please test this version thoroughly on your existing 3.1.1 projects, and make sure to [**report any regression**](https://github.com/godotengine/godot/issues) that you may notice. 400 commits is a lot, and the `3.1` branch is not tested as thoroughly as the `master` branch outside releases such as this one, so there is a lot of surface for potential regressions (yet, there shouldn't be any game breaking issue, so it's safe to test it on existing projects and revert back to 3.1.1 if there's any problem).
 

--- a/collections/_article/release-candidate-godot-3-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-1-rc-1.md
@@ -33,8 +33,8 @@ The documentation's [*latest* branch](http://docs.godotengine.org/en/latest/) in
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [**Classic build**](https://downloads.tuxfamily.org/godotengine/3.1/rc1) (GDScript, GDNative, VisualScript)
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.1/rc1/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build.
+- [**Classic build**](https://github.com/godotengine/godot-builds/releases/3.1-rc1) (GDScript, GDNative, VisualScript)
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.1-rc1) (C# support + all the above). You need to have MSbuild installed to use the Mono build.
 
 **Important:** Windows binaries are now signed by [**Prehensile Tales B.V.**](https://www.prehensile-tales.com), the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/release-candidate-godot-3-1-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-1-rc-2.md
@@ -31,8 +31,8 @@ The documentation's [*latest* branch](http://docs.godotengine.org/en/latest/) in
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [**Classic build**](https://downloads.tuxfamily.org/godotengine/3.1/rc2) (GDScript, GDNative, VisualScript)
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.1/rc2/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build.
+- [**Classic build**](https://github.com/godotengine/godot-builds/releases/3.1-rc2) (GDScript, GDNative, VisualScript)
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.1-rc2) (C# support + all the above). You need to have MSbuild installed to use the Mono build.
 
 **Important:** Windows binaries are now signed by [**Prehensile Tales B.V.**](https://www.prehensile-tales.com), the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/release-candidate-godot-3-1-rc-3.md
+++ b/collections/_article/release-candidate-godot-3-1-rc-3.md
@@ -30,8 +30,8 @@ The documentation's [*latest* branch](http://docs.godotengine.org/en/latest/) in
 
 The download links are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary and export templates that matches your platform and Godot flavour:
 
-- [**Standard build**](https://downloads.tuxfamily.org/godotengine/3.1/rc3) (GDScript, GDNative, VisualScript)
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.1/rc3/mono) (C# support + all the above). You need to have MSbuild installed to use the Mono build.
+- [**Standard build**](https://github.com/godotengine/godot-builds/releases/3.1-rc3) (GDScript, GDNative, VisualScript)
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.1-rc3) (C# support + all the above). You need to have MSbuild installed to use the Mono build.
 
 **Important:** Windows binaries are now signed by [**Prehensile Tales B.V.**](https://www.prehensile-tales.com), the company of our release manager [HP van Braam](https://github.com/hpvb). You can trust this signature and accept any warning that Windows may issue due to the novelty of this certificate. As more users accept it, the certificate will be recognized as trusted for future releases.
 

--- a/collections/_article/release-candidate-godot-3-2-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-2-1-rc-1.md
@@ -37,8 +37,8 @@ Some new/improved features are planned further down the road for the 3.2.x relea
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.1/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.1/rc1/mono) (C# support + all the above). You need to have MSBuild and .NET Framework 4.7 installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.1-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.1-rc1) (C# support + all the above). You need to have MSBuild and .NET Framework 4.7 installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-1-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-2-1-rc-2.md
@@ -40,8 +40,8 @@ Some new/improved features are planned further down the road for the 3.2.x relea
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.1/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.1/rc2/mono) (C# support + all the above). You need to have MSBuild (and on Windows .NET Framework 4.7 installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.1-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.1-rc2) (C# support + all the above). You need to have MSBuild (and on Windows .NET Framework 4.7 installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-2-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-2-2-rc-1.md
@@ -142,8 +142,8 @@ Godot 3.2.2 RC 1 is built from commit [5ee9553591ebb7926a238f2d5b5fb154db602b95]
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [**Classical build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc1/) (GDScript, GDNative, VisualScript).
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [**Classical build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc1) (GDScript, GDNative, VisualScript).
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-2-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-2-2-rc-2.md
@@ -148,8 +148,8 @@ Godot 3.2.2 RC 2 is built from commit [ae59e22cdd7101d85bcb92871ce53f05c668f5c4]
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [**Classical build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc2/) (GDScript, GDNative, VisualScript).
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc2/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [**Classical build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc2) (GDScript, GDNative, VisualScript).
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc2) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-2-rc-3.md
+++ b/collections/_article/release-candidate-godot-3-2-2-rc-3.md
@@ -149,8 +149,8 @@ Godot 3.2.2 RC 3 is built from commit [1468c0b4d4592406502c7e4eaa2121f1d0a7e5f6]
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [**Classical build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc3/) (GDScript, GDNative, VisualScript).
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc3/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [**Classical build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc3) (GDScript, GDNative, VisualScript).
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc3) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-2-rc-4.md
+++ b/collections/_article/release-candidate-godot-3-2-2-rc-4.md
@@ -28,8 +28,8 @@ If all goes well, I intend to release `3.2.2-stable` in a day or two (Famous Las
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [**Classical build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc4/) (GDScript, GDNative, VisualScript).
-- [**Mono build**](https://downloads.tuxfamily.org/godotengine/3.2.2/rc4/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [**Classical build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc4) (GDScript, GDNative, VisualScript).
+- [**Mono build**](https://github.com/godotengine/godot-builds/releases/3.2.2-rc4) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-3-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-2-3-rc-1.md
@@ -64,8 +64,8 @@ This release is built from commit [a24e30abd7b1bc226dc1231ef2b8eb5a9ee50df6](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-3-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-2-3-rc-2.md
@@ -79,8 +79,8 @@ This release is built from commit [ac2e7d87d1c398db9c796afba6973a2f170ddfa2](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc2/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc2) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-3-rc-4.md
+++ b/collections/_article/release-candidate-godot-3-2-3-rc-4.md
@@ -79,8 +79,8 @@ This release is built from commit [dbb0ad3b59e4d9150d41a0f5177069224cb2f837](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc4/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc4) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-3-rc-5.md
+++ b/collections/_article/release-candidate-godot-3-2-3-rc-5.md
@@ -82,8 +82,8 @@ This release is built from commit [d773de6d244116c3ad26f0506a10038cc11019ff](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc5/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc5/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc5) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc5) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-3-rc-6.md
+++ b/collections/_article/release-candidate-godot-3-2-3-rc-6.md
@@ -88,8 +88,8 @@ This release is built from commit [8c5ed688476da64cbea17b34f1eacc76bac1d9c7](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc6/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.3/rc6/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc6) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.3-rc6) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.166 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-4-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-2-4-rc-1.md
@@ -132,7 +132,7 @@ The main new features are highlighted in bold. Refer to the linked pull requests
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.2.4/rc1/Godot_v3.2.4-rc1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4/rc1/Godot_v3.2.4-rc1_changelog_authors.txt)), or the [changes since the previous beta 6 build](https://github.com/godotengine/godot/compare/029d2568c364b9755b333c59fae8c04d955055be...dae72fcdd50094ef909ab99b7d19e46cdec463d5).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.2.4-rc1/Godot_v3.2.4-rc1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4-rc1/Godot_v3.2.4-rc1_changelog_authors.txt)), or the [changes since the previous beta 6 build](https://github.com/godotengine/godot/compare-029d2568c364b9755b333c59fae8c04d955055be...dae72fcdd50094ef909ab99b7d19e46cdec463d5).
 
 This release is built from commit [dae72fcdd50094ef909ab99b7d19e46cdec463d5](https://github.com/godotengine/godot/commit/dae72fcdd50094ef909ab99b7d19e46cdec463d5).
 
@@ -140,8 +140,8 @@ This release is built from commit [dae72fcdd50094ef909ab99b7d19e46cdec463d5](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-4-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-2-4-rc-2.md
@@ -152,7 +152,7 @@ The main new features are highlighted in bold. Refer to the linked pull requests
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.2.4/rc2/Godot_v3.2.4-rc2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4/rc2/Godot_v3.2.4-rc2_changelog_authors.txt)), or the [changes since the previous RC 1 build](https://github.com/godotengine/godot/compare/dae72fcdd50094ef909ab99b7d19e46cdec463d5...9918fd722e3e555cb174f9806cdb38b6e8b0c2b7).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.2.4-rc2/Godot_v3.2.4-rc2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4-rc2/Godot_v3.2.4-rc2_changelog_authors.txt)), or the [changes since the previous RC 1 build](https://github.com/godotengine/godot/compare-dae72fcdd50094ef909ab99b7d19e46cdec463d5...9918fd722e3e555cb174f9806cdb38b6e8b0c2b7).
 
 This release is built from commit [9918fd722e3e555cb174f9806cdb38b6e8b0c2b7](https://github.com/godotengine/godot/commit/9918fd722e3e555cb174f9806cdb38b6e8b0c2b7).
 
@@ -160,8 +160,8 @@ This release is built from commit [9918fd722e3e555cb174f9806cdb38b6e8b0c2b7](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc2/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc2) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-4-rc-3.md
+++ b/collections/_article/release-candidate-godot-3-2-4-rc-3.md
@@ -168,7 +168,7 @@ The main new features are highlighted in bold. Refer to the linked pull requests
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.2.4/rc3/Godot_v3.2.4-rc3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4/rc3/Godot_v3.2.4-rc3_changelog_authors.txt)), or the [changes since the previous RC 2 build](https://github.com/godotengine/godot/compare/9918fd722e3e555cb174f9806cdb38b6e8b0c2b7...4f891b706027dc800f6949bec413f448defdd20d).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.2.4-rc3/Godot_v3.2.4-rc3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4-rc3/Godot_v3.2.4-rc3_changelog_authors.txt)), or the [changes since the previous RC 2 build](https://github.com/godotengine/godot/compare-9918fd722e3e555cb174f9806cdb38b6e8b0c2b7...4f891b706027dc800f6949bec413f448defdd20d).
 
 This release is built from commit [4f891b706027dc800f6949bec413f448defdd20d](https://github.com/godotengine/godot/commit/4f891b706027dc800f6949bec413f448defdd20d).
 
@@ -176,8 +176,8 @@ This release is built from commit [4f891b706027dc800f6949bec413f448defdd20d](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc3/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc3) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-4-rc-4.md
+++ b/collections/_article/release-candidate-godot-3-2-4-rc-4.md
@@ -186,7 +186,7 @@ The main new features are highlighted in bold. Refer to the linked pull requests
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.2.4/rc4/Godot_v3.2.4-rc4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4/rc4/Godot_v3.2.4-rc4_changelog_authors.txt)), or the [changes since the previous RC 3 build](https://github.com/godotengine/godot/compare/4f891b706027dc800f6949bec413f448defdd20d...dc99f04d51d6556e5ba4d9cfcce8117d168ac6f1).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.2.4-rc4/Godot_v3.2.4-rc4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.2.4-rc4/Godot_v3.2.4-rc4_changelog_authors.txt)), or the [changes since the previous RC 3 build](https://github.com/godotengine/godot/compare-4f891b706027dc800f6949bec413f448defdd20d...dc99f04d51d6556e5ba4d9cfcce8117d168ac6f1).
 
 This release is built from commit [dc99f04d51d6556e5ba4d9cfcce8117d168ac6f1](https://github.com/godotengine/godot/commit/dc99f04d51d6556e5ba4d9cfcce8117d168ac6f1).
 
@@ -194,8 +194,8 @@ This release is built from commit [dc99f04d51d6556e5ba4d9cfcce8117d168ac6f1](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc4/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc4) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-4-rc-5.md
+++ b/collections/_article/release-candidate-godot-3-2-4-rc-5.md
@@ -27,8 +27,8 @@ This release is built from commit [b169a16cb51b7203a171245acb5b4193c9d4bca4](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc5/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2.4/rc5/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc5) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2.4-rc5) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-2-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-2-rc-1.md
@@ -40,8 +40,8 @@ For changes since the last beta build, see [the list of commits](https://github.
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/rc1/mono) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-rc1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/release-candidate-godot-3-2-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-2-rc-2.md
@@ -42,8 +42,8 @@ For changes since the last RC build, see [the list of commits](https://github.co
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/rc2/mono) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-rc2) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/release-candidate-godot-3-2-rc-3.md
+++ b/collections/_article/release-candidate-godot-3-2-rc-3.md
@@ -48,8 +48,8 @@ For changes since the last RC build, see [the list of commits](https://github.co
 
 The download links are not featured on the [Download](/download) page for now to avoid confusion for new users. Instead, browse one of our download repository and fetch the editor binary that matches your platform:
 
-- [Classical build](https://downloads.tuxfamily.org/godotengine/3.2/rc3/) (GDScript, GDNative, VisualScript). Note: UWP templates are missing from this build.
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.2/rc3/mono) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
+- [Classical build](https://github.com/godotengine/godot-builds/releases/3.2-rc3) (GDScript, GDNative, VisualScript). Note: UWP templates are missing from this build.
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.2-rc3) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.6.0.161 are included in this build.
 
 **IMPORTANT:** Make backups of your Godot 3.1 projects before opening them in any 3.2 development build.
 

--- a/collections/_article/release-candidate-godot-3-3-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-3-1-rc-1.md
@@ -47,9 +47,9 @@ This release is built from commit [140cf0f2cb7b51d7866e63aba1aa6d8029cf540b](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3.1/rc1/) (GDScript, GDNative, VisualScript).
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3.1-rc1) (GDScript, GDNative, VisualScript).
   * Note: UWP export templates are missing from this build, will be re-added in the next build.
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3.1/rc1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3.1-rc1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-1-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-3-1-rc-2.md
@@ -53,9 +53,9 @@ This release is built from commit [f6c29d1cf5eddebbace38172c0f30b6d4ab5e5f2](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3.1/rc2/) (GDScript, GDNative, VisualScript).
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3.1-rc2) (GDScript, GDNative, VisualScript).
   * Note: UWP export templates are missing from this build, will be re-added in the next build.
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3.1/rc2/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3.1-rc2) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-3-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-3-3-rc-1.md
@@ -58,7 +58,7 @@ Here are some of the main changes since 3.3.2-stable:
 - Translation updates.
 - API documentation updates.
 
-See the full changelog since 3.3.2-stable [on GitHub](https://github.com/godotengine/godot/compare/3.3.2-stable...dec840452d5986ec8099b92ebabf454757da8b04), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.3.3/rc1/Godot_v3.3.3-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.3.3/rc1/Godot_v3.3.3-rc1_changelog_chrono.txt)).
+See the full changelog since 3.3.2-stable [on GitHub](https://github.com/godotengine/godot/compare/3.3.2-stable...dec840452d5986ec8099b92ebabf454757da8b04), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.3.3-rc1/Godot_v3.3.3-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.3.3-rc1-Godot_v3.3.3-rc1_changelog_chrono.txt)).
 
 This release is built from commit [f6c29d1cf5eddebbace38172c0f30b6d4ab5e5f2](https://github.com/godotengine/godot/commit/f6c29d1cf5eddebbace38172c0f30b6d4ab5e5f2).
 
@@ -66,9 +66,9 @@ This release is built from commit [f6c29d1cf5eddebbace38172c0f30b6d4ab5e5f2](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3.3/rc1/) (GDScript, GDNative, VisualScript).
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3.3-rc1) (GDScript, GDNative, VisualScript).
   * Note: UWP export templates are missing from this build, will be re-added in the next build.
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3.3/rc1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3.3-rc1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-3-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-3-3-rc-2.md
@@ -66,7 +66,7 @@ Here are some of the main changes since 3.3.2-stable:
 - Translation updates.
 - API documentation updates.
 
-See the full changelog since 3.3.2-stable [on GitHub](https://github.com/godotengine/godot/compare/3.3.2-stable...f66ff33b25e1a1298d119b6a198f2562789e5f0c), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.3.3/rc2/Godot_v3.3.3-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.3.3/rc2/Godot_v3.3.3-rc2_changelog_chrono.txt)). You can also review the [changes since 3.3.3 RC 1](https://github.com/godotengine/godot/compare/dec840452d5986ec8099b92ebabf454757da8b04...f66ff33b25e1a1298d119b6a198f2562789e5f0c).
+See the full changelog since 3.3.2-stable [on GitHub](https://github.com/godotengine/godot/compare/3.3.2-stable...f66ff33b25e1a1298d119b6a198f2562789e5f0c), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.3.3-rc2/Godot_v3.3.3-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.3.3-rc2/Godot_v3.3.3-rc2_changelog_chrono.txt)). You can also review the [changes since 3.3.3 RC 1](https://github.com/godotengine/godot/compare-dec840452d5986ec8099b92ebabf454757da8b04...f66ff33b25e1a1298d119b6a198f2562789e5f0c).
 
 This release is built from commit [f66ff33b25e1a1298d119b6a198f2562789e5f0c](https://github.com/godotengine/godot/commit/f66ff33b25e1a1298d119b6a198f2562789e5f0c).
 
@@ -74,9 +74,9 @@ This release is built from commit [f66ff33b25e1a1298d119b6a198f2562789e5f0c](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3.3/rc2/) (GDScript, GDNative, VisualScript).
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3.3-rc2) (GDScript, GDNative, VisualScript).
   * Note: UWP export templates are missing from this build, will be re-added in the next build.
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3.3/rc2/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3.3-rc2) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-4-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-3-4-rc-1.md
@@ -45,7 +45,7 @@ Here are some of the main changes since 3.3.3-stable:
 - VisualScript: Fix VisualScriptPropertySet value hint ([GH-52219](https://github.com/godotengine/godot/pull/52219)).
 - API documentation updates.
 
-See the full changelog since 3.3.3-stable [on GitHub](https://github.com/godotengine/godot/compare/3.3.3-stable...90022710ab6e5490e4b1e563f163bc5edc9b9735), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.3.4/rc1/Godot_v3.3.4-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.3.4/rc1/Godot_v3.3.4-rc1_changelog_chrono.txt)).
+See the full changelog since 3.3.3-stable [on GitHub](https://github.com/godotengine/godot/compare/3.3.3-stable...90022710ab6e5490e4b1e563f163bc5edc9b9735), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/download/3.3.4-rc1/Godot_v3.3.4-rc1_changelog_authors.txt) or [chronologically](https://github.com/godotengine/godot-builds/releases/download/3.3.4-rc1/Godot_v3.3.4-rc1_changelog_chrono.txt)).
 
 This release is built from commit [90022710ab6e5490e4b1e563f163bc5edc9b9735](https://github.com/godotengine/godot/commit/90022710ab6e5490e4b1e563f163bc5edc9b9735).
 
@@ -53,9 +53,9 @@ This release is built from commit [90022710ab6e5490e4b1e563f163bc5edc9b9735](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3.4/rc1/) (GDScript, GDNative, VisualScript).
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3.4-rc1) (GDScript, GDNative, VisualScript).
   * Note: UWP export templates are missing from this build, will be re-added in the next build.
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3.4/rc1/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3.4-rc1) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-rc-6.md
+++ b/collections/_article/release-candidate-godot-3-3-rc-6.md
@@ -188,7 +188,7 @@ The main new features are highlighted in bold. Refer to the linked pull requests
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.3/rc6/Godot_v3.3-rc6_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3/rc6/Godot_v3.3-rc6_changelog_authors.txt)), or the [changes since the previous RC 5 build](https://github.com/godotengine/godot/compare/b169a16cb51b7203a171245acb5b4193c9d4bca4...15ff752737c53a1727cbc011068afa15683509be).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.3-rc6/Godot_v3.3-rc6_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3-rc6/Godot_v3.3-rc6_changelog_authors.txt)), or the [changes since the previous RC 5 build](https://github.com/godotengine/godot/compare-b169a16cb51b7203a171245acb5b4193c9d4bca4...15ff752737c53a1727cbc011068afa15683509be).
 
 This release is built from commit [15ff752737c53a1727cbc011068afa15683509be](https://github.com/godotengine/godot/commit/15ff752737c53a1727cbc011068afa15683509be).
 
@@ -196,8 +196,8 @@ This release is built from commit [15ff752737c53a1727cbc011068afa15683509be](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3/rc6/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3/rc6/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3-rc6) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3-rc6) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono 6.12.0.114 are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-rc-7.md
+++ b/collections/_article/release-candidate-godot-3-3-rc-7.md
@@ -188,7 +188,7 @@ The main new features are highlighted in bold. Refer to the linked pull requests
 - Editor translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.3/rc7/Godot_v3.3-rc7_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3/rc7/Godot_v3.3-rc7_changelog_authors.txt)), or the [changes since the previous RC 6 build](https://github.com/godotengine/godot/compare/15ff752737c53a1727cbc011068afa15683509be...cca2637b9b9dcb16070eb50a69c601a5f076c683).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.3-rc7/Godot_v3.3-rc7_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3-rc7/Godot_v3.3-rc7_changelog_authors.txt)), or the [changes since the previous RC 6 build](https://github.com/godotengine/godot/compare-15ff752737c53a1727cbc011068afa15683509be...cca2637b9b9dcb16070eb50a69c601a5f076c683).
 
 This release is built from commit [cca2637b9b9dcb16070eb50a69c601a5f076c683](https://github.com/godotengine/godot/commit/cca2637b9b9dcb16070eb50a69c601a5f076c683).
 
@@ -196,8 +196,8 @@ This release is built from commit [cca2637b9b9dcb16070eb50a69c601a5f076c683](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3/rc7/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3/rc7/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build. (Note: Previous builds used Mono 6.12.0.114.)
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3-rc7) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3-rc7) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build. (Note: Previous builds used Mono 6.12.0.114.)
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-rc-8.md
+++ b/collections/_article/release-candidate-godot-3-3-rc-8.md
@@ -19,7 +19,7 @@ As usual, you can try it live with the [**online version of the Godot editor**](
 
 Compared to the previous RC 7 build, this release fixes a few regressions in GDNative, rendering, GodotPhysics (BVH), and Android JNI threads. It also fixes the GLES2 fallback option for HTML5 exports.
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.3/rc8/Godot_v3.3-rc8_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3/rc8/Godot_v3.3-rc8_changelog_authors.txt)), or the [**changes since the previous RC 7 build**](https://github.com/godotengine/godot/compare/cca2637b9b9dcb16070eb50a69c601a5f076c683...b076150b086a5001b190a9a20a425d1bc842fe21).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.3-rc8/Godot_v3.3-rc8_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3-rc8/Godot_v3.3-rc8_changelog_authors.txt)), or the [**changes since the previous RC 7 build**](https://github.com/godotengine/godot/compare-cca2637b9b9dcb16070eb50a69c601a5f076c683...b076150b086a5001b190a9a20a425d1bc842fe21).
 
 This release is built from commit [b076150b086a5001b190a9a20a425d1bc842fe21](https://github.com/godotengine/godot/commit/b076150b086a5001b190a9a20a425d1bc842fe21).
 
@@ -27,8 +27,8 @@ This release is built from commit [b076150b086a5001b190a9a20a425d1bc842fe21](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3/rc8/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3/rc8/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build. (Note: Builds prior to 3.3 RC 7 used Mono 6.12.0.114.)
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3-rc8) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3-rc8) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build. (Note: Builds prior to 3.3 RC 7 used Mono 6.12.0.114.)
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-3-rc-9.md
+++ b/collections/_article/release-candidate-godot-3-3-rc-9.md
@@ -21,7 +21,7 @@ Compared to the previous RC 8 build, this release fixes a few issues with: 2D ba
 
 For 2D rendering, we're also re-adding some testing options which were used in earlier betas to allow users to test different scenarios which may impact performance for some OpenGL drivers (especially on Windows and macOS). See [GH-47864](https://github.com/godotengine/godot/pull/47864) for details. For the legacy render path (non-batching), we're changing a flag to `GL_STREAM_DRAW` which seems to give significant FPS gains on some test cases. Please report if you see any suspicious FPS drop in RC9 compared to RC8!
 
-See the full changelog since 3.2.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.3/rc9/Godot_v3.3-rc9_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3/rc9/Godot_v3.3-rc9_changelog_authors.txt)), or the [**changes since the previous RC 8 build**](https://github.com/godotengine/godot/compare/b076150b086a5001b190a9a20a425d1bc842fe21...00d087e47d9f1d9ae358a19a9ac0862349d391ce).
+See the full changelog since 3.2.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.3-rc9/Godot_v3.3-rc9_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.3-rc9/Godot_v3.3-rc9_changelog_authors.txt)), or the [**changes since the previous RC 8 build**](https://github.com/godotengine/godot/compare-b076150b086a5001b190a9a20a425d1bc842fe21...00d087e47d9f1d9ae358a19a9ac0862349d391ce).
 
 This release is built from commit [00d087e47d9f1d9ae358a19a9ac0862349d391ce](https://github.com/godotengine/godot/commit/00d087e47d9f1d9ae358a19a9ac0862349d391ce).
 
@@ -29,8 +29,8 @@ This release is built from commit [00d087e47d9f1d9ae358a19a9ac0862349d391ce](htt
 
 The download links for dev snapshots are not featured on the [Download](/download) page to avoid confusion for new users. Instead, browse our download repository and fetch the editor binary that matches your platform:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.3/rc9/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.3/rc9/mono/) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build. (Note: Builds prior to 3.3 RC 7 used Mono 6.12.0.114.)
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.3-rc9) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.3-rc9) (C# support + all the above). You need to have MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.122** are included in this build. (Note: Builds prior to 3.3 RC 7 used Mono 6.12.0.114.)
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-4-1-rc-1.md
@@ -58,16 +58,16 @@ Here are some of the main changes since 3.4-stable:
 - Thirdparty library updates: libogg 1.3.5, libvorbis 1.3.7, CA certificates from 2021-11-01.
 - API documentation and translation updates.
 
-See the full changelog since 3.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4-stable...7b0801c7fb4416625fb9ca124b41b93677689420), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.1/rc1/Godot_v3.4.1-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.1/rc1/Godot_v3.4.1-rc1_changelog_chrono.txt)).
+See the full changelog since 3.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4-stable...7b0801c7fb4416625fb9ca124b41b93677689420), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/download/3.4.1-rc1/Godot_v3.4.1-rc1_changelog_authors.txt) or [chronologically](https://github.com/godotengine/godot-builds/releases/download/3.4.1-rc1/Godot_v3.4.1-rc1_changelog_chrono.txt)).
 
-This release is built from commit [`7b0801c7f`](https://github.com/godotengine/godot/commit/7b0801c7fb4416625fb9ca124b41b93677689420) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.1/rc1/README.txt)).
+This release is built from commit [`7b0801c7f`](https://github.com/godotengine/godot/commit/7b0801c7fb4416625fb9ca124b41b93677689420) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.1-rc1README.txt)).
 
 <h2 id="downloads">Downloads</h2>
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.1/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.1/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.1-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.1-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-1-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-4-1-rc-2.md
@@ -74,19 +74,19 @@ Here are some of the main changes since 3.4-stable:
 - Thirdparty library updates: libogg 1.3.5, libvorbis 1.3.7, minimp3 from 2021-11-30, CA certificates from 2021-11-01.
 - API documentation and translation updates.
 
-See the full changelog since 3.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4-stable...d5aa00c2cb6e240ec1ec572e3d4bd9c5325ff219), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.1/rc2/Godot_v3.4.1-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.1/rc2/Godot_v3.4.1-rc2_changelog_chrono.txt)).
+See the full changelog since 3.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4-stable...d5aa00c2cb6e240ec1ec572e3d4bd9c5325ff219), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/download/3.4.1-rc2/Godot_v3.4.1-rc2_changelog_authors.txt) or [chronologically](https://github.com/godotengine/godot-builds/releases/download/3.4.1-rc2/Godot_v3.4.1-rc2_changelog_authors.txt)).
 
 If you reviewed changes in [3.4.1 RC 1](/article/release-candidate-godot-3-4-1-rc-1) already, here's the [changelog between RC 1 and RC 2](https://github.com/godotengine/godot/compare/7b0801c7fb4416625fb9ca124b41b93677689420...d5aa00c2cb6e240ec1ec572e3d4bd9c5325ff219).
 
-This release is built from commit [`d5aa00c2c`](https://github.com/godotengine/godot/commit/d5aa00c2cb6e240ec1ec572e3d4bd9c5325ff219) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.1/rc2/README.txt)).
+This release is built from commit [`d5aa00c2c`](https://github.com/godotengine/godot/commit/d5aa00c2cb6e240ec1ec572e3d4bd9c5325ff219) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.1-rc2README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.1/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.1/rc2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.1-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.1-rc2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-1-rc-3.md
+++ b/collections/_article/release-candidate-godot-3-4-1-rc-3.md
@@ -86,19 +86,19 @@ Here are some of the main changes since 3.4-stable:
 - Thirdparty library updates: libogg 1.3.5, libvorbis 1.3.7, minimp3 from 2021-11-30, CA certificates from 2021-11-01.
 - API documentation and translation updates.
 
-See the full changelog since 3.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4-stable...69585b051629ec9f8be63a1b5212510f98b81e6f), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.1/rc3/Godot_v3.4.1-rc3_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.1/rc3/Godot_v3.4.1-rc3_changelog_chrono.txt)).
+See the full changelog since 3.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4-stable...69585b051629ec9f8be63a1b5212510f98b81e6f), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/download/3.4.1-rc3/Godot_v3.4.1-rc3_changelog_authors.txt) or [chronologically](https://github.com/godotengine/godot-builds/releases/download/3.4.1-rc3/Godot_v3.4.1-rc3_changelog_chrono.txt)).
 
 If you reviewed changes in [3.4.1 RC 2](/article/release-candidate-godot-3-4-1-rc-2) already, here's the [changelog between RC 2 and RC 3](https://github.com/godotengine/godot/compare/d5aa00c2cb6e240ec1ec572e3d4bd9c5325ff219...69585b051629ec9f8be63a1b5212510f98b81e6f).
 
-This release is built from commit [`69585b051`](https://github.com/godotengine/godot/commit/69585b051629ec9f8be63a1b5212510f98b81e6f) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.1/rc3/README.txt)).
+This release is built from commit [`69585b051`](https://github.com/godotengine/godot/commit/69585b051629ec9f8be63a1b5212510f98b81e6f) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.1-rc3README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.1/rc3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.1/rc3/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.1-rc3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.1-rc3) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-3-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-4-3-rc-1.md
@@ -72,17 +72,17 @@ Here are some of the main changes since 3.4.2-stable:
 - XR: Fix Android manifest XR metadata ([GH-57263](https://github.com/godotengine/godot/pull/57263)).
 - API documentation and translation updates.
 
-See the full changelog since 3.4.2-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.2-stable...894b6d50493756be25d7f25dc1138b0272f7532e), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.3/rc1/Godot_v3.4.3-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.3/rc1/Godot_v3.4.3-rc1_changelog_chrono.txt)).
+See the full changelog since 3.4.2-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.2-stable...894b6d50493756be25d7f25dc1138b0272f7532e), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/download/3.4.3-rc1/Godot_v3.4.3-rc1_changelog_authors.txt) or [chronologically](https://github.com/godotengine/godot-builds/releases/download/3.4.3-rc1/Godot_v3.4.3-rc1_changelog_chrono.txt)).
 
-This release is built from commit [`894b6d504`](https://github.com/godotengine/godot/commit/894b6d50493756be25d7f25dc1138b0272f7532e) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.3/rc1/README.txt)).
+This release is built from commit [`894b6d504`](https://github.com/godotengine/godot/commit/894b6d50493756be25d7f25dc1138b0272f7532e) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.3-rc1README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.3/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.3/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.3-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.3-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-3-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-4-3-rc-2.md
@@ -85,17 +85,17 @@ Here are some of the main changes since 3.4.2-stable:
 - XR: Fix Android manifest XR metadata ([GH-57263](https://github.com/godotengine/godot/pull/57263)).
 - API documentation and translation updates.
 
-See the full GitHub changelog [since 3.4.2-stable](https://github.com/godotengine/godot/compare/3.4.2-stable...0ea54d07f29e9813a368ca6858aa38a6139385dc) or [since 3.4.3 RC 1](https://github.com/godotengine/godot/compare/894b6d50493756be25d7f25dc1138b0272f7532e...0ea54d07f29e9813a368ca6858aa38a6139385dc), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.3/rc2/Godot_v3.4.3-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.3/rc2/Godot_v3.4.3-rc2_changelog_chrono.txt)).
+See the full GitHub changelog [since 3.4.2-stable](https://github.com/godotengine/godot/compare/3.4.2-stable...0ea54d07f29e9813a368ca6858aa38a6139385dc) or [since 3.4.3 RC 1](https://github.com/godotengine/godot/compare/894b6d50493756be25d7f25dc1138b0272f7532e...0ea54d07f29e9813a368ca6858aa38a6139385dc), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/download/3.4.3-rc2/Godot_v3.4.3-rc2_changelog_authors.txt) or [chronologically](https://github.com/godotengine/godot-builds/releases/download/3.4.3-rc2/Godot_v3.4.3-rc2_changelog_chrono.txt)).
 
-This release is built from commit [`894b6d504`](https://github.com/godotengine/godot/commit/0ea54d07f29e9813a368ca6858aa38a6139385dc) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.3/rc2/README.txt)).
+This release is built from commit [`894b6d504`](https://github.com/godotengine/godot/commit/0ea54d07f29e9813a368ca6858aa38a6139385dc) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.3-rc2README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.3/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.3/rc2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.3-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.3-rc2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-4-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-4-4-rc-1.md
@@ -38,17 +38,17 @@ Here are the main changes since 3.4.3-stable:
 - Rendering: GLES3: Fix shader state caching when blend shapes used ([GH-58808](https://github.com/godotengine/godot/pull/58808)) **[regression fix]**.
 - API documentation updates.
 
-See the full changelog since 3.4.3-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.3-stable...6b4d7d20a48ddcc5bf457df38053086ab6041c9f), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.4/rc1/Godot_v3.4.4-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.4/rc1/Godot_v3.4.4-rc1_changelog_chrono.txt)).
+See the full changelog since 3.4.3-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.3-stable...6b4d7d20a48ddcc5bf457df38053086ab6041c9f), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.4.4-rc1/Godot_v3.4.4-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.4-rc1-Godot_v3.4.4-rc1_changelog_chrono.txt)).
 
-This release is built from commit [`6b4d7d20a`](https://github.com/godotengine/godot/commit/6b4d7d20a48ddcc5bf457df38053086ab6041c9f) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.4/rc1/README.txt)).
+This release is built from commit [`6b4d7d20a`](https://github.com/godotengine/godot/commit/6b4d7d20a48ddcc5bf457df38053086ab6041c9f) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.4-rc1README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.4/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.4/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.4-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.4-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 **Note:** The Windows builds are signed, but the certificate expired recently. We're working on having it renewed, this should be fixed in time for 3.4.4 stable.
 

--- a/collections/_article/release-candidate-godot-3-4-4-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-4-4-rc-2.md
@@ -43,17 +43,17 @@ Here are the main changes since 3.4.3-stable:
 - RichTextLabel: Fix shadow color when text has transparency ([GH-59054](https://github.com/godotengine/godot/pull/59054)).
 - API documentation updates.
 
-See the full changelog since 3.4.3-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.3-stable...69e9e8f87def0d6c21d7f5919e1fb37fa7b8e662), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.4/rc2/Godot_v3.4.4-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.4/rc2/Godot_v3.4.4-rc2_changelog_chrono.txt)).
+See the full changelog since 3.4.3-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.3-stable...69e9e8f87def0d6c21d7f5919e1fb37fa7b8e662), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.4.4-rc2/Godot_v3.4.4-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.4-rc2-Godot_v3.4.4-rc2_changelog_chrono.txt)).
 
-This release is built from commit [`69e9e8f87`](https://github.com/godotengine/godot/commit/69e9e8f87def0d6c21d7f5919e1fb37fa7b8e662) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.4/rc2/README.txt)).
+This release is built from commit [`69e9e8f87`](https://github.com/godotengine/godot/commit/69e9e8f87def0d6c21d7f5919e1fb37fa7b8e662) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.4-rc2README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.4/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.4/rc2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.4-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.4-rc2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 **Notes:**
 

--- a/collections/_article/release-candidate-godot-3-4-5-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-4-5-rc-1.md
@@ -71,17 +71,17 @@ Here are the main changes since 3.4.4-stable:
 - Thirdparty libraries: zlib/minizip 1.2.12, mbedTLS 2.28.1, CA certificates from 2022-03-31, SDL GameControllerDB from 2022-07-15.
 - API documentation updates.
 
-See the full changelog since 3.4.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.4-stable...375d9905b59dcb31edca0a83198199449f094eca), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.4.5/rc1/Godot_v3.4.5-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.5/rc1/Godot_v3.4.5-rc1_changelog_chrono.txt)).
+See the full changelog since 3.4.4-stable [on GitHub](https://github.com/godotengine/godot/compare/3.4.4-stable...375d9905b59dcb31edca0a83198199449f094eca), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.4.5-rc1/Godot_v3.4.5-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.4.5-rc1-Godot_v3.4.5-rc1_changelog_chrono.txt)).
 
-This release is built from commit [`375d9905b`](https://github.com/godotengine/godot/commit/375d9905b59dcb31edca0a83198199449f094eca) (see [README](https://downloads.tuxfamily.org/godotengine/3.4.5/rc1/README.txt)).
+This release is built from commit [`375d9905b`](https://github.com/godotengine/godot/commit/375d9905b59dcb31edca0a83198199449f094eca) (see [README](https://github.com/godotengine/godot-builds/releases/3.4.5-rc1README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4.5/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4.5/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4.5-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4.5-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-4-rc-1.md
@@ -355,7 +355,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor and doc translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/rc1/Godot_v3.4-rc1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/rc1/Godot_v3.4-rc1_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-rc1/Godot_v3.4-rc1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-rc1-Godot_v3.4-rc1_changelog_authors.txt)).
 
 You can also browse the [changes between 3.4 beta 6 and RC 1 ](https://github.com/godotengine/godot/compare/3e2bb415a9b186596b9ce02debc79590380c2355...90f8cd89a738316563dac9b133628df6bafe2cb2).
 
@@ -366,8 +366,8 @@ This release is built from commit [90f8cd89a738316563dac9b133628df6bafe2cb2](htt
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-4-rc-2.md
@@ -371,7 +371,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor and doc translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/rc2/Godot_v3.4-rc2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/rc2/Godot_v3.4-rc2_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-rc2/Godot_v3.4-rc2_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-rc2-Godot_v3.4-rc2_changelog_authors.txt)).
 
 You can also browse the [changes between 3.4 RC 1 and RC 2 ](https://github.com/godotengine/godot/compare/90f8cd89a738316563dac9b133628df6bafe2cb2...23955fc282b95bcd318034b5de536d42f2a08359).
 
@@ -382,8 +382,8 @@ This release is built from commit [23955fc282b95bcd318034b5de536d42f2a08359](htt
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/rc2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-rc2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-4-rc-3.md
+++ b/collections/_article/release-candidate-godot-3-4-rc-3.md
@@ -374,7 +374,7 @@ Note that some of the changes in 3.4 have already been backported and published 
 - Editor and doc translation updates.
 - And many more bug fixes and usability enhancements all around the engine!
 
-See the full changelog since 3.3-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.4/rc3/Godot_v3.4-rc3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4/rc3/Godot_v3.4-rc3_changelog_authors.txt)).
+See the full changelog since 3.3-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.4-rc3/Godot_v3.4-rc3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.4-rc3-Godot_v3.4-rc3_changelog_authors.txt)).
 
 You can also browse the [changes between 3.4 RC 2 and RC 3 ](https://github.com/godotengine/godot/compare/23955fc282b95bcd318034b5de536d42f2a08359...1a1a450616d00e301057fec3f7247d57e40a77c3).
 
@@ -385,8 +385,8 @@ This release is built from commit [1a1a450616d00e301057fec3f7247d57e40a77c3](htt
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.4/rc3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.4/rc3/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.4-rc3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.4-rc3) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.158** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-5-1-rc-1.md
@@ -65,17 +65,17 @@ Here are the main changes since 3.5-stable:
 - Windows: Fix list dir handle leak ([GH-64461](https://github.com/godotengine/godot/pull/64461)).
 - API documentation updates.
 
-See the full changelog since 3.5-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5-stable...293c3844b3424b4a64d6245f99145266101a146f), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.5.1/rc1/Godot_v3.5.1-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.1/rc1/Godot_v3.5.1-rc1_changelog_chrono.txt)).
+See the full changelog since 3.5-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5-stable...293c3844b3424b4a64d6245f99145266101a146f), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.5.1-rc1/Godot_v3.5.1-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.1-rc1-Godot_v3.5.1-rc1_changelog_chrono.txt)).
 
-This release is built from commit [`293c3844b`](https://github.com/godotengine/godot/commit/293c3844b3424b4a64d6245f99145266101a146f) (see [README](https://downloads.tuxfamily.org/godotengine/3.5.1/rc1/README.txt)).
+This release is built from commit [`293c3844b`](https://github.com/godotengine/godot/commit/293c3844b3424b4a64d6245f99145266101a146f) (see [README](https://github.com/godotengine/godot-builds/releases/3.5.1-rc1README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5.1/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5.1/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5.1-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5.1-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-1-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-5-1-rc-2.md
@@ -77,17 +77,17 @@ Here are the main changes since 3.5-stable:
 - Thirdparty libraries: libpng 1.6.38, GameControllerDB from 2022-09-04.
 - API documentation updates.
 
-See the full changelog since 3.5-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5-stable...ea5d5704d605decaadcc7099da53eb76ea72d883), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.5.1/rc2/Godot_v3.5.1-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.1/rc2/Godot_v3.5.1-rc2_changelog_chrono.txt)).
+See the full changelog since 3.5-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5-stable...ea5d5704d605decaadcc7099da53eb76ea72d883), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.5.1-rc2/Godot_v3.5.1-rc2_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.1-rc2-Godot_v3.5.1-rc2_changelog_chrono.txt)).
 
-This release is built from commit [`ea5d5704d`](https://github.com/godotengine/godot/commit/ea5d5704d605decaadcc7099da53eb76ea72d883) (see [README](https://downloads.tuxfamily.org/godotengine/3.5.1/rc2/README.txt)).
+This release is built from commit [`ea5d5704d`](https://github.com/godotengine/godot/commit/ea5d5704d605decaadcc7099da53eb76ea72d883) (see [README](https://github.com/godotengine/godot-builds/releases/3.5.1-rc2README.txt)).
 
 <a id="downloads"></a>
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5.1/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5.1/rc2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5.1-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5.1-rc2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-2-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-5-2-rc-1.md
@@ -56,16 +56,16 @@ Here are the main changes since 3.5.1-stable:
 - Thirdparty libraries: libwebp 1.2.4, miniupnpc 2.2.4, nanosvg from 2022-11-21, Recast from 2022-11-26, stb_vorbis 1.22, CA root certificates from 2022-10-21, GameControllerDB from 2022-12-07.
 - API documentation and translation updates.
 
-See the full changelog since 3.5.1-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5.1-stable...f5f0543aec4fe89405bf6365b3a2d4e36092c8ab), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.5.2/rc1/Godot_v3.5.2-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.2/rc1/Godot_v3.5.2-rc1_changelog_chrono.txt)).
+See the full changelog since 3.5.1-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5.1-stable...f5f0543aec4fe89405bf6365b3a2d4e36092c8ab), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.5.2-rc1/Godot_v3.5.2-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.2-rc1-Godot_v3.5.2-rc1_changelog_chrono.txt)).
 
-This release is built from commit [`f5f0543ae`](https://github.com/godotengine/godot/commit/f5f0543aec4fe89405bf6365b3a2d4e36092c8ab) (see [README](https://downloads.tuxfamily.org/godotengine/3.5.2/rc1/README.txt)).
+This release is built from commit [`f5f0543ae`](https://github.com/godotengine/godot/commit/f5f0543aec4fe89405bf6365b3a2d4e36092c8ab) (see [README](https://github.com/godotengine/godot-builds/releases/3.5.2-rc1README.txt)).
 
 ## Downloads {#downloads}
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5.2/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5.2/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5.2-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5.2-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-2-rc-2.md
+++ b/collections/_article/release-candidate-godot-3-5-2-rc-2.md
@@ -62,16 +62,16 @@ Here are the main changes since 3.5.1-stable:
 - Thirdparty libraries: libwebp 1.2.4, miniupnpc 2.2.4, nanosvg from 2022-11-21, Recast from 2022-11-26, stb_vorbis 1.22, zlib/minizip 1.2.13, CA root certificates from 2022-10-21, GameControllerDB from 2022-12-07.
 - API documentation and translation updates.
 
-See the full changelog since 3.5.1-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5.1-stable...66d2b7ca2b29b098cc5e310a5dd7a1d4fd03231d), or in text form (sorted [by authors](https://downloads.tuxfamily.org/godotengine/3.5.2/rc1/Godot_v3.5.2-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.2/rc1/Godot_v3.5.2-rc1_changelog_chrono.txt)).
+See the full changelog since 3.5.1-stable [on GitHub](https://github.com/godotengine/godot/compare/3.5.1-stable...66d2b7ca2b29b098cc5e310a5dd7a1d4fd03231d), or in text form (sorted [by authors](https://github.com/godotengine/godot-builds/releases/3.5.2-rc1/Godot_v3.5.2-rc1_changelog_authors.txt) or [chronologically](https://downloads.tuxfamily.org/godotengine/3.5.2-rc1-Godot_v3.5.2-rc1_changelog_chrono.txt)).
 
-This release is built from commit [`66d2b7ca2`](https://github.com/godotengine/godot/commit/66d2b7ca2b29b098cc5e310a5dd7a1d4fd03231d) (see [README](https://downloads.tuxfamily.org/godotengine/3.5.2/rc2/README.txt)).
+This release is built from commit [`66d2b7ca2`](https://github.com/godotengine/godot/commit/66d2b7ca2b29b098cc5e310a5dd7a1d4fd03231d) (see [README](https://github.com/godotengine/godot-builds/releases/3.5.2-rc2README.txt)).
 
 ## Downloads {#downloads}
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5.2/rc2/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5.2/rc2/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5.2-rc2) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5.2-rc2) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-3-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-5-3-rc-1.md
@@ -70,8 +70,8 @@ This release is built from commit [fc32e066a](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5.3/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5.3/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5.3-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5.3-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-rc-1.md
+++ b/collections/_article/release-candidate-godot-3-5-rc-1.md
@@ -60,7 +60,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc1/Godot_v3.5-rc1_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc1-Godot_v3.5-rc1_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -157,7 +157,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc1/Godot_v3.5-rc1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc1/Godot_v3.5-rc1_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc1/Godot_v3.5-rc1_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc1-Godot_v3.5-rc1_changelog_authors.txt)).
 
 You can also review the [changes between beta 5 and RC 1](https://github.com/godotengine/godot/compare/815f7fe636e6937f6ae7d7a9e00a85798afb324b...f33899d5bf3c046392a83d46cbf8c4c71e395550).
 
@@ -168,8 +168,8 @@ This release is built from commit [f33899d5b](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc1/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc1/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.178** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc1) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.178** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-rc-3.md
+++ b/collections/_article/release-candidate-godot-3-5-rc-3.md
@@ -61,7 +61,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc3/Godot_v3.5-rc3_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc3-Godot_v3.5-rc3_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -173,7 +173,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc3/Godot_v3.5-rc3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc3/Godot_v3.5-rc3_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc3/Godot_v3.5-rc3_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc3-Godot_v3.5-rc3_changelog_authors.txt)).
 
 You can also review the [changes between RC 2 and RC 3](https://github.com/godotengine/godot/compare/5f9bc7ea5a8f6bd5229af3bfc8115dd80c5834c5...af8a02ddafd64f0195956c74c6a60bf389af278f).
 
@@ -184,8 +184,8 @@ This release is built from commit [af8a02dda](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc3/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc3/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.179** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc3) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc3) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.179** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-rc-4.md
+++ b/collections/_article/release-candidate-godot-3-5-rc-4.md
@@ -61,7 +61,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc4/Godot_v3.5-rc4_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc4-Godot_v3.5-rc4_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -181,7 +181,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 There's no curated changelog just yet, I still have to skim through all commits to select the changelog worthy changes.
 
-For now, you can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc4/Godot_v3.5-rc4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc4/Godot_v3.5-rc4_changelog_authors.txt)).
+For now, you can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc4/Godot_v3.5-rc4_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc4-Godot_v3.5-rc4_changelog_authors.txt)).
 
 You can also review the [changes between RC 3 and RC 4](https://github.com/godotengine/godot/compare/af8a02ddafd64f0195956c74c6a60bf389af278f...daf6fdf0b7d9d20be7fcc135eccdb6b40f626455).
 
@@ -192,8 +192,8 @@ This release is built from commit [daf6fdf0b](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc4/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc4/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.179** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc4) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc4) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.179** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-rc-5.md
+++ b/collections/_article/release-candidate-godot-3-5-rc-5.md
@@ -61,7 +61,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc5/Godot_v3.5-rc5_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc5-Godot_v3.5-rc5_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -184,7 +184,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 ## Changelog
 
-You can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc5/Godot_v3.5-rc5_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc5/Godot_v3.5-rc5_changelog_authors.txt)).
+You can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc5/Godot_v3.5-rc5_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc5-Godot_v3.5-rc5_changelog_authors.txt)).
 
 You can also review the [changes between RC 4 and RC 5](https://github.com/godotengine/godot/compare/daf6fdf0b7d9d20be7fcc135eccdb6b40f626455...ae60597930a306097ddbc6e8ad49eb50471533b4).
 
@@ -195,8 +195,8 @@ This release is built from commit [ae6059793](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc5/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc5/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc5) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc5) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-rc-6.md
+++ b/collections/_article/release-candidate-godot-3-5-rc-6.md
@@ -67,7 +67,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc6/Godot_v3.5-rc6_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc6-Godot_v3.5-rc6_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -198,7 +198,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 ## Changelog
 
-You can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc6/Godot_v3.5-rc6_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc6/Godot_v3.5-rc6_changelog_authors.txt)).
+You can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc6/Godot_v3.5-rc6_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc6-Godot_v3.5-rc6_changelog_authors.txt)).
 
 You can also review the [changes between RC 5 and RC 6](https://github.com/godotengine/godot/compare/ae60597930a306097ddbc6e8ad49eb50471533b4...f05cecdc43ebfbe58ca9ed5b44fac888b4109dad).
 
@@ -209,8 +209,8 @@ This release is built from commit [f05cecdc4](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc6/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc6/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc6) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc6) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-rc-7.md
+++ b/collections/_article/release-candidate-godot-3-5-rc-7.md
@@ -68,7 +68,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc7/Godot_v3.5-rc7_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc7-Godot_v3.5-rc7_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -209,7 +209,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 ## Changelog
 
-You can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc7/Godot_v3.5-rc7_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc7/Godot_v3.5-rc7_changelog_authors.txt)).
+You can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc7/Godot_v3.5-rc7_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc7-Godot_v3.5-rc7_changelog_authors.txt)).
 
 You can also review the [changes between RC 6 and RC 7](https://github.com/godotengine/godot/compare/f05cecdc43ebfbe58ca9ed5b44fac888b4109dad...38b95cc2fd7f898ead8c7be2732a6817eed1fba0).
 
@@ -220,8 +220,8 @@ This release is built from commit [38b95cc2f](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc7/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc7/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc7) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc7) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-3-5-rc-8.md
+++ b/collections/_article/release-candidate-godot-3-5-rc-8.md
@@ -64,7 +64,7 @@ Two years ago (!), [thebestnom](https://github.com/thebestnom) started working o
 
 With a lot of testing from interested users, things progressed slowly but steadily, and our Android maintainer Fredia Huya-Kouadio ([m4gr3d](https://github.com/m4gr3d)) put the finishing touches to get this work merged for Godot 3.5 ([GH-57747](https://github.com/godotengine/godot/pull/57747/)). The current version doesn't have a lot of mobile specific changes, so it's only really usable on a tablet with keyboard and mouse - but the foundation is there to improve upon, and we're interested in your feedback and ideas son how to make the Godot experience more mobile friendly!
 
-From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://downloads.tuxfamily.org/godotengine/3.5/rc8/Godot_v3.5-rc8_android_editor.apk)
+From now on you'll find builds of the Android editor as `<godot_version>_android_editor.apk` in the download repository. Note that builds are currently not signed, so you will get a warning on install. [**Give it a try!**](https://github.com/godotengine/godot-builds/releases/3.5-rc8-Godot_v3.5-rc8_android_editor.apk)
 
 With [helpful input](https://github.com/godotengine/godot/pull/55604#issuecomment-1077590602) from contributors Dan Edwards ([Gromph](https://github.com/Gromph)) and Péter Magyar ([Relintai](https://github.com/Relintai)), Fredia was also able to fix the low processor usage mode on Android ([GH-59606](https://github.com/godotengine/godot/pull/59606)), which the editor port uses. It should now work fine for users who make non-game applications or non real-time games on Android and want to preserve battery life.
 
@@ -209,7 +209,7 @@ All these need to be thoroughly tested to ensure that they work as intended in t
 
 ## Changelog
 
-You can check the full changelog since 3.4-stable ([chronological](https://downloads.tuxfamily.org/godotengine/3.5/rc8/Godot_v3.5-rc8_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5/rc8/Godot_v3.5-rc8_changelog_authors.txt)).
+You can check the full changelog since 3.4-stable ([chronological](https://github.com/godotengine/godot-builds/releases/3.5-rc8/Godot_v3.5-rc8_changelog_chrono.txt), or [for each contributor](https://downloads.tuxfamily.org/godotengine/3.5-rc8-Godot_v3.5-rc8_changelog_authors.txt)).
 
 You can also review the [changes between RC 7 and RC 8](https://github.com/godotengine/godot/compare/38b95cc2fd7f898ead8c7be2732a6817eed1fba0...516d6b6bad68d506391a4262ba40cbceeea8be22).
 
@@ -220,8 +220,8 @@ This release is built from commit [516d6b6ba](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-- [Standard build](https://downloads.tuxfamily.org/godotengine/3.5/rc8/) (GDScript, GDNative, VisualScript).
-- [Mono build](https://downloads.tuxfamily.org/godotengine/3.5/rc8/mono/) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+- [Standard build](https://github.com/godotengine/godot-builds/releases/3.5-rc8) (GDScript, GDNative, VisualScript).
+- [Mono build](https://github.com/godotengine/godot-builds/releases/3.5-rc8) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
 
 ## Bug reports
 

--- a/collections/_article/release-candidate-godot-4-0-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-4-0-1-rc-1.md
@@ -101,14 +101,14 @@ Some of the most notable feature changes in this update are:
 - Tiles editor: Fix TileSetEditor painting `texture_origin` Vector2i ([GH-73514](https://github.com/godotengine/godot/pull/73514)).
 - Tiles editor: Remember previously selected TileMap tile ([GH-74039](https://github.com/godotengine/godot/pull/74039)).
 
-This release is built from commit [`d23922ffe`](https://github.com/godotengine/godot/commit/d23922ffebe48f29126c003411495737d07e5a9f) (see [README](https://downloads.tuxfamily.org/godotengine/4.0.1/rc1/README.txt)).
+This release is built from commit [`d23922ffe`](https://github.com/godotengine/godot/commit/d23922ffebe48f29126c003411495737d07e5a9f) (see [README](https://github.com/godotengine/godot-builds/releases/download/4.0.1-rc1/README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0.1/rc1/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0.1/rc1/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0.1-rc1) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0.1-rc1) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-1-rc-2.md
+++ b/collections/_article/release-candidate-godot-4-0-1-rc-2.md
@@ -43,14 +43,14 @@ Some of the most notable feature changes in this update are:
 - Project converter: Add conversion for common Theme Overrides ([GH-74624](https://github.com/godotengine/godot/pull/74624)).
 - As well as several improvements to the documentation.
 
-This release is built from commit [`6970257cf`](https://github.com/godotengine/godot/commit/6970257cffc6790f4d7e847e87e5cab9e252874e) (see [README](https://downloads.tuxfamily.org/godotengine/4.0.1/rc2/README.txt)).
+This release is built from commit [`6970257cf`](https://github.com/godotengine/godot/commit/6970257cffc6790f4d7e847e87e5cab9e252874e) (see [README](https://github.com/godotengine/godot-builds/releases/download/4.0.1-rc2/README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0.1/rc2/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0.1/rc2/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0.1-rc2) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0.1-rc2) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-2-rc-1.md
+++ b/collections/_article/release-candidate-godot-4-0-2-rc-1.md
@@ -118,14 +118,14 @@ Some of the most notable feature changes in this update are:
 - Thirdparty: Update `mymindstorm/setup-emsdk` to v12 ([GH-75339](https://github.com/godotengine/godot/pull/75339)).
 - As well as several improvements to the documentation.
 
-This release is built from commit [`50f26811b`](https://github.com/godotengine/godot/commit/50f26811b0409a0b44b1d7df4532c38cafd0a14a) (see [README](https://downloads.tuxfamily.org/godotengine/4.0.2/rc1/README.txt)).
+This release is built from commit [`50f26811b`](https://github.com/godotengine/godot/commit/50f26811b0409a0b44b1d7df4532c38cafd0a14a) (see [README](https://github.com/godotengine/godot-builds/releases/download/4.0.2-rc1/README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0.2/rc1/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0.2/rc1/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0.2-rc1) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0.2-rc1) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-3-rc-1.md
+++ b/collections/_article/release-candidate-godot-4-0-3-rc-1.md
@@ -97,14 +97,14 @@ Some of the most notable feature changes in this update are:
 - Thirdparty: Update mbedtls to 2.28.3 ([GH-76200](https://github.com/godotengine/godot/pull/76200)).
 - As well as many improvements to the documentation.
 
-This release is built from commit [`2d74ee0e5`](https://github.com/godotengine/godot/commit/2d74ee0e5b89e233ef5e86c0667f09a48e963f82) (see [README](https://downloads.tuxfamily.org/godotengine/4.0.3/rc1/README.txt)).
+This release is built from commit [`2d74ee0e5`](https://github.com/godotengine/godot/commit/2d74ee0e5b89e233ef5e86c0667f09a48e963f82) (see [README](https://github.com/godotengine/godot-builds/releases/download/4.0.3-rc1/README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0.3/rc1/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0.3/rc1/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0.3-rc1) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0.3-rc1) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-3-rc-2.md
+++ b/collections/_article/release-candidate-godot-4-0-3-rc-2.md
@@ -71,14 +71,14 @@ Some of the most notable feature changes in this update are:
 - Thirdparty library updates: astcenc 4.4.0, doctest 2.4.11, thorvg 0.9.0, CA certificates from March 2023.
 - Documentation and translation updates.
 
-This release is built from commit [`2ac4e3bb3`](https://github.com/godotengine/godot/commit/2ac4e3bb30517998916bb6b81b7b76788276038c) (see [README](https://downloads.tuxfamily.org/godotengine/4.0.3/rc2/README.txt)).
+This release is built from commit [`2ac4e3bb3`](https://github.com/godotengine/godot/commit/2ac4e3bb30517998916bb6b81b7b76788276038c) (see [README](https://github.com/godotengine/godot-builds/releases/download/4.0.3-rc2/README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0.3/rc2/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0.3/rc2/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0.3-rc2) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0.3-rc2) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-rc-1.md
+++ b/collections/_article/release-candidate-godot-4-0-rc-1.md
@@ -132,8 +132,8 @@ This release is built from commit [c4fb119f0](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/rc1/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/rc1/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-rc1) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-rc1) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location. .NET 7.0 support was recently merged and requires testing, please report any issue you experience with either version.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-rc-2.md
+++ b/collections/_article/release-candidate-godot-4-0-rc-2.md
@@ -82,8 +82,8 @@ This release is built from commit [d2699dc7a](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/rc2/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/rc2/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-rc2) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-rc2) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location. .NET 7.0 support was recently merged and requires testing, please report any issue you experience with either version.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-rc-3.md
+++ b/collections/_article/release-candidate-godot-4-0-rc-3.md
@@ -101,8 +101,8 @@ This release is built from commit [7e79aead9](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/rc3/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/rc3/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-rc3) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-rc3) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location. .NET 7.0 support was recently merged and requires testing, please report any issue you experience with either version.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-rc-4.md
+++ b/collections/_article/release-candidate-godot-4-0-rc-4.md
@@ -63,8 +63,8 @@ This release is built from commit [e0de3573f](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/rc4/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/rc4/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-rc4) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-rc4) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-rc-5.md
+++ b/collections/_article/release-candidate-godot-4-0-rc-5.md
@@ -39,8 +39,8 @@ This release is built from commit [6296b4600](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/rc5/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/rc5/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-rc5) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-rc5) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-0-rc-6.md
+++ b/collections/_article/release-candidate-godot-4-0-rc-6.md
@@ -49,8 +49,8 @@ This release is built from commit [0cd148313](https://github.com/godotengine/god
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.0/rc6/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.0/rc6/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.0-rc6) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.0-rc6) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-1-rc-1.md
+++ b/collections/_article/release-candidate-godot-4-1-rc-1.md
@@ -64,14 +64,14 @@ A previously included fix has been reverted due to regressions and will be addre
 
 - Editor: Revert "Fix paste value not updated in dictionaries/arrays" ([GH-78643](https://github.com/godotengine/godot/pull/78643)).
 
-This release is built from commit [`1f9e540f1`](https://github.com/godotengine/godot/commit/1f9e540f14edbf2d496a1421f8d37e5b483c4c53) (see [README](https://downloads.tuxfamily.org/godotengine/4.1/rc1/README.txt)).
+This release is built from commit [`1f9e540f1`](https://github.com/godotengine/godot/commit/1f9e540f14edbf2d496a1421f8d37e5b483c4c53) (see [README](https://github.com/godotengine/godot-builds/releases/4.1-rc1-README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/rc1/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/rc1/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1-rc1) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1-rc1) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-1-rc-2.md
+++ b/collections/_article/release-candidate-godot-4-1-rc-2.md
@@ -42,14 +42,14 @@ A previously included change has been reverted due to regressions and will be ad
 
 - Thirdparty: Revert "Update RVO2 to git 2022.09" ([GH-78831](https://github.com/godotengine/godot/pull/78831)).
 
-This release is built from commit [`46424488e`](https://github.com/godotengine/godot/commit/46424488edc341b65467ee7fd3ac423e4d49ad34) (see [README](https://downloads.tuxfamily.org/godotengine/4.1/rc2/README.txt)).
+This release is built from commit [`46424488e`](https://github.com/godotengine/godot/commit/46424488edc341b65467ee7fd3ac423e4d49ad34) (see [README](https://github.com/godotengine/godot-builds/releases/4.1-rc2-README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/rc2/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/rc2/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1-rc2) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1-rc2) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/release-candidate-godot-4-1-rc-3.md
+++ b/collections/_article/release-candidate-godot-4-1-rc-3.md
@@ -38,14 +38,14 @@ There is a number of major changes in Godot 4.1, and you can read more about the
 - Navigation: Fix NavigationAgent position not always updating ([GH-78857](https://github.com/godotengine/godot/pull/78857)).
 - Navigation: Fix crash in `NavigationAgent3D` ([GH-78939](https://github.com/godotengine/godot/pull/78939)).
 
-This release is built from commit [`cdd2313ba`](https://github.com/godotengine/godot/commit/cdd2313ba27d0a2600a18e849b4c5d1fd6a6e351) (see [README](https://downloads.tuxfamily.org/godotengine/4.1/rc3/README.txt)).
+This release is built from commit [`cdd2313ba`](https://github.com/godotengine/godot/commit/cdd2313ba27d0a2600a18e849b4c5d1fd6a6e351) (see [README](https://github.com/godotengine/godot-builds/releases/4.1-rc3-README.txt)).
 
 ## Downloads
 
 The downloads for this dev snapshot can be found directly on our repository:
 
-* [Standard build](https://downloads.tuxfamily.org/godotengine/4.1/rc3/) (GDScript, GDExtension).
-* [.NET 6 build](https://downloads.tuxfamily.org/godotengine/4.1/rc3/mono) (C#, GDScript, GDExtension).
+* [Standard build](https://github.com/godotengine/godot-builds/releases/4.1-rc3) (GDScript, GDExtension).
+* [.NET 6 build](https://github.com/godotengine/godot-builds/releases/4.1-rc3) (C#, GDScript, GDExtension).
   - Requires [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) or [7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed in a standard location.
 
 ## Known issues

--- a/collections/_article/tests-needed-godot-2-1-4-beta.md
+++ b/collections/_article/tests-needed-godot-2-1-4-beta.md
@@ -9,27 +9,27 @@ date: 2017-06-25 18:14:52
 
 **Edit 2017-08-25:** Here's finally the release candidate build. WinRT templates are still missing, but they're not blocking for the release given that they are experimental.
 
-- [Download the RC build](http://downloads.tuxfamily.org/godotengine/2.1.4/rc/)
-- [Check the detailed changelog since 2.1.3](http://downloads.tuxfamily.org/godotengine/2.1.4/rc/Godot_v2.1.4-rc_changelog.txt)
-- [Check the changelog diff since the 2017-07-31 build](http://downloads.tuxfamily.org/godotengine/2.1.4/rc/Godot_v2.1.4-rc_changelog_since_20170817.txt)
+- [~~Download the RC build~~](https://github.com/godotengine/godot-builds/releases/2.1.4-rc/)
+- [~~Check the detailed changelog since 2.1.3~~](https://github.com/godotengine/godot-builds/releases/2.1.4/rc-Godot_v2.1.4-rc_changelog.txt)
+- [~~Check the changelog diff since the 2017-07-31 build~~](https://github.com/godotengine/godot-builds/releases/2.1.4/rc-Godot_v2.1.4-rc_changelog_since_20170817.txt)
 - [Report regressions on GitHub](https://github.com/godotengine/godot/issues/) so that they can be fixed before the stable release.
 
 -----
 
 **Edit 2017-08-17:** And another beta build, probably the last one before the release candidate. Note that WinRT templates are missing in this build, will be fixed for the RC.
 
-- [Download the 2017-08-17 build](http://downloads.tuxfamily.org/godotengine/2.1.4/beta/20170817/)
-- [Check the detailed changelog since 2.1.3](http://downloads.tuxfamily.org/godotengine/2.1.4/beta/20170817/Godot_v2.1.4-beta_20170817_changelog.txt)
-- [Check the changelog diff since the 2017-07-31 build](http://downloads.tuxfamily.org/godotengine/2.1.4/beta/20170817/Godot_v2.1.4-beta_20170817_changelog_since_20170731.txt)
+- [~~Download the 2017-08-17 build~~](https://github.com/godotengine/godot-builds/releases/2.1.4/beta-20170817/)
+- [~~Check the detailed changelog since 2.1.3~~](https://github.com/godotengine/godot-builds/releases/2.1.4/beta/20170817-Godot_v2.1.4-beta_20170817_changelog.txt)
+- [~~Check the changelog diff since the 2017-07-31 build~~](https://github.com/godotengine/godot-builds/releases/2.1.4/beta/20170817-Godot_v2.1.4-beta_20170817_changelog_since_20170731.txt)
 - [Report regressions on GitHub](https://github.com/godotengine/godot/issues/) so that they can be fixed before the stable release.
 
 -----
 
 **Edit 2017-07-31:** Time for another beta build, with one month's worth of further improvements and especially fixes for various regressions found in the 2017-06-25 build:
 
-- [Download the 2017-07-31 build](http://downloads.tuxfamily.org/godotengine/2.1.4/beta/20170731/)
-- [Check the detailed changelog since 2.1.3](http://downloads.tuxfamily.org/godotengine/2.1.4/beta/20170731/Godot_v2.1.4-beta_20170731_changelog.txt)
-- [Check the changelog diff since the 2017-06-25 build](http://downloads.tuxfamily.org/godotengine/2.1.4/beta/20170731/Godot_v2.1.4-beta_20170731_changelog_since_20170625.txt)
+- [~~Download the 2017-07-31 build~~](https://github.com/godotengine/godot-builds/releases/2.1.4/beta-20170731/)
+- [~~Check the detailed changelog since 2.1.3~~](https://github.com/godotengine/godot-builds/releases/2.1.4/beta/20170731-Godot_v2.1.4-beta_20170731_changelog.txt)
+- [~~Check the changelog diff since the 2017-06-25 build~~](https://github.com/godotengine/godot-builds/releases/2.1.4/beta/20170731-Godot_v2.1.4-beta_20170731_changelog_since_20170625.txt)
 - [Report regressions on GitHub](https://github.com/godotengine/godot/issues/) so that they can be fixed before the stable release.
 
 -----
@@ -42,8 +42,8 @@ Some of those new developments being slightly more experimental than we use to m
 
 So now's your time to shine:
 
-- [Download today's beta build](http://download.tuxfamily.org/godotengine/2.1.4/beta/20170625/) and test it extensively on your projects, both the editor and the exported games (make sure to install the corresponding templates).
-- [Check the detailed changelog](http://download.tuxfamily.org/godotengine/2.1.4/beta/20170625/Godot_v2.1.4-beta_20170625_changelog.txt) to see what changed since 2.1.3 and should therefore be tested thoroughly.
+- [~~Download today's beta build~~](http://download.tuxfamily.org/godotengine/2.1.4/beta/20170625/) and test it extensively on your projects, both the editor and the exported games (make sure to install the corresponding templates).
+- [~~Check the detailed changelog~~](http://download.tuxfamily.org/godotengine/2.1.4/beta/20170625/Godot_v2.1.4-beta_20170625_changelog.txt) to see what changed since 2.1.3 and should therefore be tested thoroughly.
 - [Report regressions on GitHub](https://github.com/godotengine/godot/issues/) so that they can be fixed before the stable release.
 
 What are **regressions**? They are bugs that did not occur in the previous stable release (2.1.3) but which can now be experienced in the beta build. You can also report bugs in the new features of 2.1.4, which, even if not strictly speaking regressions, should be worth looking into before the release.

--- a/collections/_article/update-godot-ar-and-vr.md
+++ b/collections/_article/update-godot-ar-and-vr.md
@@ -25,13 +25,13 @@ We also talked to Oculus about the support we've added to Godot for the Rift hea
 
 But let's start with talking about AR first. An ARKit interface has been available unofficially for well over a year. One of the more interesting projects to come out of this is [Torch](https://www.torch.app), an AR prototyping tool worth checking out. In the beginning of this year we made great strides with this interface implementing some of the ARKit 2.0 features Apple added in. There are now 3 companies we are aware of that are building products for ARKit using Godot.
 
-You can follow the development of this interface here: http://github.com/godotengine/godot/pull/24227
+You can follow the development of this interface here: https://github.com/godotengine/godot/pull/24227
 
 ## ARCore
 
 Work on Google's ARCore is progressing with basic tracking logic now functional. Google has taken an interest and is helping us out so we expect things to progress pretty quickly in the coming months.
 
-You can follow the development of this interface here: http://github.com/godotengine/godot/pull/26221
+You can follow the development of this interface here: https://github.com/godotengine/godot/pull/26221
 
 ## Cardboard and Daydream
 
@@ -51,7 +51,7 @@ We do not yet know what this means for Hololens 2 and possible Hololens support 
 
 The Oculus Rift driver has been available for some time and works great. We haven't had a chance to play with the Rift S yet but we have every reason to believe this will work with the drivers we already created.
 
-You can follow development of the Oculus interface here: http://github.com/GodotVR/godot_oculus
+You can follow development of the Oculus interface here: https://github.com/GodotVR/godot_oculus
 
 You can download the official plugin from the asset library here: [Godot Oculus plugin](http://godotengine.org/asset-library/asset/164)
 
@@ -61,7 +61,7 @@ We're hoping to pick up where we have left off soon.
 ## OpenHMD
 
 OpenHMD as a project has been growing steadily over the last year adding many interesting headsets to the list of devices they support, while many are still in development. Godot has had an interface for OpenHMD for some time now which works well but needs a compositor, something we hope to tackle in the near future.
-You can follow development of the OpenHMD interface here: http://github.com/GodotVR/godot_openhmd
+You can follow development of the OpenHMD interface here: https://github.com/GodotVR/godot_openhmd
 
 ## OpenVR
 
@@ -70,7 +70,7 @@ You can follow development of the OpenHMD interface here: http://github.com/Godo
 OpenVR has been working well and has several teams working on various projects using this driver. We have yet to look at some of the new additions and support for the new knuckles controllers.
 
 The problem with HDR remains, Godot renders to high detail buffers for its HDR support and OpenVR does not like these.
-There is a PR in the official [godot_openvr](http://github.com/GodotVR/godot_openvr) repository that contains a fix, but for the official release of the plugin, HDR still needs to be turned off or the GLES2 renderer needs to be used.
+There is a PR in the official [godot_openvr](https://github.com/GodotVR/godot_openvr) repository that contains a fix, but for the official release of the plugin, HDR still needs to be turned off or the GLES2 renderer needs to be used.
 
 You can download the official plugin from the asset library here: [Godot OpenVR plugin](http://godotengine.org/asset-library/asset/150)
 

--- a/collections/_article/updates-on-the-release-cycle-and-godot-2-0-1.md
+++ b/collections/_article/updates-on-the-release-cycle-and-godot-2-0-1.md
@@ -45,6 +45,6 @@ The main fixes in this release are:
 - Fixed transform localization event in mouse motion
 - Fixed closing a scene tab when it was not the current tab
 
-See the [full changelog](http://downloads.tuxfamily.org/godotengine/2.0.1/Godot_v2.0.1_stable_changelog.txt) for more details, and head towards the [Download page](/download) to get it!
+See the [full changelog](https://github.com/godotengine/godot-builds/releases/download/2.0.1-stable/Godot_v2.0.1_stable_changelog.txt) for more details, and head towards the [Download page](-download) to get it!
 
 For this release, we also used a new buildsystem to create and deploy the binaries, so please [contact us](/community) if you experience any regression relatively to 2.0 stable.

--- a/pages/maintenance.html
+++ b/pages/maintenance.html
@@ -17,7 +17,6 @@ permalink: /maintenance/index.html
 	<h2>Downloads</h2>
 	<ul>
 		<li><a href="https://github.com/godotengine/godot/releases">Download Godot from GitHub</a></li>
-		<li><a href="https://downloads.tuxfamily.org/godotengine">Download Godot from TuxFamily</a></li>
 	</ul>
 
 	<h2>Documentation</h2>


### PR DESCRIPTION
https://download.tuxfamily.org has been down for months now, due to a datacenter failure. It may not go back up again as per this forum post:

https://forum.tuxfamily.org/post/3383/

Some download links are still broken as their files haven't been uploaded to the godot-builds releases, especially for old pre-releases like 3.0.alpha1.

TuxFamily still hosts the asset library, so the privacy policy and education pages are unchanged.

This also removes links to https://op.godotengine.org which has been long defunct.
