### PR TITLE
Add Godot East Coast Guild to communities

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -419,3 +419,10 @@ United States:
     links:
       - title: Discord
         url: https://discord.gg/G7WNW6GYrf
+  - name: Godot East Coast Guild
+    coordinates:
+      - 38.89867917282319
+      - -77.02480110061525
+    links:
+      - title: Discord
+        url: https://discord.gg/4mmza4kP


### PR DESCRIPTION
Adds a new community group & Discord, based on the East Coast, near Washington D.C. Inclusive of anyone with an interest in Godot in VA, DC, MD, DE, PA, NC, etc. Thanks