### PR TITLE
Add Austrian user group

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -8,6 +8,18 @@ Argentina:
     links:
       - title: Discord
         url: https://discord.gg/2BtycSPdkk
+Austria:
+  - name: Godot User Group Austria
+    coordinates:
+      - 48.20835
+      - 16.37250
+    links:
+      - title: Meetup
+        url: https://www.meetup.com/godot-usergroup-austria
+      - title: Discord
+        url: https://discord.gg/cVGY3mhAnV
+      - title: Wiki
+        url: https://metalab.at/wiki/Godot_Usergroup
 Brazil:
   - name: Godot Brazil
     links:


### PR DESCRIPTION
Inspired by a lightning talk given at GodotCon 2024, the Godot User Group Austria has come into existence. There have already been three successful in-person meetups with plenty of great talks 🙂

Hope the PR includes everything necessary to put Vienna on the map!