### PR TITLE
Internationalize the Features and Download pages

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1,5 +1,6 @@
 meta:
   description: Develop your 2D & 3D games, cross-platform projects, or even XR ideas!
+
 header:
   features: Features
   showcase: Showcase
@@ -11,6 +12,7 @@ header:
   contribute: Contribute
   donate: Donate
   language: Language
+
 footer:
   godot_engine: Godot Engine
   download: Download
@@ -38,10 +40,12 @@ footer:
   privacy_policy: Privacy policy
   contact_us: Contact us
   text: "Juan Linietsky, Ariel Manzur and <a href='https://github.com/godotengine/godot/blob/master/AUTHORS.md' target='_blank' rel='noopener'>contributors</a>. Hosted by the <a href='https://godot.foundation/' target='_blank' rel='noopener'>Godot Foundation</a>. Website <a href='https://github.com/godotengine/godot-website' target='_blank' rel='noopener'>source code on  GitHub</a>."
+
 sponsors:
   title: "Godot is sponsored by:"
   text: If you are interested in a corporate sponsorship, please write to <a href='mailto:contact@godot.foundation'>contact@godot.foundation</a>.<br>To donate as an individual, you can do so through the <a href='https://fund.godotengine.org/'>Godot Engine development fund</a>.
   cta: Donate
+
 home:
   h1: Your free, open&#8209;source<br>game engine.
   subtitle: Develop your 2D &amp; 3D games, cross-platform projects, or even XR ideas!
@@ -89,3 +93,150 @@ home:
   foundation:
     text: "You don't need to be an engine developer to help Godot. Join the <a href='https://fund.godotengine.org/'>development fund</a> and help us make the Godot&nbsp;Engine even more awesome!"
     donate: Donate
+
+features:
+  why: Why Godot is right for you
+  showcase: "A picture is worth a thousand words, and these developers have chosen Godot for their projects:"
+  see_more_projects: See more projects made with Godot
+  main: Main features
+  new_in_4: "New in 4.0:"
+  containers:
+    design:
+      title: Intuitive scene-driven design
+      cards:
+        build_game:
+          title: Build your game from simple blocks
+          text: Use building blocks called nodes to create more complex and reusable scenes. Add scripts to your scenes and customize built-in behavior to implement your unique game mechanics. Rely on composition and node hierarchy to make game logic clear at a glance.
+        extend_features:
+          title: Extend beyond features provided by the engine
+          text: Make your scenes into full-featured components, with tools for your designers to tweak and adjust the look and function. Share your components with the community of like-minded developers as addons and templates.
+        data_driven:
+          title: Create data-driven elements with custom resources
+          text: Define scriptable objects called resources to describe characters, entities, and data structures in your game. Use your custom objects directly in the editor by assigning them to nodes. Resources come with a high-level API to store and read them, and they support every Godot type, including other resources.
+    script:
+      title: Coding tools that fit your needs
+      cards:
+        gdscript:
+          title: Write code without hurdles with a high-level scripting language
+          text: Get things done quickly with Godot's built-in scripting language GDScript. Inspired by Python and other languages, it is easy to pick up even if you are a beginner. Tight engine integration allows it to express game logic in a clear and natural form.
+          extra: GDScript offers optional static typing support, boosting your coding efficiency and runtime performance. Powerful language features and first-class functions allow for expressive yet concise code.
+        csharp:
+          title: Leverage your C# experience to feel right at home
+          text: If you're an experienced C# user, Godot offers you first-class support for the .NET platform. Power your games with familiar libraries and give them a performance boost, while still benefiting from close engine integration.
+          extra: "<strong>Note:</strong> .NET support is provided as a dedicated engine executable. <a href='https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html#c-platform-support'>C# support is available for desktop and mobile platforms as of Godot 4.2.</a> Web support should be added in the future, but until then, <a href='/download/3.x/'>Godot 3</a> remains a supported option."
+        gdextension:
+          title: Pick from a variety of community-supported languages
+          text: Godot is built to be extended, and that means you can choose a programming language not provided by the Godot team itself. Thanks to our community there are many language bindings for popular tools like Rust, Nim, Python, and JavaScript.
+          extra: C++ supports comes officially in the form of GDExtension API, which gives you a way to script and program your game components for maximum performance without having to recompile the engine.
+        modules:
+          title: Modify the engine itself and integrate with 3rd party libraries
+          text: Thanks to the modular structure and a straightforward build process of Godot, you can create your own engine modules. Gain every last drop of performance or integrate with many 3rd party libraries with low-level C++ code.
+    3d:
+      title: Simple yet powerful 3D engine
+      cards:
+        rendering:
+          title: Support both high and low-end devices
+          text: Make beautiful 3D games for a range of devices, starting from desktop computers and ending with mid-range Android phones. Powered by OpenGL, Godot allows your projects to run on most modern GPUs, including integrated graphics.
+          extra: With the new Vulkan renderer and a set of modern graphical features, bring your worlds to life and harvest the power of gaming GPUs for your benefit.
+        import:
+          title: Seamlessly integrate with your asset pipeline
+          text: Bring your 3D models into your game world with a robust importing pipeline. Take entire scenes — with animated models, lighting, cameras, and physics objects, — and customize how the engine views them. Modify your assets and see changes in the engine immediately.
+          extra: Import Blender files directly for fast iterations or keep using familiar glTF and FBX formats.
+        movie:
+          title: Create animated videos and prerendered cutscenes in engine
+          text: With the new movie maker mode, you can record gameplay and scripted scenes from your project at a stable framerate and guaranteed simulation speed. Together with Godot's animation capabilities, make the most out of the engine's visuals.
+    2d:
+      title: Specialized 2D workflow for games and apps
+      cards:
+        units:
+          title: Work with real 2D and pixel-based unit system
+          text: Thanks to a dedicated 2D pipeline, you can forget about the Z axis and simplify your game logic. Think in pixels and screen coordinates, while the engine does the rest.
+        tilemap:
+          title: Save time creating 2D worlds with a tile map editor
+          text: Whether you want procedural generation or a meticulously hand-crafted level, with Godot's built-in tile map editor you can achieve every goal. Import a sprite and convert it into a database of building blocks for your 2D worlds.
+        gui:
+          title: Master usability with a flexible GUI system
+          text: Build scalable and adaptive user interfaces with Godot's unique GUI system. Created specifically to power layouts common to games, it is also capable of handling complex UI applications and tools.
+          extra: For an example of what Godot's UI system is capable of, see the Godot editor itself!
+    deploy:
+      title: Cross-platform support with one project
+      cards:
+        export:
+          title: Deliver your game to desktop and mobile
+          text: Develop and publish your project on any modern desktop platform. Let everyone play your game by deploying to web and mobile. Make your game handle various forms of inputs and share the same project between every release.
+        test:
+          title: Test directly on your target device
+          text: Iterate on real hardware, or with an emulator by deploying your game directly to the target device over SSH. Run any project on a mobile device, on another desktop, or on your favorite Linux-based handheld with full debug and inspect capabilities.
+        consoles:
+          title: Partner with a publisher to target consoles
+          text: If you want to release to a console, you can find several third-party publishers which specialize on that. Godot games can run on any modern hardware, all you need to worry about is your performance and controls.
+    open:
+      title: Completely open and free
+      cards:
+        free:
+          title: Download and create with no contracts or hidden fees
+          text: Godot is free under the MIT license. This means you don't owe us anything (other than a friendly mention), and can do with your project or even the engine itself whatever you want. Build your game or build your own engine on top of it — it's all in your hands.
+        source_code:
+          title: Find the logic behind any system in an open source codebase
+          text: "No need to wait for a support team to respond when you can read the source code. Godot is an open book, and you can figure out everything that is not yet documented after a single <code>git checkout</code>. If you find and fix an issue, we will appreciate a PR upstream too."
+  showreel:
+    title: Choice of many developers
+    text: Watch our annual showreel videos to see more examples of projects using Godot!
+  see_complete_list: View a complete list of features
+
+download_section:
+  title: Ready to start?
+  text: Download the <strong>latest version of Godot 4</strong> right now and begin your creative journey!
+  download_latest: Download Latest
+  looking_for_previous_version: Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?
+
+download:
+  redirect:
+    title: Redirecting...
+    link: "If you are not being redirected automatically, <a href='/download/windows/' class='set-os-download-url'>click here</a>."
+  download_godot_4_for: Download Godot&nbsp;4 for
+  csharp_support: C# support
+  looking_for_previous_version: Looking for <strong class="previous-releases-featured"><a href="/download/3.x/" class="set-os-download-url" data-version="3">Godot 3</a></strong> or a <strong><a href="/download/archive">previous version</a>?</strong>
+  looking_for_other_platforms: Looking for other platforms?
+  see_below: See below!
+  requirements:
+    title: Requirements
+    recommended:
+      title: "Recommended:"
+      text: Vulkan 1.0 compatible hardware
+    minimal:
+      title: "Minimal:"
+      text: OpenGL 3.3 / OpenGL ES 3.0 compatible hardware
+    csharp:
+      title: "Additional requirements for the .NET version:"
+      net_sdk: .NET SDK
+  all_downloads: All downloads
+  instructions: Instructions
+  digital_stores:
+    title: "Godot Engine is also available on digital distribution platforms:"
+    stores:
+      itch_io: Godot Engine on itch.io
+      steam: Godot Engine on Steam
+      epic_games_store: Godot Engine on Epic Games Store
+    notes: Digital store versions <strong>do not</strong> include .NET/C# support.
+  supported_platforms: Supported platforms
+  web_editor: Web Editor
+  other_downloads:
+    title: Other Godot downloads
+    demo_projects:
+      title: Godot demo projects
+      text: Give a try to demo projects showcasing some of the engine features.
+      link_github: Demo projects on GitHub
+      link_assetlib: Demo projects in Asset Library
+    android_aar:
+      title: AAR library for Android
+      text: Use it to develop Android plugins in Java or Kotlin using the Godot API.
+  preview_builds:
+    title: Preview builds
+    text: Godot is continuously being developed with several minor releases being published every year. To ensure high quality and stability of each release, we also publish preview builds at various stages of development.
+    cta: Help test Godot's new features or be the first to benefit from upcoming improvements by downloading a preview build!
+    link: See latest preview builds
+    source:
+      text: Don't want to wait for official releases? You can compile Godot from source!
+      link: "Get the source code from the <a href='https://github.com/godotengine/godot'>GitHub project page</a>."
+      docs: "Follow the instructions from the <a href='https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html'>official documentation</a>."

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1,5 +1,6 @@
 meta:
   description: Desarrolla tus juegos 2D y 3D, proyectos multiplataforma o incluso XR
+
 header:
   features: Funciones
   showcase: Creaciones
@@ -11,6 +12,7 @@ header:
   contribute: Contribuir
   donate: Donar
   language: Idioma
+
 footer:
   godot_engine: Godot Engine
   download: Descargar
@@ -38,10 +40,12 @@ footer:
   privacy_policy: Política de privacidad
   contact_us: Contáctanos
   text: "Juan Linietsky, Ariel Manzur y <a href='https://github.com/godotengine/godot/blob/master/AUTHORS.md' target='_blank' rel='noopener'>colaboradores</a>. Alojado por la <a href='https://godot.foundation/' target='_blank' rel='noopener'>Godot Foundation</a>. <a href='https://github.com/godotengine/godot-website' target='_blank' rel='noopener'>Código fuente de la web en GitHub</a>."
+
 sponsors:
   title: "Godot está patrocinado por:"
   text: Si estás interesado en un patrocinio corporativo, por favor escribe a <a href='mailto:'mailto:contact@godot.foundation'>contact@godot.foundation</a>.<br>Si quieres donar como individuo, puedes hacerlo a través del <a href='https://fund.godotengine.org/'>fondo de desarrollo de Godot Engine</a>.
   cta: Donar
+
 home:
   h1: Tu motor de juegos gratuito<br> y de código abierto.
   subtitle: Desarrolla tus juegos 2D y 3D, proyectos multiplataforma o incluso XR

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1,5 +1,6 @@
 meta:
-  description: Développez vos jeux en 2D et 3D, des projets cross-plateformes ou même des applications XR&nbsp;!
+  description: Développez vos jeux en 2D et 3D, des projets multiplateforme ou même des applications XR&nbsp;!
+
 header:
   features: Fonctions
   showcase: Vitrine
@@ -11,6 +12,7 @@ header:
   contribute: Contribuer
   donate: Donner
   language: Langue
+
 footer:
   godot_engine: Godot Engine
   download: Télécharger
@@ -38,13 +40,15 @@ footer:
   privacy_policy: Politique de confidentialité
   contact_us: Contactez-nous
   text: "Juan Linietsky, Ariel Manzur et <a href='https://github.com/godotengine/godot/blob/master/AUTHORS.md' target='_blank' rel='noopener'>contributeurs</a>. Hébergé par la <a href='https://godot.foundation/' target='_blank' rel='noopener'>Godot Foundation</a>. Code source du site web <a href='https://github.com/godotengine/godot-website' target='_blank' rel='noopener'>sur GitHub</a>."
+
 sponsors:
   title: "Godot est soutenu par&nbsp;:"
   text: Si vous êtes intéressé pour sponsoriser Godot avec votre organisation, veuillez écrire à <a href='mailto:contact@godot.foundation'>contact@godot.foundation</a>.<br>Pour faire un don à titre personnel, vous pouvez faire ainsi à travers le <a href='https://fund.godotengine.org/'>fonds de développement Godot Engine</a>.
   cta: Faire un don
+
 home:
   h1: Votre moteur de jeu gratuit et open&#8209;source.
-  subtitle: Développez vos jeux en 2D et 3D, des projets cross-plateformes ou même des applications XR&nbsp;!
+  subtitle: Développez vos jeux en 2D et 3D, des projets multiplateforme ou même des applications XR&nbsp;!
   whats_new: Nouveautés
   download_latest: Télécharger la dernière version
   looking_for: 'Vous cherchez <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Téléchargez la version supportée à long terme de Godot 3">Godot 3</a>, des <a href="/download/archive">versions expérimentales</a> ou une <a href="/download/archive">ancienne version</a>&nbsp;?'
@@ -89,3 +93,150 @@ home:
   foundation:
     text: "Vous n'avez pas besoin d'être un développeur de moteur pour aider Godot. Rejoignez le <a href='https://fund.godotengine.org/'>fonds de développement</a> et aidez-nous à rendre le moteur Godot encore plus génial&nbsp;!"
     donate: Faire un don
+
+features:
+  why: Pourquoi Godot est fait pour vous
+  showcase: "Une image vaut mille mots. Ces développeurs ont choisi Godot pour leurs projets&nbsp;:"
+  see_more_projects: Voir plus de jeux réalisés avec Godot
+  main: Fonctionnalités principales
+  new_in_4: "Nouveau dans la 4.0:"
+  containers:
+    design:
+      title: Conception intuitive basée sur les scènes
+      cards:
+        build_game:
+          title: Construisez votre jeu à partir de blocs simples
+          text: Utilisez des blocs de construction appelés nœuds pour créer des scènes plus complexes et réutilisables. Ajoutez des scripts à vos scènes et personnalisez les comportements intégrés pour implémenter des mécaniques de jeu uniques. Utilisez la composition et la hiérarchie des nœuds pour rendre la logique du jeu claire en un coup d'œil.
+        extend_features:
+          title: Étendez les fonctionnalités au-delà de celles fournies par le moteur
+          text: Transformez vos scènes en composants complets, avec des outils pour que vos designers puissent ajuster leur apparence et leur fonction. Partagez vos composants avec la communauté de développeurs sous forme d'extensions et de modèles.
+        data_driven:
+          title: Créez des éléments pilotés par les données grâce aux ressources personnalisées
+          text: Définissez des objets scriptables appelés ressources pour décrire les personnages, les entités et les structures de données de votre jeu. Utilisez vos objets personnalisés directement dans l'éditeur en les assignant à des nœuds. Les ressources sont dotées d'une API de haut niveau pour les stocker et les lire. Elles prennent en charge tous les types de Godot, y compris d'autres ressources.
+    script:
+      title: Outils de programmation adaptés à vos besoins
+      cards:
+        gdscript:
+          title: Écrivez du code facilement avec un langage de script de haut niveau
+          text: Faites les choses rapidement avec le langage de script intégré de Godot, GDScript. Inspiré de Python et d'autres langages, il est facile à prendre en main même si vous êtes débutant. Son intégration étroite au moteur vous permet d'exprimer la logique du jeu de manière claire et naturelle.
+          extra: GDScript offre un support de typage statique en option, ce qui améliore votre efficacité de programmation et les performances d'exécution. Les fonctionnalités puissantes du langage et les fonctions de première classe permettent un code expressif mais concis.
+        csharp:
+          title: Utilisez votre expérience C# pour vous sentir chez vous
+          text: Si vous êtes un utilisateur expérimenté de C#, Godot vous offre un support de première classe pour la plateforme .NET. Alimentez vos jeux avec des bibliothèques familières et donnez-leur un coup de pouce de performance, tout en bénéficiant d'une intégration étroite avec le moteur.
+          extra: "<strong>Note&nbsp;:</strong> Le support de .NET est fourni sous la forme d'un exécutable moteur dédié. <a href='https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html#c-platform-support'>Le support de C# est disponible pour les plateformes de bureau et mobiles à partir de Godot 4.2.</a> Le support Web devrait être ajouté à l'avenir, mais jusqu'à ce moment, <a href='/download/3.x/'>Godot 3</a> reste une option prise en charge."
+        gdextension:
+          title: Choisissez parmi une variété de langages maintenus par la communauté
+          text: Godot est conçu pour être étendu, ce qui signifie que vous pouvez choisir un langage de programmation non fourni par l'équipe de Godot elle-même. Grâce à notre communauté, il existe de nombreuses intégrations de langage pour des outils populaires comme Rust, Nim, Python et JavaScript.
+          extra: Le support de C++ est fourni officiellement sous la forme de l'API GDExtension, qui vous permet de scripter et programmer les composants de votre jeu pour une performance maximale sans avoir à recompiler le moteur.
+        modules:
+          title: Modifiez le moteur lui-même et intégrez des bibliothèques tierces
+          text: Grâce à la structure modulaire et au processus de construction simple de Godot, vous pouvez créer vos propres modules moteur. Profitez des performances maximales ou intégrez de nombreuses bibliothèques tierces avec du code C++ de bas niveau.
+    3d:
+      title: Moteur 3D simple mais puissant
+      cards:
+        rendering:
+          title: Supportez à la fois les appareils haut de gamme et entrée de gamme
+          text: Créez des jeux 3D magnifiques pour toute une gamme d'appareils, allant des ordinateurs de bureau aux téléphones Android milieu de gamme. Alimenté par OpenGL, Godot permet à vos projets de fonctionner sur la plupart des GPU modernes, y compris les graphiques intégrés.
+          extra: Avec le nouveau moteur de rendu Vulkan et un ensemble de fonctionnalités graphiques modernes, donnez vie à vos mondes et exploitez toute la puissance des GPU actuels.
+        import:
+          title: Intégrez parfaitement votre pipeline d'assets
+          text: Importez vos modèles 3D dans votre monde de jeu avec un processus d'importation robuste. Prenez des scènes entières — avec des modèles animés, de l'éclairage, des caméras et des objets physiques, — et personnalisez la façon dont le moteur les affiche. Modifiez vos assets et visualisez immédiatement les modifications dans le moteur.
+          extra: Importez des fichiers Blender directement pour une itération plus rapide, ou continuez à utiliser les formats habituels glTF et FBX.
+        movie:
+          title: Créez des vidéos animées et des cinématiques pré-rendues dans le moteur
+          text: "Avec le nouveau mode <em>Movie Maker</em>, vous pouvez enregistrer le gameplay et les scènes scriptées de votre projet à une fréquence d'images stable et une vitesse de simulation garantie. Associé aux capacités d'animation de Godot, tirez le meilleur parti des visuels du moteur."
+    2d:
+      title: Un workflow 2D spécialisé pour les jeux et applications
+      cards:
+        units:
+          title: Travaillez avec un vrai système d'unités 2D basé sur les pixels
+          text: Grâce à une pipeline 2D dédiée, vous pouvez oublier l'axe Z et simplifier la logique de votre jeu. Pensez en pixels et en coordonnées d'écran, tandis que le moteur fait le reste.
+        tilemap:
+          title: Gagnez du temps en créant des mondes 2D avec un éditeur de tilemaps
+          text: Que vous souhaitiez une génération procédurale ou un niveau minutieusement conçu à la main, avec l'éditeur de tilemaps intégré de Godot, vous pouvez atteindre tous vos objectifs. Importez une image et convertissez-la en une base de données de blocs de construction pour vos mondes 2D.
+        gui:
+          title: Maîtrisez l'ergonomie avec un système GUI flexible
+          text: Créez des interfaces utilisateur évolutives et adaptatives avec le système GUI unique de Godot. Conçu spécifiquement pour fournir des mises en page courantes dans les jeux, il est également capable de gérer des applications et des outils GUI complexes.
+          extra: Pour voir un exemple de ce que le système GUI de Godot est capable de faire, regardez l'éditeur Godot lui-même&nbsp;!
+    deploy:
+      title: Support multiplateforme avec un seul projet
+      cards:
+        export:
+          title: Délivrez votre jeu sur n'importe quelle plateforme PC et mobile
+          text: Développez et publiez votre projet sur n'importe quelle plateforme de bureau moderne. Laissez tout le monde jouer à votre jeu en le déployant sur le web et le mobile. Gérez différentes méthodes d'entrée (clavier, souris, manette, tactile) et partagez le même projet entre chaque version.
+        test:
+          title: Testez directement sur votre appareil cible
+          text: Itérez sur du matériel physique, ou avec un émulateur en déployant votre jeu directement sur l'appareil cible via SSH. Exécutez n'importe quel projet sur un appareil mobile, sur un autre ordinateur de bureau, ou sur votre console de jeu Linux préférée avec des capacités de débogage et d'inspection complètes.
+        consoles:
+          title: Faites appel à un éditeur pour cibler les consoles
+          text: Si vous souhaitez publier sur une console, vous pouvez trouver plusieurs éditeurs tiers spécialisés dans ce domaine. Les jeux Godot peuvent fonctionner sur n'importe quel matériel moderne&nbsp;; vous n'avez donc qu'à vous soucier de vos performances et de vos contrôles.
+    open:
+      title: Complètement ouvert et gratuit
+      cards:
+        free:
+          title: Téléchargez et créez sans contrat ni frais cachés
+          text: Godot est gratuit sous licence MIT. Cela signifie que vous ne nous devez rien (autre qu'une mention amicale), et que vous pouvez faire ce que vous voulez avec votre projet ou même le moteur lui-même. Créez votre jeu ou créez votre propre moteur par-dessus — tout est entre vos mains.
+        source_code:
+          title: Trouvez la logique derrière n'importe quel système dans un code source ouvert
+          text: "Pas besoin d'attendre qu'une équipe de support réponde quand vous pouvez lire le code source. Godot est comme un livre ouvert, et vous pouvez comprendre tout ce qui n'est pas encore documenté après un simple <code>git checkout</code>. Si vous trouvez et corrigez un problème, nous apprécierons également un <em>pull request</em> en amont."
+  showreel:
+    title: Le choix de nombreux développeurs
+    text: Regardez nos vidéos de démonstration annuelles pour voir plus d'exemples de projets utilisant Godot&nbsp;!
+  see_complete_list: Voir la liste complète des fonctionnalités
+
+download_section:
+  title: Prêt à commencer&nbsp;?
+  text: Téléchargez la <strong>dernière version de Godot 4</strong> dès maintenant et commencez votre aventure créative&nbsp;!
+  download_latest: Télécharger la dernière version
+  looking_for_previous_version: Vous cherchez <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Téléchargez la version supportée à long terme de Godot 3">Godot 3</a> ou une <a href="/download/archive">ancienne version</a>&nbsp;?
+
+download:
+  redirect:
+    title: Redirection...
+    link: "Si vous n'êtes pas redirigé automatiquement, <a href='/download/windows/' class='set-os-download-url'>cliquez ici</a>."
+  download_godot_4_for: Télécharger Godot&nbsp;4 pour
+  csharp_support: Support C#
+  looking_for_previous_version: Vous cherchez <strong class="previous-releases-featured"><a href="/download/3.x/" class="set-os-download-url" data-version="3">Godot 3</a></strong> ou une <strong><a href="/download/archive">ancienne version</a>&nbsp;?</strong>
+  looking_for_other_platforms: Vous cherchez d'autres plateformes&nbsp;?
+  see_below: Voir ci-dessous&nbsp;!
+  requirements:
+    title: Configuration requise
+    recommended:
+      title: "Recommandé&nbsp;:"
+      text: Matériel compatible Vulkan 1.0
+    minimal:
+      title: "Minimal&nbsp;:"
+      text: Matériel compatible OpenGL 3.3 / OpenGL ES 3.0
+    csharp:
+      title: "Pré-requis supplémentaires pour la version .NET&nbsp;:"
+      net_sdk: SDK .NET
+  all_downloads: Tous les téléchargements
+  instructions: Instructions
+  digital_stores:
+    title: "Godot Engine est également disponible sur des plateformes de distribution numérique&nbsp;:"
+    stores:
+      itch_io: Godot Engine sur itch.io
+      steam: Godot Engine sur Steam
+      epic_games_store: Godot Engine sur Epic Games Store
+    notes: Les versions des plateformes de distribution numérique <strong>n'incluent pas</strong> le support .NET/C#.
+  supported_platforms: Plateformes prises en charge
+  web_editor: Éditeur web
+  other_downloads:
+    title: Autres téléchargements Godot
+    demo_projects:
+      title: Projets de démonstration Godot
+      text: Essayez des projets de démonstration mettant en avant les fonctionnalités du moteur.
+      link_github: Projets de démonstration sur GitHub
+      link_assetlib: Projets de démonstration dans la bibliothèque d'assets
+    android_aar:
+      title: Bibliothèque AAR pour Android
+      text: Utilisez-la pour développer des plugins Android en Java ou Kotlin avec l'API Godot.
+  preview_builds:
+    title: Versions en aperçu
+    text: Godot est en développement continu avec plusieurs versions mineures publiées chaque année. Pour garantir la qualité et la stabilité de chaque version, nous publions également des versions en aperçu à divers stades de développement.
+    cta: Aidez à tester les nouvelles fonctionnalités de Godot ou soyez le premier à bénéficier des améliorations à venir en téléchargeant une version en aperçu&nbsp;!
+    link: Voir les dernières versions en aperçu
+    source:
+      text: Vous ne voulez pas attendre les versions officielles&nbsp;? Vous pouvez compiler Godot à partir du code source&nbsp;!
+      link: "Obtenez le code source depuis la <a href='https://github.com/godotengine/godot'>page de projet GitHub</a>."
+      docs: "Suivez les instructions de la <a href='https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html'>documentation officielle</a>."

--- a/_i18n/zh-cn.yml
+++ b/_i18n/zh-cn.yml
@@ -1,5 +1,6 @@
 meta:
   description: 开发你的 2D 与 3D 游戏，跨平台项目，甚至是 XR 创意！
+
 header:
   features: 特性
   showcase: 展示
@@ -11,6 +12,7 @@ header:
   contribute: 贡献
   donate: 捐助
   language: 语言
+
 footer:
   download: 下载
   documentation: 文档
@@ -37,10 +39,12 @@ footer:
   privacy_policy: 隐私政策
   contact_us: 联系我们
   text: "Juan Linietsky，Ariel Manzur 与<a href='https://github.com/godotengine/godot/blob/master/AUTHORS.md' target='_blank' rel='noopener'>贡献者们</a>。由 <a href='https://godot.foundation/' target='_blank' rel='noopener'>Godot 基金会</a>架设。网站<a href='https://github.com/godotengine/godot-website' target='_blank' rel='noopener'>源码可在 GitHub 上获取</a>."
+
 sponsors:
   title: "Godot 由以下企业赞助："
   text: 如果您对企业赞助感兴趣，请发邮件至 <a href='mailto:contact@godot.foundation'>contact@godot.foundation</a>。<br>作为个人捐助，你可以通过 <a href='https://fund.godotengine.org/'>Godot Engine 开发基金</a> 进行。
   cta: 捐助
+
 home:
   h1: 属于你的免费，<br>开源游戏引擎。
   subtitle: 开发你的 2D 与 3D 游戏，跨平台项目，甚至是 XR 创意！

--- a/_i18n/zh-tw.yml
+++ b/_i18n/zh-tw.yml
@@ -1,5 +1,6 @@
 meta:
   description: 開發你的 2D 與 3D 遊戲，跨平台專案，甚至是 XR 創意！
+
 header:
   features: 特性
   showcase: 展示
@@ -11,6 +12,7 @@ header:
   contribute: 貢獻
   donate: 捐助
   language: 語言
+
 footer:
   download: 下載
   documentation: 文件
@@ -37,10 +39,12 @@ footer:
   privacy_policy: 隱私政策
   contact_us: 聯繫我們
   text: "Juan Linietsky，Ariel Manzur 與<a href='https://github.com/godotengine/godot/blob/master/AUTHORS.md' target='_blank' rel='noopener'>貢獻者們</a>。由 <a href='https://godot.foundation/' target='_blank' rel='noopener'>Godot 基金會</a>架設。網站<a href='https://github.com/godotengine/godot-website' target='_blank' rel='noopener'>原始碼可在 GitHub 上獲取</a>."
+
 sponsors:
   title: "Godot 由以下企業贊助："
   text: 如果您對企業贊助感興趣，請發電郵至 <a href='mailto:contact@godot.foundation'>contact@godot.foundation</a>。<br>作為個人捐助，你可以通過 <a href='https://fund.godotengine.org/'>Godot Engine 開發基金</a> 進行。
   cta: 捐助
+
 home:
   h1: 屬於你的免費，<br>開源遊戲引擎。
   subtitle: 開發你的 2D 與 3D 遊戲，跨平台專案，甚至是 XR 創意！

--- a/_includes/download/download-section.html
+++ b/_includes/download/download-section.html
@@ -58,19 +58,19 @@
 	}
 </style>
 <div id="{{ include.anchor | default: 'call-to-action' }}" class="container card section-download">
-    <h2>{{ include.title | default: 'Ready to start?' }}</h2>
+    <h2>{{ include.title | default: t download-section.title}}</h2>
 
 	<div class="section-download-ready">
 		{% assign stable_version_3 = site.data.versions | find: "featured", "3" %}
 		{% assign stable_version_4 = site.data.versions | find: "featured", "4" %}
 
-		<p>Download the <strong>latest version of Godot 4</strong> right now and begin your creative journey!</p>
+		<p>{% t download_section.text %}</p>
 		<a href="/download/windows/" class="btn btn-download set-os-download-url" data-version="4"
 			title="Download the latest version of Godot 4">
-			<div class="download-title">Download Latest</div>
+			<div class="download-title">{% t download_section.download_latest %}</div>
 			<div class="download-hint">{{ stable_version_4.name }}</div>
 		</a>
 
-		<span class="download-3">Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
+		<span class="download-3">{% t download_section.looking_for_previous_version %}</span>
 	</div>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -59,17 +59,17 @@
 		event.preventDefault();
 		const path = element.getAttribute('data-lang-path');
 		const lang = element.getAttribute('data-lang');
-		
+
 		// Set cookie that expires in 365 days
 		const expirationDate = new Date();
 		expirationDate.setDate(expirationDate.getDate() + 365);
 		document.cookie = `preferred_language=${lang}; expires=${expirationDate.toUTCString()}; path=/; SameSite=Lax`;
-		
+
 		// Redirect to the language-specific path
 		window.location.href = path;
 	}
 
-	
+
 </script>
 
 <main>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,16 +5,24 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="author" content="Godot Engine">
-	<meta name="description" content="{% if page.description %}{{ page.description }}{% elsif page.excerpt %}{{ page.excerpt }}{% else %}{% t meta.description %}{% endif %}">
+	{% if page.description[current_lang] %}
+		<meta name="description" content="{{ page.description[current_lang] }}">
+	{% else %}
+		<meta name="description" content="{% if page.description %}{{ page.description }}{% elsif page.excerpt %}{{ page.excerpt }}{% else %}{% t meta.description %}{% endif %}">
+	{% endif %}
 
 	<!-- Plausible -->
 	<script defer data-domain="godotengine.org" src="https://plausible.godot.foundation/js/script.file-downloads.outbound-links.js"></script>
-	
+
 	<!-- Social meta tags -->
 	<meta property="og:site_name" content="Godot Engine">
 	<meta property="og:url" content="https://godotengine.org{{ page.url }}">
 	<meta property="og:type" content="website">
-	<meta property="og:description" content="{% if page.description %}{{ page.description }}{% elsif page.excerpt %}{{ page.excerpt }}{% else %}{% t meta.description %}{% endif %}">
+	{% if page.description[current_lang] %}
+		<meta property="og:description" content="{{ page.description[current_lang] }}">
+	{% else %}
+		<meta property="og:description" content="{% if page.description %}{{ page.description }}{% elsif page.excerpt %}{{ page.excerpt }}{% else %}{% t meta.description %}{% endif %}">
+	{% endif %}
 	<meta property="og:image" content="{{ site.url }}{{ page.image | default: '/assets/share-image.webp' }}">
 	<!-- meta tags -->
 	<meta name="twitter:card" content="summary_large_image">
@@ -33,7 +41,7 @@
 		<meta property="og:title" content="Godot Engine">
 		<title>Godot Engine</title>
 	{% endif %}
-	
+
 	<link rel="alternate" type="application/rss+xml" title="Godot News" href="/rss.xml">
 	<link rel="alternate" type="application/json" title="Godot News" href="/rss.json" />
 	<link rel="alternate" type="application/atom+xml" title="Godot News" href="/atom.xml" />

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -17,7 +17,7 @@ layout: default
 
 <div class="hero">
 	<div class="hero-wrapper">
-		<h1>Download Godot&nbsp;4 for {{ page.platform }}</h1>
+		<h1>{% t download.download_godot_4_for %} {{ page.platform }}</h1>
 
 		<div class="main-downloads">
 			{% assign featured_downloads = page.downloads | where: "featured", "true" %}
@@ -42,21 +42,21 @@ layout: default
 						<div class="download-hint">{{ stable_version.name }}</div>
 					</a>
 					<p class="main-download-details">
-						<strong>{% for tag in platform_info.tags %}{{ tag }} · {% endfor %}{% if download.mono %}C# support · {% endif %}</strong>{{ stable_version.release_date }}
+						<strong>{% for tag in platform_info.tags %}{{ tag }} · {% endfor %}{% if download.mono %}{% t download.csharp_support %} · {% endif %}</strong>{{ stable_version.release_date }}
 					</p>
 				</div>
 
 			{% endfor %}
 
 			<p class="previous-releases">
-				Looking for <strong class="previous-releases-featured"><a href="/download/3.x/" class="set-os-download-url" data-version="3">Godot 3</a></strong> or a <strong><a href="/download/archive">previous version</a>?</strong>
+				{% t download.looking_for_previous_version %}
 			</p>
 		</div>
 	</div>
 
 	<div class="other-platforms">
 		<div class="other-platforms-wrapper">
-			Looking for other platforms? <a href="#platforms">See below!</a>
+			{% t download.looking_for_other_platforms %} <a href="#platforms">{% t download.see_below %}</a>
 		</div>
 	</div>
 </div>
@@ -64,18 +64,18 @@ layout: default
 <div class="container">
 	<div id="links" class="platform-details">
 		<div class="card base-padding">
-			<h3>Requirements</h3>
+			<h3>{% t download.requirements.title %}</h3>
 
 			<ul>
-				<li><strong>Recommended:</strong> Vulkan 1.0 compatible hardware</li>
-				<li><strong>Minimal:</strong> OpenGL 3.3 / OpenGL ES 3.0 compatible hardware</li>
+				<li><strong>{% t download.requirements.recommended.title %}</strong> {% t download.requirements.recommended.text %}</li>
+				<li><strong>{% t download.requirements.minimal.title %}</strong> {% t download.requirements.minimal.text %}</li>
 			</ul>
 
 			{% unless page.ignore_mono %}
-			<p>Additional requirements for the .NET version:</p>
+			<p>{% t download.requirements.csharp.title %}</p>
 			<ul>
 				<li>
-					<a href="https://dotnet.microsoft.com/download">.NET SDK</a>
+					<a href="https://dotnet.microsoft.com/download">{% t download.requirements.csharp.net_sdk %}</a>
 				</li>
 			</ul>
 			{% endunless %}
@@ -83,7 +83,7 @@ layout: default
 
 		<div class="platform-split">
 			<div class="card base-padding">
-				<h3>All downloads</h3>
+				<h3>{% t download.all_downloads %}</h3>
 
 				{% for download in page.downloads %}
 
@@ -104,7 +104,7 @@ layout: default
 						</a>
 						<span class="download-details">
 							{% for tag in platform_info.tags %}{% if forloop.index > 1 %} · {% endif %}{{ tag }}{% endfor %}
-							{% if download.mono %} · C# support{% endif %}
+							{% if download.mono %} · {% t download.csharp_support %}{% endif %}
 						</span>
 					</div>
 
@@ -129,7 +129,7 @@ layout: default
 								{% unless templates_info.caption == empty %} - {{ templates_info.caption }}{% endunless %}
 							</a>
 							<span class="download-details">
-								{% for tag in templates_info.tags %}{{ tag }} · {% endfor %}C# support
+								{% for tag in templates_info.tags %}{{ tag }} · {% endfor %}{% t download.csharp_support %}
 							</span>
 						</div>
 					{% endunless %}
@@ -143,7 +143,7 @@ layout: default
 			</div>
 
 			<div class="card base-padding">
-				<h3>Instructions</h3>
+				<h3>{% t download.instructions %}</h3>
 
 				{{ page.content_instructions }}
 			</div>
@@ -151,22 +151,22 @@ layout: default
 
 		<div id="digital-stores" class="card base-padding digital-stores">
 			<div>
-				<p>Godot Engine is also available on digital distribution platforms:</p>
+				<p>{% t download.digital_stores.title %}</p>
 
 				<div class="digital-store-list">
-					<a class="btn btn-digital-store" href="https://godotengine.itch.io/godot" title="Godot Engine on itch.io">
+					<a class="btn btn-digital-store" href="https://godotengine.itch.io/godot" title="{% t download.digital_stores.stores.itch_io %}">
 						<div class="digital-store-logo">
 							<img src="/assets/download/itch_logo.svg" width="28" height="28" alt="itch logo">
 						</div>
 						<div class="digital-store-name">itch.io</div>
 					</a>
-					<a class="btn btn-digital-store" href="https://store.steampowered.com/app/404790" title="Godot Engine on Steam">
+					<a class="btn btn-digital-store" href="https://store.steampowered.com/app/404790" title="{% t download.digital_stores.stores.steam %}">
 						<div class="digital-store-logo">
 							<img src="/assets/download/steam_logo.svg" width="28" height="28" alt="Steam logo">
 						</div>
 						<div class="digital-store-name">Steam</div>
 					</a>
-					<a class="btn btn-digital-store" href="https://store.epicgames.com/p/godot-engine" title="Godot Engine on Epic Games Store">
+					<a class="btn btn-digital-store" href="https://store.epicgames.com/p/godot-engine" title="{% t download.digital_stores.stores.epic_games_store %}">
 						<div class="digital-store-logo">
 							<img src="/assets/download/epic_logo.svg" width="28" height="28" alt="Epic Games Store logo">
 						</div>
@@ -176,7 +176,7 @@ layout: default
 			</div>
 			<div class="digital-stores-notes">
 				<ul>
-					<li>Digital store versions <strong>do not</strong> include .NET/C# support.</li>
+					<li>{% t download.digital_stores.notes %}</li>
 				</ul>
 			</div>
 		</div>
@@ -185,7 +185,7 @@ layout: default
 
 <div class="platforms-wrapper">
 	<div id="platforms" class="container" style="overflow: hidden;">
-		<h2>Supported platforms</h2>
+		<h2>{% t download.supported_platforms %}</h2>
 
 		<div class="tabs platform-tabs">
 			<a href="/download/android" class="tab title-font {% if page.platform == 'Android' %} active {% endif %}">
@@ -205,8 +205,8 @@ layout: default
 				<span>Windows</span>
 			</a>
 			<a href="https://editor.godotengine.org/releases/{{stable_version.name}}.stable/godot.editor.html" target="_blank" class="tab title-font">
-				<img width="24" height="24" src="/assets/images/platforms/web.svg" title="Web Editor" alt="Web Editor" />
-				<span>Web Editor</span>
+				<img width="24" height="24" src="/assets/images/platforms/web.svg" title="{% t download.web_editor %}" alt="Web Editor" />
+				<span>{% t download.web_editor %}</span>
 			</a>
 		</div>
 	</div>
@@ -214,25 +214,25 @@ layout: default
 
 <div class="container">
 	<div id="extras" class="padded" style="padding-top: 0">
-		<h2>Other Godot downloads</h2>
+		<h2>{% t download.other_downloads.title %}</h2>
 
 		<div class="other-download">
 
 			<div class="other-download-card">
-				<h3>Godot demo projects</h3>
+				<h3>{% t download.other_downloads.demo_projects.title %}</h3>
 				<p>
-					Give a try to demo projects showcasing some of the engine features.
+					{% t download.other_downloads.demo_projects.text %}
 				</p>
 				<p>
 					<a href="https://github.com/godotengine/godot-demo-projects">
-						Demo projects on GitHub
+						{% t download.other_downloads.demo_projects.link_github %}
 					</a>
 				</p>
 				<p>
 					{% assign stable_version_comp = stable_version.name | split: "." %}
 
 					<a href="https://godotengine.org/asset-library/asset?category=10&godot_version={{stable_version_comp[0]}}.{{stable_version_comp[1]}}&support[official]=1">
-						Demo projects in Asset Library
+						{% t download.other_downloads.demo_projects.link_assetlib %}
 					</a>
 				</p>
 			</div>
@@ -240,10 +240,10 @@ layout: default
 			<div class="other-download-card">
 				{% assign aar_library_info = site.data.download_platforms | find: "name", "aar_library" %}
 
-				<h3>AAR library for Android</h3>
-				<p>Use it to develop Android plugins in Java or Kotlin using the Godot API.</p>
+				<h3>{% t download.other_downloads.android_aar.title %}</h3>
+				<p>{% t download.other_downloads.android_aar.text %}</p>
 				<p>
-					<a href="{{ stable_version | make_download: "aar_library", false }}">
+					<a href="{{ stable_version | make_download: 'aar_library', false }}">
 						{{ aar_library_info.title }}
 						{% unless aar_library_info.caption == empty %} - {{ aar_library_info.caption }}{% endunless %}
 					</a>
@@ -255,21 +255,17 @@ layout: default
 
 	<div class="unstable-downloads">
 		<div id="previews" class="unstable-download-previews">
-			<h2>Preview builds</h2>
+			<h2>{% t download.preview_builds.title %}</h2>
 
 			<p>
-				Godot is continuously being developed with several minor releases
-				being published every year. To ensure high quality and stability
-				of each release, we also publish preview builds at various stages of
-				development.
+				{% t download.preview_builds.text %}
 			</p>
 			<p>
-				Help test Godot's new features or be the first to benefit from upcoming
-				improvements by downloading a preview build!
+				{% t download.preview_builds.cta %}
 			</p>
 
 			<a class="btn" href="/download/preview">
-				See latest preview builds
+				{% t download.preview_builds.link %}
 			</a>
 		</div>
 
@@ -277,15 +273,14 @@ layout: default
 			<img class="flex-center dark-invert" src="/assets/download/dl_icon_github.png" width="200" height="200" alt="A GitHub logo">
 			<div>
 				<p>
-					Don't want to wait for official releases? You can compile Godot from source!
+					{% t download.preview_builds.source.text %}
 				</p>
 				<ul>
 					<li>
-						Get the source code from the <a href="https://github.com/godotengine/godot">GitHub project page</a>.
+						{% t download.preview_builds.source.link %}
 					</li>
 					<li>
-						Follow the instructions from the
-						<a href="https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html">official documentation</a>.
+						{% t download.preview_builds.source.docs %}
 					</li>
 				</ul>
 			</div>

--- a/pages/download.html
+++ b/pages/download.html
@@ -1,17 +1,21 @@
 ---
 permalink: /download/index.html
-title: "Download - Godot Engine"
-description: "Download the latest stable version of the Godot Engine for Linux, macOS, Windows, or Android"
+title:
+  en: "Download - Godot Engine"
+  fr: "Télécharger - Godot Engine"
+description:
+  en: "Download the latest stable version of the Godot Engine for Linux, macOS, Windows, or Android"
+  fr: "Téléchargez la dernière version stable du moteur Godot pour Linux, macOS, Windows ou Android"
 layout: default
-
+localize: ["en", "fr"]
 redirect_from:
   - /download/4.x/
 ---
 
 <div style="padding: 16px 32px">
-	<h3>Redirecting...</h3>
+	<h3>{% t download.redirect.title %}</h3>
 	<p>
-		If you are not being redirected automatically, <a href="/download/windows/" class="set-os-download-url">click here</a>.
+		{% t download.redirect.link %}
 	</p>
 </div>
 

--- a/pages/features.html
+++ b/pages/features.html
@@ -1,8 +1,13 @@
 ---
 permalink: /features/index.html
-title: "Features - Godot Engine"
-description: "Discover what Godot has to offer for 2D and 3D game development."
+title:
+  en: "Features - Godot Engine"
+  fr: "Fonctionnalités - Godot Engine"
+description:
+  en: "Discover what Godot has to offer for 2D and 3D game development."
+  fr: "Découvrez ce que Godot fournit pour le développement de jeux 2D et 3D."
 layout: default
+localize: ["en", "fr"]
 ---
 
 {% include header.html %}
@@ -270,14 +275,10 @@ layout: default
 </style>
 
 <div class="features-why">
-	<h2>
-		Why Godot is right for you
-	</h2>
+	<h2>{% t features.why %}</h2>
 
 	<div class="features-showcase" id="showcase">
-		<p>
-			A picture is worth a thousand words, and these developers have chosen Godot for their projects:
-		</p>
+		<p>{% t features.showcase %}</p>
 
 		<script>
 			document.addEventListener('DOMContentLoaded', () => {
@@ -366,7 +367,7 @@ layout: default
 		</div>
 
 		<a href="/showcase/" class="btn btn-flat btn-flat-white btn-flat-frosted btn-see-showcase">
-			See more projects made with Godot
+			{% t features.see_more_projects %}
 		</a>
 	</div>
 </div>
@@ -374,250 +375,170 @@ layout: default
 <div class="features-wrapper">
 
 	<div class="container" id="features">
-		<h2>Main features</h2>
+		<h2>{% t features.main %}</h2>
 	</div>
 
 	<div class="feature-container feature-container-3x" id="design">
-		<h3>Intuitive scene-driven design</h3>
+		<h3>{% t features.containers.design.title %}</h3>
 
 		<div class="card feature-card">
-			<h4>Build your game from simple blocks</h4>
-			<p>
-				Use building blocks called nodes to create more complex and reusable
-				scenes. Add scripts to your scenes and customize built-in behavior to
-				implement your unique game mechanics. Rely on composition and node hierarchy
-				to make game logic clear at a glance.
-			</p>
+			<h4>{% t features.containers.design.cards.build_game.title %}</h4>
+			<p>{% t features.containers.design.cards.build_game.text %}</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Extend beyond features provided by the engine</h4>
-			<p>
-				Make your scenes into full-featured components, with tools for your
-				designers to tweak and adjust the look and function. Share your components
-				with the community of like-minded developers as addons and templates.
-			</p>
+			<h4>{% t features.containers.design.cards.extend_features.title %}</h4>
+			<p>{% t features.containers.design.cards.extend_features.text %}</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Create data-driven elements with custom resources</h4>
-			<p>
-				Define scriptable objects called resources
-				to describe characters, entities, and data structures in your game. Use
-				your custom objects directly in the editor by assigning them to nodes.
-				Resources come with a high-level API to store and read them, and they support
-				every Godot type, including other resources.
-			</p>
+			<h4>{% t features.containers.design.cards.data_driven.title %}</h4>
+			<p>{% t features.containers.design.cards.data_driven.text %}</p>
 		</div>
 	</div>
 
 	<div class="feature-container feature-container-2x" id="script">
-		<h3>Coding tools that fit your needs</h3>
+		<h3>{% t features.containers.script.title %}</h3>
 
 		<div class="card feature-card">
-			<h4>Write code without hurdles with a high-level scripting language</h4>
+			<h4>{% t features.containers.script.cards.gdscript.title %}</h4>
 			<p>
-				Get things done quickly with Godot's built-in scripting language GDScript.
-				Inspired by Python and other languages, it is easy to pick up even if you
-				are a beginner. Tight engine integration allows it to express game logic
-				in a clear and natural form.
+				{% t features.containers.script.cards.gdscript.text %}
 				<br><br>
-				<strong>New in 4.0:</strong> GDScript offers optional static typing support,
-				boosting your coding efficiency and runtime performance. Powerful language
-				features and first-class functions allow for expressive yet concise code.
+				<strong>{% t features.new_in_4 %}</strong>
+				{% t features.containers.script.cards.gdscript.extra %}
 			</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Leverage your C# experience to feel right at home</h4>
+			<h4>{% t features.containers.script.cards.csharp.title %}</h4>
 			<p>
-				If you're an experienced C# user, Godot offers you first-class support
-				for the .NET platform. Power your games with familiar libraries and give
-				them a performance boost, while still benefiting from close engine integration.
+				{% t features.containers.script.cards.csharp.text %}
 				<br><br>
-				<strong>Note:</strong> .NET support is provided as a dedicated engine executable.
-				<a href="https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html#c-platform-support">C# support is available for desktop and mobile platforms as of Godot 4.2.</a>
-				Web support should be added in the future, but until then,
-				<a href="/download/3.x/">Godot 3</a> remains a supported option.
+				{% t features.containers.script.cards.csharp.extra %}
 			</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Pick from a variety of community-supported languages</h4>
+			<h4>{% t features.containers.script.cards.gdextension.title %}</h4>
 			<p>
-				Godot is built to be extended, and that means you can choose
-				a programming language not provided by the Godot team itself.
-				Thanks to our community there are many language bindings for
-				popular tools like Rust, Nim, Python, and JavaScript.
+				{% t features.containers.script.cards.gdextension.text %}
 				<br><br>
-				<strong>New in 4.0:</strong> C++ supports comes officially in the form of
-				GDExtension API, which gives you a way to script and program your game
-				components for maximum performance without having to recompile the engine.
+				<strong>{% t features.new_in_4 %}</strong>
+				{% t features.containers.script.cards.gdextension.extra %}
 			</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Modify the engine itself and integrate with 3rd party libraries</h4>
+			<h4>{% t features.containers.script.cards.modules.title %}</h4>
 			<p>
-				Thanks to the modular structure and a straightforward build process of Godot
-				you can create your own engine modules. Gain every last drop of performance
-				or integrate with many 3rd party libraries with low-level C++ code.
+				{% t features.containers.script.cards.modules.text %}
 			</p>
 		</div>
 	</div>
 
 	<div class="feature-container feature-container-3x" id="features_3d">
-		<h3>Simple yet powerful 3D engine</h3>
+		<h3>{% t features.containers.3d.title %}</h3>
 
 		<div class="card feature-card">
-			<h4>Support both high and low-end devices</h4>
+			<h4>{% t features.containers.3d.cards.rendering.title %}</h4>
 			<p>
-				Make beautiful 3D games for a range of devices, starting
-				from desktop computers and ending with mid-range Android
-				phones. Powered by OpenGL, Godot allows your projects
-				to run on most modern GPUs, including integrated graphics.
+				{% t features.containers.3d.cards.rendering.text %}
 				<br><br>
-				<strong>New in 4.0:</strong> With the new Vulkan renderer
-				and a set of modern graphical features, bring your worlds
-				to life and harvest the power of gaming GPUs for your
-				benefit.
+				<strong>{% t features.new_in_4 %}</strong>
+				{% t features.containers.3d.cards.rendering.extra %}
 			</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Seamlessly integrate with your asset pipeline</h4>
+			<h4>{% t features.containers.3d.cards.import.title %}</h4>
 			<p>
-				Bring your 3D models into your game world with a robust
-				importing pipeline. Take entire scenes — with animated models,
-				lighting, cameras, and physics objects, — and customize how
-				the engine views them. Modify your assets and see changes
-				in the engine immediately.
+				{% t features.containers.3d.cards.import.text %}
 				<br><br>
-				<strong>New in 4.0:</strong> Import Blender files directly
-				for fast iterations or keep using familiar glTF and FBX formats.
+				<strong>{% t features.new_in_4 %}</strong>
+				{% t features.containers.3d.cards.import.extra %}
 			</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Create animated videos and prerendered cutscenes in engine</h4>
+			<h4>{% t features.containers.3d.cards.movie.title %}</h4>
 			<p>
-				<strong>New in 4.0:</strong> With the new movie maker mode you
-				can record gameplay and scripted scenes from your project at
-				a stable framerate and guaranteed simulation speed. Together
-				with Godot's animation capabilities, make the most out of the
-				engine's visuals.
+				<strong>{% t features.new_in_4 %}</strong>
+				{% t features.containers.3d.cards.movie.text %}
 			</p>
 		</div>
 	</div>
 
 	<div class="feature-container feature-container-3x" id="features_2d">
-		<h3>Specialized 2D workflow for games and apps</h3>
+		<h3>{% t features.containers.2d.title %}</h3>
 
 		<div class="card feature-card">
-			<h4>Work with real 2D and pixel-based unit system</h4>
-			<p>
-				Thanks to a dedicated 2D pipeline you can forget about Z axis,
-				and simplify your game logic. Think in pixels and screen coordinates,
-				while the engine does the rest.
-			</p>
+			<h4>{% t features.containers.2d.cards.units.title %}</h4>
+			<p>{% t features.containers.2d.cards.units.text %}</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Save time creating 2D worlds with a tile map editor</h4>
-			<p>
-				Whether you want procedural generation or a meticulously hand-crafted
-				level, with Godot's built-in tile map editor you can achieve every goal.
-				Import a sprite and convert it into a database of building blocks for
-				your 2D worlds.
-			</p>
+			<h4>{% t features.containers.2d.cards.tilemap.title %}</h4>
+			<p>{% t features.containers.2d.cards.tilemap.text %}</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Master usability with a flexible GUI system</h4>
+			<h4>{% t features.containers.2d.cards.gui.title %}</h4>
 			<p>
-				Build scalable and adaptive user interfaces with Godot's unique
-				GUI system. Created specifically to power layouts common to games,
-				it is also capable of handling complex UI applications and tools.
+				{% t features.containers.2d.cards.gui.text %}
 				<br><br>
-				<em>For an example of what Godot's UI system is capable of see the Godot editor itself!</em>
+				<em>{% t features.containers.2d.cards.gui.extra %}</em>
 			</p>
 		</div>
 	</div>
 
 	<div class="features-showreel">
 		<div class="feature-container">
-			<h3>Choice of many developers</h3>
-
-			<p>
-				Watch our annual showreel videos to see more examples of projects using Godot!
-			</p>
-
+			<h3>{% t features.showreel.title %}</h3>
+			<p>{% t features.showreel.text %}</p>
 			{% include showreel-shelf.html %}
 		</div>
 	</div>
 
 	<div class="feature-container feature-container-3x" id="deploy">
-		<h3>Cross-platform support with one project</h3>
+		<h3>{% t features.containers.deploy.title %}</h3>
 
 		<div class="card feature-card">
-			<h4>Deliver your game to desktop and mobile</h4>
+			<h4>{% t features.containers.deploy.cards.export.title %}</h4>
+			<p>{% t features.containers.deploy.cards.export.text %}</p>
+		</div>
+
+		<div class="card feature-card">
+			<h4>{% t features.containers.deploy.cards.test.title %}</h4>
 			<p>
-				Develop and publish your project on any modern desktop platform.
-				Let everyone play your game by deploying to web and mobile.
-				Make your game handle various forms of inputs and share the same
-				project between every release.
+				<strong>{% t features.new_in_4 %}</strong>
+				{% t features.containers.deploy.cards.test.text %}
 			</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Test directly on your target device</h4>
-			<p>
-				<strong>New in 4.0:</strong> Iterate on real hardware, or with
-				an emulator by deploying your game directly to the target device
-				over SSH. Run any project on a mobile device, on another desktop,
-				or on your favorite Linux-based handheld with full debug and inspect
-				capabilities.
-			</p>
-		</div>
-
-		<div class="card feature-card">
-			<h4>Partner with a publisher to target consoles</h4>
-			<p>
-				If you want to release to a console, you can find several
-				3rd party publishers which specialize on that. Godot games
-				can run on any modern hardware, all you need to worry about
-				is your performance and controls.
-			</p>
+			<h4>{% t features.containers.deploy.cards.consoles.title %}</h4>
+			<p>{% t features.containers.deploy.cards.consoles.text %}</p>
 		</div>
 	</div>
 
 	<div class="feature-container feature-container-2x" id="open_source">
-		<h3>Completely open and free</h3>
+		<h3>{% t features.containers.open.title %}</h3>
 
 		<div class="card feature-card">
-			<h4>Download and create with no contracts or hidden fees</h4>
-			<p>
-				Godot is free under the MIT license. This means you don't owe
-				us anything (other than a friendly mention), and can do with your
-				project or even the engine itself whatever you want. Build your game
-				or build your own engine on top of it — it's all in your hands.
-			</p>
+			<h4>{% t features.containers.open.cards.free.title %}</h4>
+			<p>{% t features.containers.open.cards.free.text %}</p>
 		</div>
 
 		<div class="card feature-card">
-			<h4>Find the logic behind any system in an open source codebase</h4>
-			<p>
-				No need to wait for a support team to respond when you can read
-				the source code. Godot is an open book, and you can figure out everything
-				that is not yet documented after a single <code>git checkout</code>.
-				If you find and fix an issue, we will appreciate a PR upstream too.
-			</p>
+			<h4>{% t features.containers.open.cards.source_code.title %}</h4>
+			<p>{% t features.containers.open.cards.source_code.text %}</p>
 		</div>
 	</div>
 
 	<div class="features-complete-list">
 		<a href="https://docs.godotengine.org/en/stable/about/list_of_features.html" class="btn btn-flat btn-flat-white btn-flat-frosted">
-			View a complete list of features
+			{% t features.see_complete_list %}
 		</a>
 	</div>
 

--- a/pages/home.html
+++ b/pages/home.html
@@ -7,8 +7,9 @@ title:
   zh-cn: "Godot Engine - 免费开源的 2D 与 3D 游戏引擎"
   zh-tw: "Godot Engine - 免費開源的 2D 與 3D 遊戲引擎"
 notitlesuffix: true
-description: "Godot provides a huge set of common tools, so you can just focus on making your game without reinventing
-the wheel."
+description:
+  en: "Godot provides a huge set of common tools, so you can just focus on making your game without reinventing the wheel."
+  fr: "Godot fournit un ensemble d'outils communs afin que vous puissez vous concentrer sur la création de votre jeu sans réinventer la roue."
 layout: default
 localize: ["en", "es", "fr", "zh-cn", "zh-tw"]
 ---


### PR DESCRIPTION
This adds a French translation for both pages as well.

<details>
<summary>Preview</summary>

![image](https://github.com/user-attachments/assets/bcfbb8de-0f41-4ba8-8e5b-c784dca8b1fb)
</details>

## TODO

- Make translations visible on the Download page by fixing URLs (`/fr/download/linux` is not being generated, only `/fr/download` is).
  - I've tried to add `localize: ["en", "fr"]` to `collections/_download/linux.md` to no avail.
- Change links to pages to use localized variants according to the current page language.
- Make the language dropdown preserve the page you're currently looking at, instead of redirecting you to the homepage. `window.location.pathname` is supposed to do this, but it doesn't work after you use it once.