### PR TITLE
Change the display name of `zh-cn` and `zh-tw` locale

### DIFF
--- a/assets/js/localize.js
+++ b/assets/js/localize.js
@@ -5,8 +5,8 @@ const languageMap = {
 	'de': 'Deutsch',
 	'fr': 'Français',
 	'ja': '日本語',
-	'zh-cn': '中文（中国）',
-	'zh-tw': '中文（台灣）',
+	'zh-cn': '中文（简体）',
+	'zh-tw': '中文（繁體）',
 	'pt': 'Português',
 };
 


### PR DESCRIPTION
Rationale: https://github.com/godotengine/godot-proposals/issues/6289

In short, the current wording could cause potential problems. This situation is more awkward than the wording in the editor, because many non-Godot users will see it.

This PR uses the same strategy as Microsoft, distinguishing by script rather than region.

| Before | After |
|---|---|
| Chinese (China) | Chinese (Simplified) |
| Chinese (Taiwan) | Chinese (Traditional) |