### PR TITLE
Fix missing `command` command

### DIFF
--- a/_plugins/minify-assets.rb
+++ b/_plugins/minify-assets.rb
@@ -8,9 +8,9 @@ Jekyll::Hooks.register :site, :post_write do
   Pathname from = Pathname.new(File.join(Dir.pwd, "_site"))
   Pathname to = Pathname.new(Dir.pwd)
   # Attempt to minify using 'minify', fallback to 'gominify' if not present
-  `command -v minify`
+  `which minify`
   minify_command = $?.exitstatus != 0 ? 'gominify' : 'minify'
-  `command -v #{minify_command}`
+  `which #{minify_command}`
   if $?.exitstatus != 0
     puts "ERROR: Neither 'minify' nor 'gominify' is installed. Please install 'minify'."
     exit 1


### PR DESCRIPTION
I encountered this issue locally, and worked around it using the same changes in this PR:

<details>
<summary>Error output</summary>

```
Minifying assets
                    ------------------------------------------------
      Jekyll 4.4.1   Please append `--trace` to the `build` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
/home/runner/work/godot-website/godot-website/_plugins/minify-assets.rb:11:in ``': No such file or directory - command (Errno::ENOENT)
	from /home/runner/work/godot-website/godot-website/_plugins/minify-assets.rb:11:in `block in <top (required)>'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/hooks.rb:103:in `block in trigger'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/hooks.rb:102:in `each'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/hooks.rb:102:in `trigger'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/site.rb:234:in `write'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/site.rb:82:in `process'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/command.rb:28:in `process_site'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/commands/build.rb:65:in `build'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/commands/build.rb:36:in `process'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/command.rb:91:in `block in process_with_graceful_fail'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/command.rb:91:in `each'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/command.rb:91:in `process_with_graceful_fail'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `block in execute'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `each'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `execute'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/mercenary-0.4.0/lib/mercenary/program.rb:44:in `go'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/mercenary-0.4.0/lib/mercenary.rb:21:in `program'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/gems/jekyll-4.4.1/exe/jekyll:15:in `<top (required)>'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/bin/jekyll:25:in `load'
	from /home/runner/work/godot-website/godot-website/vendor/bundle/ruby/3.2.0/bin/jekyll:25:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:59:in `load'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:59:in `kernel_load'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:23:in `run'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/cli.rb:452:in `exec'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor.rb:538:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/cli.rb:35:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/cli.rb:29:in `start'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/exe/bundle:28:in `block in <top (required)>'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/lib/bundler/friendly_errors.rb:1[17](https://github.com/godotengine/godot-website/actions/runs/15854713703/job/44696979630?pr=1099#step:5:18):in `with_friendly_errors'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.6.2/exe/bundle:20:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/bin/bundle:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.2.8/x64/bin/bundle:25:in `<main>'
```
</details>

I thought this may have just been some local oddity, but it happened on the CI for my PR https://github.com/godotengine/godot-website/pull/1099 too, so I figured I'd share it.

`command` is a shell built-in, not an actual program, but the error `No such file or directory - command (Errno::ENOENT)` makes it seem like it wants a program. So, I replaced it with `which`, which is a program.

I have no idea if it's the right fix, but it seems to work for me on Linux (probably won't work on non-POSIX systems)