### PR TITLE
Add custom anchor to download-section.html, and use it to fix link on previews download page

### DIFF
--- a/_includes/download/download-section.html
+++ b/_includes/download/download-section.html
@@ -57,7 +57,7 @@
 		color: white;
 	}
 </style>
-<div id="call-to-action" class="container card section-download">
+<div id="{{ include.anchor | default: 'call-to-action' }}" class="container card section-download">
 	{% if include.title %}
 		<h2>{{ include.title }}</h2>
 	{% else %}

--- a/_includes/download/download-section.html
+++ b/_includes/download/download-section.html
@@ -58,11 +58,7 @@
 	}
 </style>
 <div id="{{ include.anchor | default: 'call-to-action' }}" class="container card section-download">
-	{% if include.title %}
-		<h2>{{ include.title }}</h2>
-	{% else %}
-		<h2>Ready to start?</h2>
-	{% endif %}
+    <h2>{{ include.title | default: 'Ready to start?' }}</h2>
 
 	<div class="section-download-ready">
 		{% assign stable_version_3 = site.data.versions | find: "featured", "3" %}

--- a/pages/download/preview.html
+++ b/pages/download/preview.html
@@ -66,6 +66,6 @@ layout: default
 
 <script src="/assets/js/download-version.js"></script>
 
-{% include /download/download-section.html title="Need a stable version?" %}
+{% include /download/download-section.html title="Need a stable version?" anchor="stable" %}
 
 {% include footer.html %}


### PR DESCRIPTION
Alternative to #999.

There's a link at the top of the [previews download page](https://godotengine.org/download/preview/) which says "Looking for a stable version? See below!"

This link is supposed to scroll the page to the section lower down where you can download the stable version. However, currently this link doesn't work because it points to an anchor that no longer exists.

The old anchor, `#stable`, was [removed](https://github.com/godotengine/godot-website/commit/bb0f0a41c3cb1a69dbf7f96ce9c4d98eb9e55822#diff-48f02e6e05568e0d339b6cce00e810761d7046d12d88c855796f6c19ac6269b9L127) in https://github.com/godotengine/godot-website/commit/bb0f0a41c3cb1a69dbf7f96ce9c4d98eb9e55822, when `download-section.html` was consolidated.

This PR lets you set a custom anchor when you include `download-section.html`, and does so in `preview.html` to restore the broken link.