### PR TITLE
Add `logger` to Gemfile to fix Ruby 3.5.0 deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem 'webrick', '~> 1.8'
 gem 'csv'
 gem 'base64'
 gem 'bigdecimal'
+
+gem "logger", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -169,6 +170,7 @@ DEPENDENCIES
   jekyll-paginate-v2
   jekyll-redirect-from
   jekyll-watch
+  logger (~> 1.7)
   webrick (~> 1.8)
 
 BUNDLED WITH


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-website/pull/1079.

[The `logger` gem](https://rubygems.org/gems/logger) will be moved out of the standard library in Ruby 3.5.0. While the website can still build fine with Ruby 3.4.x, this won't be the case anymore with the latest Ruby version once 3.5.0 releases.

Previously, this was printed when running `bundle exec jekyll s`:

```
/home/hugo/.local/share/gem/ruby/3.4.0/gems/jekyll-4.4.1/lib/jekyll.rb:26: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```
