### PR TITLE
Make the check for `minify`/`gominify` binaries quiet

### DIFF
--- a/_plugins/minify-assets.rb
+++ b/_plugins/minify-assets.rb
@@ -8,9 +8,11 @@ Jekyll::Hooks.register :site, :post_write do
   Pathname from = Pathname.new(File.join(Dir.pwd, "_site"))
   Pathname to = Pathname.new(Dir.pwd)
   # Attempt to minify using 'minify', fallback to 'gominify' if not present
-  minify_command = `which minify`.empty? ? 'gominify' : 'minify'
-  if `which #{minify_command}`.empty?
-    puts "Error: Neither 'minify' nor 'gominify' is installed. Please install 'minify'."
+  `command -v minify`
+  minify_command = $?.exitstatus != 0 ? 'gominify' : 'minify'
+  `command -v #{minify_command}`
+  if $?.exitstatus != 0
+    puts "ERROR: Neither 'minify' nor 'gominify' is installed. Please install 'minify'."
     exit 1
   end
   `#{minify_command} -r -o #{to.relative_path_from(here)} #{from.relative_path_from(here)}`


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-website/pull/1096.

This prevents a message for `minify` not being found from being printed every time the website is built if you're using `gominify` instead. This still prints an error if neither `minify` or `gominify` is found.

This needs to be tested on Windows before merging. I assume it won't work, but it probably didn't work in `master` either as `which` is not a standard Windows utility (unless you happen to have Scoop installed and have run `scoop install which`).
