### PR TITLE
Fix light theme text display on Showcase page

### DIFF
--- a/pages/showcase/showcase.scss
+++ b/pages/showcase/showcase.scss
@@ -122,7 +122,7 @@ a:has(.showcase-card) {
 	.author,
 	.card-title {
 		font-size: 14px;
-		color: var(--primary-color-text);
+		color: var(--base-color-text);
 	}
 
 	.card-title {


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-website/issues/1043.

## Preview

### Light theme

Before | After
-|-
![Image](https://github.com/user-attachments/assets/ed32d4d9-b122-4762-9388-32910bc168fd) | ![Image](https://github.com/user-attachments/assets/28eaa5ca-8b1d-4f6e-b164-10e3d7b8e9a3)

### Dark theme

Before | After
-|-
![Image](https://github.com/user-attachments/assets/e784f5de-7445-4e82-9982-e085d8beb518) | ![Image](https://github.com/user-attachments/assets/69a92146-bd19-4e70-9284-3acd5fb5ea0c)

