### PR TITLE
Corrected RAM stats typo

### DIFF
--- a/collections/_article/upcoming-serious-web-performance-boost.md
+++ b/collections/_article/upcoming-serious-web-performance-boost.md
@@ -30,7 +30,7 @@ Our resident benchmark expert Hugo Locurcio (better known as [Calinou](https://g
 
 - **CPU:** Intel Core i9-13900K
 - **GPU:** NVIDIA GeForce RTX 4090
-- **RAM:** 64 GB (2×32 GB DDR5-5800 C30)
+- **RAM:** 64 GB (2×32 GB DDR5-5800 CL30)
 - **SSD:** Solidigm P44 Pro 2 TB
 - **OS:** Linux (Fedora 42)
 </div>


### PR DESCRIPTION
I know this is a minuscule nitpick, but the RAM rating `C30` should be `CL30`, as it stands for CAS-Latency (Column Address Strobe)

Thanks as always for updates and such performance improvements, I'm looking forward to trying it out!

- *Production edit: Follow-up to https://github.com/godotengine/godot-website/pull/1063.*