### PR TITLE
Fix issue with priorities yml file

### DIFF
--- a/collections/_priorities/gdscript-01-attain-full-coverage-of-static-type-hints.md
+++ b/collections/_priorities/gdscript-01-attain-full-coverage-of-static-type-hints.md
@@ -10,6 +10,6 @@ description: |
   We intend to implement static typing for areas that currently lack them. We are thinking about typed dictionaries (already merged for 4.4) and enforcing the typing of signals.
 details:
   - type: prs
-      content: |
-        - [Implement typed dictionaries #78656](https://github.com/godotengine/godot/pull/78656)
+    content: |
+      - [Implement typed dictionaries #78656](https://github.com/godotengine/godot/pull/78656)
 ---


### PR DESCRIPTION
There is a superfluous indent in the file which cause an error when building.

```
godot-website on  4.4-release [$!?] via 💎 v3.2.4 took 1m44s 
❯ ./build-and-serve.sh
Bundle complete! 5 Gemfile dependencies, 31 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Configuration file: /Users/adamscott/dev/builds/godot-website/_config.yml
Configuration file: /Users/adamscott/dev/builds/godot-website/_config.development.yml
            Source: /Users/adamscott/dev/builds/godot-website
       Destination: /Users/adamscott/dev/builds/godot-website/_site
 Incremental build: enabled
      Generating... 
             Error: YAML Exception reading /Users/adamscott/dev/builds/godot-website/collections/_priorities/gdscript-01-attain-full-coverage-of-static-type-hints.md: (<unknown>): mapping values are not allowed in this context at line 13 column 14
```