### PR TITLE
Use "third-party" not "3rd party" in features.html

### DIFF
--- a/pages/features.html
+++ b/pages/features.html
@@ -457,11 +457,11 @@ layout: default
 		</div>
 
 		<div class="card feature-card">
-			<h4>Modify the engine itself and integrate with 3rd party libraries</h4>
+			<h4>Modify the engine itself and integrate with third-party libraries</h4>
 			<p>
 				Thanks to the modular structure and a straightforward build process of Godot
 				you can create your own engine modules. Gain every last drop of performance
-				or integrate with many 3rd party libraries with low-level C++ code.
+				or integrate with many third-party libraries with low-level C++ code.
 			</p>
 		</div>
 	</div>
@@ -584,7 +584,7 @@ layout: default
 			<h4>Partner with a publisher to target consoles</h4>
 			<p>
 				If you want to release to a console, you can find several
-				3rd party publishers which specialize on that. Godot games
+				third-party publishers which specialize on that. Godot games
 				can run on any modern hardware, all you need to worry about
 				is your performance and controls.
 			</p>


### PR DESCRIPTION
I think "third" looks more professional than "3rd". And "third-party" should be hyphenated in these particular instances because it's being used as an adjective.