### PR TITLE
Correct links on 3.6.1 blog post

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -440,11 +440,16 @@
       release_date: "24 January 2022"
       release_notes: "/article/dev-snapshot-godot-4-0-alpha-1/"
 
+- name: "3.6.1"
+  flavor: "stable"
+  release_date: "6 June 2025"
+  release_notes: "/article/maintenance-release-godot-3-6-1/"
+  featured: "3"
+
 - name: "3.6"
   flavor: "stable"
   release_date: "9 September 2024"
   release_notes: "/article/godot-3-6-finally-released/"
-  featured: "3"
   releases:
     - name: "rc1"
       release_date: "9 July 2024"

--- a/collections/_article/maintenance-release-godot-3-6-1.md
+++ b/collections/_article/maintenance-release-godot-3-6-1.md
@@ -138,10 +138,9 @@ This release is built from commit [`b1ba98fce`](https://github.com/godotengine/g
 <a id="downloads"></a>
 ## Downloads
 
-The downloads for this dev snapshot can be found directly on our repository:
-
-- [Standard build](https://github.com/godotengine/godot-builds/releases/3.6.1) (GDScript, GDNative, VisualScript).
-- [Mono build](https://github.com/godotengine/godot-builds/releases/3.6.1) (C# support + all the above). You need to have dotnet CLI or MSBuild installed to use the Mono build. Relevant parts of Mono **6.12.0.182** are included in this build.
+{% include articles/download_card.html version="3.6.1" release="stable" article=page %}
+**Standard build** includes support for GDScript, GDNative, and VisualScript.
+**.NET build** (marked as `mono`) includes support for C#, as well as GDScript, GDNative, and VisualScript.
 
 ### UWP (Universal Windows Platform)
 


### PR DESCRIPTION
These both point to the same releases page, but at least the links work. :grin: 