### PR TITLE
Add experimental download links to Download page and download secton

### DIFF
--- a/_includes/download/download-section.html
+++ b/_includes/download/download-section.html
@@ -71,6 +71,6 @@
 			<div class="download-hint">{{ stable_version_4.name }}</div>
 		</a>
 
-		<span class="download-3">Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a> or a <a href="/download/archive">previous version</a>?</span>
+		<span class="download-3">Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a>, our <a href="/download/archive">experimental releases</a>, or a <a href="/download/archive">previous version</a>?</span>
 	</div>
 </div>

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -49,7 +49,7 @@ layout: default
 			{% endfor %}
 
 			<p class="previous-releases">
-				Looking for <strong class="previous-releases-featured"><a href="/download/3.x/" class="set-os-download-url" data-version="3">Godot 3</a></strong> or a <strong><a href="/download/archive">previous version</a>?</strong>
+				Looking for <strong class="previous-releases-featured"><a href="/download/3.x/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a></strong>, our <strong><a href="/download/archive">experimental releases</a></strong>, or a <strong><a href="/download/archive">previous version</a></strong>?
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
This mimics the homepage which links to both (even though it's the same URL, as both are provided on the same page).

- This closes https://github.com/godotengine/godot-website/issues/1037.

## Preview

![image](https://github.com/user-attachments/assets/f6fcab84-17e7-4016-bc34-47cd96b03aaf)

![image](https://github.com/user-attachments/assets/1b6395bf-b5fa-424c-b26f-ef7d350152ee)
