### PR TITLE
Fix dotnet download button being too pale on the release pages

### DIFF
--- a/assets/css/releases/4.3.scss
+++ b/assets/css/releases/4.3.scss
@@ -262,7 +262,7 @@ $donate-robot-size: 500px;
 			}
 
 			.download-net-button {
-				background-color: rgba(111, 111, 111, 27%);
+				background-color: rgba(0, 0, 0, 27%);
 				-webkit-backdrop-filter:
 					blur(4px);
 				backdrop-filter:

--- a/assets/css/releases/4.4.scss
+++ b/assets/css/releases/4.4.scss
@@ -305,7 +305,7 @@ $donate-robot-size: 500px;
 			}
 
 			.download-net-button {
-				background-color: rgba(111, 111, 111, 27%);
+				background-color: rgba(0, 0, 0, 27%);
 				-webkit-backdrop-filter: blur(4px);
 				backdrop-filter: blur(4px);
 			}


### PR DESCRIPTION
Currently, the dotnet download button on the release pages is too pale when hovered: it becomes pure white. This doesn't happen on the download page because the background is dark, and the gray of the button is actually transparent. As the background is white, it makes the button even bright.

The fix is to make the button darker.

| State | Before | After |
| :---: | :---: | :---: |
| Default | <img width="562" alt="Capture d’écran, le 2025-06-25 à 11 53 32" src="https://github.com/user-attachments/assets/089ec670-fda4-4272-8d96-614d15c0af27" /> | <img width="557" alt="Capture d’écran, le 2025-06-25 à 11 53 21" src="https://github.com/user-attachments/assets/65acd4f3-8f4f-4e85-b039-7afd3f93cf94" /> |
| Hover | <img width="596" alt="Capture d’écran, le 2025-06-25 à 11 40 46" src="https://github.com/user-attachments/assets/19152fd1-356b-48e2-bda3-bc88881fa136" /> | <img width="552" alt="Capture d’écran, le 2025-06-25 à 11 52 45" src="https://github.com/user-attachments/assets/47765bfd-d488-4125-9593-2832a49fe27c" /> |

