### PR TITLE
Fix minify plugin relying on shell builtin

### DIFF
--- a/_plugins/minify-assets.rb
+++ b/_plugins/minify-assets.rb
@@ -8,9 +8,9 @@ Jekyll::Hooks.register :site, :post_write do
   Pathname from = Pathname.new(File.join(Dir.pwd, "_site"))
   Pathname to = Pathname.new(Dir.pwd)
   # Attempt to minify using 'minify', fallback to 'gominify' if not present
-  `command -v minify`
+  `sh -c 'command -v minify'`
   minify_command = $?.exitstatus != 0 ? 'gominify' : 'minify'
-  `command -v #{minify_command}`
+  `sh -c 'command -v #{minify_command}'`
   if $?.exitstatus != 0
     puts "ERROR: Neither 'minify' nor 'gominify' is installed. Please install 'minify'."
     exit 1


### PR DESCRIPTION
Explicitly initialize a shell to have access to 'command' it's not an actual program.

- Fixes regression from #1097.
- Supersedes #1100.