### PR TITLE
Fix community Discord link for East Coast Guild to never expire

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -433,4 +433,4 @@ United States:
       - -77.02480110061525
     links:
       - title: Discord
-        url: https://discord.gg/4mmza4kP
+        url: https://discord.gg/62nkHTnndg


### PR DESCRIPTION
When I created the East Coast Guild in #1078, I accidentally had a 7 day link. Fixed to have a new one that will never expire. I had some people reach out to me to join & couldn't so I am correcting this. Sorry about that, and thank you!