### PR TITLE
Shorten Jekyll log when building the website

### DIFF
--- a/_plugins/download_archive_generator.rb
+++ b/_plugins/download_archive_generator.rb
@@ -5,9 +5,11 @@ module DownloadArchiveGeneratorPlugin
 	  def generate(site)
 		puts "Generating download archive pages..."
 
+		versions = 0
+
 		site.data["versions"].each do |version|
 		  version_name = version["name"]
-		  puts "    Rendering version '#{version_name}'."
+		  versions += 1
 
 		  # Generate files for the current main flavor (stable or latest pre-release).
 		  site.pages << DownloadArchivePage.new(site, version, nil)
@@ -20,7 +22,7 @@ module DownloadArchiveGeneratorPlugin
 		  end
 		end
 
-		puts "Finished generating the download archive."
+		puts "Finished generating the download archive (#{versions} versions generated)."
 	  end
 	end
 

--- a/_plugins/mirrorlist_generator.rb
+++ b/_plugins/mirrorlist_generator.rb
@@ -5,9 +5,11 @@ module MirrorlistGeneratorPlugin
 	  def generate(site)
 		puts "Generating mirrorlist pages..."
 
+		versions = 0
+
 		site.data["versions"].each do |version|
 		  version_name = version["name"]
-		  puts "    Rendering version '#{version_name}'."
+		  versions += 1
 
 		  # Generate files for the current main flavor (stable or latest pre-release).
 		  site.pages << MirrorlistPage.new(site, version, false)
@@ -28,7 +30,7 @@ module MirrorlistGeneratorPlugin
 		  end
 		end
 
-		puts "Finished generating the mirrorlist."
+		puts "Finished generating the mirrorlist (#{versions} versions generated)."
 	  end
 	end
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-website/pull/1089.

The list of individual versions is no longer displayed twice every time the website is (re)built. Instead, only the number of versions that were generated is displayed.

```
Configuration file: /home/hugo/Documents/Git/godotengine/godot-website/_config.yml
            Source: /home/hugo/Documents/Git/godotengine/godot-website
       Destination: /home/hugo/Documents/Git/godotengine/godot-website/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
Generating download archive pages...
Finished generating the download archive (62 versions generated).
Generating mirrorlist pages...
Finished generating the mirrorlist (62 versions generated).
         AutoPages: Disabled/Not configured in site.config.
        Pagination: Complete, processed 7 pagination page(s)
```
