### PR TITLE
Fix download card donate link color on light theme

### DIFF
--- a/assets/css/article-cards.css
+++ b/assets/css/article-cards.css
@@ -56,8 +56,8 @@
 	text-decoration-thickness: 1px;
 }
 .card-download-sublinks .card-download-donate {
-	color: var(--fund-color);
-	text-decoration-color: var(--fund-color);
+	color: #fff;
+	text-decoration-color: #fff;
 	font-weight: 600;
 	text-shadow: 0 0 2px #000; /* Adding more contrast */
 }


### PR DESCRIPTION
Previously, it appeared as dark gray text on a blue background, which was difficult to read. It now appears as white text on a blue background.

The appearance on dark theme is unchanged.

## Preview

Before | After
-|-
![image](https://github.com/user-attachments/assets/d616bd46-2db5-4e8f-a18c-d6726f4c980b) | ![image](https://github.com/user-attachments/assets/ee7587af-6416-4104-8ead-6c010902b117)

___

Light theme | Dark theme (unchanged)
-|-
![image](https://github.com/user-attachments/assets/ee7587af-6416-4104-8ead-6c010902b117) | ![image](https://github.com/user-attachments/assets/027bdbc2-6cf5-4b68-9b59-471d39ef9d4e)
