### PR TITLE
Add note to user groups page with info on where to open a PR to add a group

### DIFF
--- a/pages/community/user-groups.html
+++ b/pages/community/user-groups.html
@@ -197,7 +197,11 @@ layout: default
 
 		<p style="margin-top: 4rem">
 			If you run a local community and would like to have it listed here,
-			please send an email to <em>webmaster at godotengine · org</em>.
+			please send an email to <em>webmaster at godotengine · org</em>
+			or open a pull request on GitHub modifying the
+			<a href="https://github.com/godotengine/godot-website/blob/master/_data/communities.yml">
+				<code>_data/communities.yml</code> file
+			</a>.
 		</p>
 	</div>
 </main>

--- a/pages/community/user-groups.html
+++ b/pages/community/user-groups.html
@@ -199,7 +199,7 @@ layout: default
 			If you run a local community and would like to have it listed here,
 			please send an email to <em>webmaster at godotengine · org</em>
 			or open a pull request on GitHub modifying the
-			<a href="https://github.com/godotengine/godot-website/blob/master/_data/communities.yml">
+			<a href="https://github.com/godotengine/godot-website/blob/master/_data/communities.yml" target="_blank" rel="noopener">
 				<code>_data/communities.yml</code> file
 			</a>.
 		</p>


### PR DESCRIPTION
Over in the Godot Seattle group, it sounds like somebody emailed `webmaster@godotengine.org` but we never got a response. It seems like adding directly to the `_data/communities.yml` is the more "correct" way to do things (see also https://github.com/godotengine/godot-website/pull/1058 )

![image](https://github.com/user-attachments/assets/5a2e2e5a-f1f7-4643-ab91-9fb8e2089c59)
