### PR TITLE
Fix building with Jekyll on Ruby 3.4

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,10 +18,10 @@ jobs:
 
     # Configure the build environment.
 
-    - name: Install Ruby 3.1
+    - name: Install Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         # Runs 'bundle install' and caches installed gems automatically
         bundler-cache: true
 
@@ -34,7 +34,7 @@ jobs:
       run: bundle exec jekyll build
 
     # Upload resulting "_site" directory as artifact
-    
+
     - uses: actions/upload-artifact@v4
       with:
         name: site

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -23,10 +23,10 @@ jobs:
 
     # Configure the build environment.
 
-    - name: Install Ruby 3.1
+    - name: Install Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         # Runs 'bundle install' and caches installed gems automatically
         bundler-cache: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '4.2.2'
+gem 'jekyll', '4.4.1'
 gem 'jekyll-watch'
 gem 'jekyll-paginate-v2'
 gem 'jekyll-redirect-from'
 
-gem "webrick", "~> 1.8"
+gem 'webrick', '~> 1.8'
+
+# Required on Ruby 3.4 and later as these are no longer part of the standard library.
+gem 'csv'
+gem 'base64'
+gem 'bigdecimal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,79 +3,173 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.5)
-    ffi (1.15.5-x64-unknown)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
+    google-protobuf (4.31.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.2)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
-      jekyll-sass-converter (~> 2.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 2.3)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.4.0)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
-      rouge (~> 3.0)
+      rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
-      terminal-table (~> 2.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
     jekyll-paginate-v2 (3.0.0)
       jekyll (>= 3.0, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-sass-converter (2.2.0)
-      sassc (> 2.0.1, < 3.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.12.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.7.1)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
+    rake (13.3.0)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.0)
-    rouge (3.30.0)
+    rexml (3.4.1)
+    rouge (4.5.2)
     safe_yaml (1.0.5)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    terminal-table (2.0.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.8.0)
-    webrick (1.8.2)
+    sass-embedded (1.89.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.89.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-aarch64-mingw-ucrt)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-23
-  arm64-darwin-24
-  x64-unknown
-  x86_64-linux
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  aarch64-mingw-ucrt
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll (= 4.2.2)
+  base64
+  bigdecimal
+  csv
+  jekyll (= 4.4.1)
   jekyll-paginate-v2
   jekyll-redirect-from
   jekyll-watch
   webrick (~> 1.8)
 
 BUNDLED WITH
-   2.4.18
+   2.6.2

--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ When working on new features, keep in mind this website only supports _evergreen
 
 To build the website locally, follow these steps:
 
-1. Install Ruby and Jekyll.
-  - For our current setup you need to have a specific version of Ruby using `rbenv`:
+1. Install Ruby 3.2 or later and Jekyll.
+  - If you don't have access to Ruby 3.2 or later in your distribution's repositories, install a compatible version of Ruby using `rbenv`:
     - Install in Ubuntu:
-      - `sudo apt install rubenv`
+      - `sudo apt install rbenv`
     - Install in Fedora:
       - Install `rbenv` with dnf
       - Run `echo 'eval "$(rbenv init -)"' >> ~/.bashrc` to add the rbenv init to `.bashrc` (or `.bash_profile`)
   - Set up `rbenv` running the following:
-    - `rbenv install 3.1.2`
-    - `rbenv global 3.1.2`
+    - `rbenv install 3.4.4`
+    - `rbenv global 3.4.4`
 2. Install [Minify](https://github.com/tdewolff/minify/tree/master/cmd/minify).
-	- Make sure `minify` is available from the command line.
+	- Make sure either `minify` or `gominify` is available from the command line.
 3. Clone this repository.
 4. Install the necessary dependencies: `bundle install`.
 5. Build the site: `bundle exec jekyll build`.
@@ -203,7 +203,7 @@ some pages.
 
 ### Localizing the website
 
-To localize the website, the `_i18n` folder contains translation files for each language. The default and fallback language is English `/_i18n/en.yml`. 
+To localize the website, the `_i18n` folder contains translation files for each language. The default and fallback language is English `/_i18n/en.yml`.
 
 If you want to add a new language, create a new file in the `_i18n` folder with the language code as the filename and add the label for that language at `/assets/js/localize.js`. For example, for French, create `/_i18n/fr.yml` and add `'fr': 'Français'` in the `languageMap` const.
 


### PR DESCRIPTION
Ruby 3.4 removed several standard library packages, so they have to be installed as gems instead.

This also updates Jekyll to use a version that's supported in Ruby 3.4.

The minimum required Ruby version is now 3.2.

Many deprecation warnings occur when building Sass, which I've fixed in a separate PR that depends on this one: https://github.com/godotengine/godot-website/pull/1080