### PR TITLE
Fix incorrect link on preview downloads page

### DIFF
--- a/pages/download/preview.html
+++ b/pages/download/preview.html
@@ -41,7 +41,7 @@ layout: default
 
 	<div class="other-platforms">
 		<div class="other-platforms-wrapper">
-			Looking for the stable version? <a href="#stable">See below!</a>
+			Looking for the stable version? <a href="#call-to-action">See below!</a>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Edit: #1000 is an alternative that's probably better, since `#stable` is a better anchor for this section of this page than `#call-to-action`.

---

There's a link at the top of the [previews download page](https://godotengine.org/download/preview/) which says "Looking for a stable version? See below!"

This link is supposed to scroll the page to the section lower down where you can download the stable version. However, currently this link doesn't work because it points to an anchor that didn't exist.

The link points to `#stable`. However, the actual anchor, [as defined](https://github.com/godotengine/godot-website/blob/5d28982dffd98030300ec87582f1d352453e78c6/_includes/download/download-section.html#L60C10-L60C24) in `download-section.html`, is `#call-to-action`.

This PR fixes the link so that clicking it works properly.