### PR TITLE
Fix Godot 4.4-beta1 showing as released in 2024

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,6 +1,6 @@
 - name: "4.4"
   flavor: "beta1"
-  release_date: "16 January 2024"
+  release_date: "16 January 2025"
   release_notes: "/article/dev-snapshot-godot-4-4-beta-1/"
   releases:
     - name: "dev7"


### PR DESCRIPTION
Does what it says on the tin.