### PR TITLE
Make sure that `get_latest_patch` returns a `stable` patch

### DIFF
--- a/_plugins/version_filter.rb
+++ b/_plugins/version_filter.rb
@@ -13,6 +13,10 @@ module Jekyll
       latest_patch = 0
 
       versions.each do |version|
+        if version["flavor"] != "stable"
+          next
+        end
+
         version_split = version["name"].split(".")
 
         if version_split.length() != 3

--- a/pages/releases/4.4.html
+++ b/pages/releases/4.4.html
@@ -43,8 +43,8 @@ authors_list: "0x0ACB,1,1|0x53A,1,1|0xafbf,1,1|0xcafeb33f,1,1|10Drenth,1,1|2nafi
 ---
 
 {% assign release_version_number = "4.4" %}
-{% assign release_version = release_version_number | make_release_version: "stable" %}
 {% assign latest_patch = release_version_number | get_latest_patch %}
+{% assign release_version = latest_patch | make_release_version: "stable" %}
 
 {% assign data = site.release_4_4 %}
 


### PR DESCRIPTION
Currently, if there's a `rc1` patch in `_data/versions.yml`, it would be chosen instead of the current stable release.