### PR TITLE
Add `&NoBreak;` to make sure "C++" isn't split in feature page

### DIFF
--- a/pages/features.html
+++ b/pages/features.html
@@ -450,7 +450,7 @@ layout: default
 				Thanks to our community there are many language bindings for
 				popular tools like Rust, Nim, Python, and JavaScript.
 				<br><br>
-				<strong>New in 4.0:</strong> C++ supports comes officially in the form of
+				<strong>New in 4.0:</strong> C&NoBreak;+&NoBreak;+ supports comes officially in the form of
 				GDExtension API, which gives you a way to script and program your game
 				components for maximum performance without having to recompile the engine.
 			</p>
@@ -461,7 +461,7 @@ layout: default
 			<p>
 				Thanks to the modular structure and a straightforward build process of Godot
 				you can create your own engine modules. Gain every last drop of performance
-				or integrate with many third-party libraries with low-level C++ code.
+				or integrate with many third-party libraries with low-level C&NoBreak;+&NoBreak;+ code.
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
https://github.com/user-attachments/assets/8bdda285-d08d-4c61-bb59-3dfa5aaa8ad0

Fixes #1093