### PR TITLE
Update the Consoles page

### DIFF
--- a/pages/consoles.html
+++ b/pages/consoles.html
@@ -8,30 +8,39 @@ providers:
   - name: W4 Games
     url: https://www.w4games.com/
     image: /assets/images/consoles/w4-games.png
+    platforms: ["switch", "xbox-series", "playstation-5"]
   - name: Lone Wolf Technology
     url: https://www.lonewolftechnology.com/
     image: /assets/images/consoles/lone-wolf.png
+    platforms: ["switch", "playstation-4", "playstation-5"]
   - name: Pineapple Works
     url: https://pineapple.works/
     image: /assets/images/consoles/pineapple-works.png
+    platforms: ["switch", "switch-2", "xbox-one", "xbox-series", "playstation-5"]
   - name: RAWRLAB Games
     url: https://www.rawrlab.com/
     image: /assets/images/consoles/rawrlab-games.png
+    platforms: ["switch"]
   - name: mazette!
     url: https://mazette.games/
     image: /assets/images/consoles/mazette-games.png
+    platforms: ["switch", "xbox-one", "xbox-series"]
   - name: Olde Sküül
     url: https://oldeskuul.com/
     image: /assets/images/consoles/olde-skuul.png
+    platforms: ["switch", "xbox-one", "playstation-4", "playstation-5"]
   - name: Tuanisapps
     url: https://www.tuanisapps.com/
     image: /assets/images/consoles/tuanis-apps.png
+    platforms: ["switch"]
   - name: Seaven Studio
     url: https://www.seaven-studio.com/
     image: /assets/images/consoles/seaven-studio.png
+    platforms: ["switch", "xbox-one", "xbox-series", "playstation-4", "playstation-5"]
   - name: Sickhead Games
     url: https://www.sickhead.com
     image: /assets/images/consoles/sickhead-games.png
+    platforms: ["switch", "xbox-one", "xbox-series", "playstation-4", "playstation-5"]
 ---
 
 {% include header.html %}
@@ -100,6 +109,66 @@ providers:
 		.consoles-wrapper {
 			width: auto;
 		}
+	}
+
+	.main {
+		display: grid;
+		grid-template-columns: 1fr 200px;
+		grid-template-areas: "content aside";
+		gap: 20px;
+		margin-bottom: 60px;
+	}
+
+	@media (max-width: 800px) {
+		.main {
+			grid-template-columns: 1fr;
+			grid-template-areas: "aside" "content";
+		}
+	}
+
+	.content {
+		grid-area: content;
+	}
+
+	.hidden {
+		display: none !important;
+	}
+
+	aside {
+		grid-area: aside;
+		position: sticky;
+		top: 10px;
+		align-self: start;
+	}
+
+	aside h3 {
+		margin-top: 24px;
+		margin-bottom: 0;
+		font-size: 36px;
+		font-weight: 800;
+	}
+
+	.filter-options {
+		margin-bottom: 20px;
+		margin-top: 12px;
+		display: grid;
+		gap: 8px; 
+	}
+
+	@media (max-width: 800px) {
+		.filter-options {
+			grid-template-columns: 1fr 1fr;
+			gap: 8px 16px;
+		}
+	}
+	@media (max-width: 430px) {
+		.filter-options {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.filter-options label {
+		cursor: pointer;
 	}
 
 	.grid-container {
@@ -219,13 +288,27 @@ providers:
 			grid-template-columns: 1fr;
 		}
 	}
+	.section-description {
+		margin-top: 12px;
+	}
 	.add-your-company {
 		margin-top: 24px;
 		margin-bottom: 42px;
+		width: 100%;
 	}
 	.add-your-company .card-content {
 		padding: 20px;
 		text-align: left;
+	}
+	.add-your-company-card {
+		margin: 0 auto;
+	}
+	.add-your-company .add-your-company-content {
+		text-align: center;
+	}
+	.contact-button {
+		display: inline-block;
+		width: auto;
 	}
 
 </style>
@@ -241,29 +324,13 @@ providers:
 			<div class="content-card">
 				<h4>Closed ecosystems</h4>
 				<p>
-					Console platforms are like closed ecosystems. Working with them
-					requires contracts, SDKs, and developer hardware. These
-					platforms are governed by strict NDAs and legal requirements.
-				</p>
-				<p>
-					While Godot cannot directly provide official support due to its open-source
-					license, developers approved by console vendors can still build
-					and ship console games using Godot with the help of certified
-					third-party providers.
+					Consoles are closed platforms that require special permissions, SDKs, and hardware. They're bound by strict NDAs and legal rules. While Godot can't offer official support due to its open source license, approved developers can still ship console games using Godot through certified third-party providers.
 				</p>
 			</div>
 			<div class="content-card">
-				<h4>An open-source system</h4>
+				<h4>An open source system</h4>
 				<p>
-					Godot is fully open source and licensed under MIT. That means no NDAs,
-					no closed tools, and no legal liability accepted. Console development,
-					however, requires exactly the opposite: legal agreements, restricted
-					access, and liability coverage.
-				</p>
-				<p>
-					Because of this, the Godot Foundation has decided not to develop or
-					maintain official console ports. Doing so would compromise its core
-					values of transparency and freedom.
+					Godot is MIT-licensed and fully open source, no NDAs, no restricted tools, and no legal liability. Console development requires the opposite: legal contracts and closed access. To preserve its values of openness and freedom, the Godot Foundation does not maintain official console ports.
 				</p>
 			</div>
 		</div>
@@ -272,30 +339,19 @@ providers:
 			<div class="content-card">
 				<h4>Console porting in Godot</h4>
 				<p>
-					You can release a Godot game on consoles. You'll need to be approved
-					by the platform holder and either create the export tools yourself or
-					use middleware from a certified third party.
+					You can release a Godot game on consoles if you're approved by the platform holder and use official SDKs, either building tools yourself or using licensed third-party middleware.
 				</p>
 				<p>
-					The Godot engine itself can run on consoles, but export templates for
-					those platforms must be built separately. These templates are
-					typically created using official SDKs, and thus can only be
-					distributed privately to developers approved by the console makers.
-					Several third-party companies offer this middleware under the
-					necessary legal constraints.
+					Godot runs on consoles, but export templates must be built with official SDKs and can only be shared privately with approved developers. Several third-party companies offer this middleware under the necessary legal constraints.
 				</p>
 				<p>
-					For more information, check the following link:
-					<a
-						href="https://godotengine.org/article/about-official-console-ports/"
-					>official console ports</a>.
+					More info: <a href="https://godotengine.org/article/about-official-console-ports/">https://godotengine.org/article/about-official-console-ports/</a>
 				</p>
 			</div>
 			<div class="content-card">
 				<h4>What's the console porting process?</h4>
 				<p>
-					To start the process of bringing your Godot game to consoles, you'll
-					need to:
+					To start the process of bringing your Godot game to consoles, you'll need to:
 				</p>
 				<ol>
 					<li>Register as a developer with the console manufacturer</li>
@@ -303,43 +359,82 @@ providers:
 					<li>Obtain a devkit (confidential pricing)</li>
 					<li>Use or build console export templates</li>
 					<li>Rate your game with regional agencies (ESRB, PEGI, etc.)</li>
-					<li>
-						Either do the porting in-house or partner with a trusted vendor
-					</li>
+					<li>Either do the porting in-house or partner with a trusted vendor</li>
 				</ol>
-				<p>
-					Several companies offer console porting and publishing services for
-					Godot-based games.
-				</p>
 			</div>
 		</div>
 
-		<h2>Third-party support</h2>
-		<div class="grid-container grid-container-3x" id="third-party-support">
-			{% for provider in page.providers %}
-			<a href="{{ provider.url }}" class="content-card card-vendor">
-				<div class="card-image">
-					<img src="{{ provider.image }}" alt="{{ provider.name }}" />
+		<div class="main">
+			<aside>
+				<h3>Filter by:</h3>
+				<div class="filter-options">
+					<label><input type="checkbox" class="platform-filter" value="switch"> Nintendo Switch</label>
+					<label><input type="checkbox" class="platform-filter" value="switch-2"> Nintendo Switch 2</label>
+					<label><input type="checkbox" class="platform-filter" value="xbox-one"> Xbox One</label>
+					<label><input type="checkbox" class="platform-filter" value="xbox-series"> Xbox Series X/S</label>
+					<label><input type="checkbox" class="platform-filter" value="playstation-4"> PlayStation 4</label>
+					<label><input type="checkbox" class="platform-filter" value="playstation-5"> PlayStation 5</label>
 				</div>
-				<div class="card-content">
-					<h4>{{ provider.name }}</h4>
-					<div class="vendor-button">Visit {{ provider.name }}</div>
+			</aside>
+
+			<div class="content">
+				<div class="middleware-section">
+					<h2 class="section-title">Middleware (download and self-port)</h2>
+					<div class="content-card section-description">
+						<p>
+							Middleware ports are available directly from the console vendor's portal. These provide a version of Godot that runs natively on the target console. You are still responsible for adapting your game to each platform, but since the engine itself is already ported, the workload is significantly reduced.
+						</p>
+						<p>
+							W4 Games offers official middleware ports for Nintendo Switch, Xbox Series X/S, and PlayStation 5.
+						</p>
+					</div>
+					<div class="grid-container grid-container-3x" id="middleware-support">
+						{% for provider in page.providers %}
+						{% if provider.name == "W4 Games" or provider.name == "RAWRLAB Games" %}
+						<a href="{{ provider.url }}" class="content-card card-vendor {% for platform in provider.platforms%}{{platform}} {% endfor %}">
+							<div class="card-image">
+								<img src="{{ provider.image }}" alt="{{ provider.name }}" />
+							</div>
+							<div class="card-content">
+								<h4>{{ provider.name }}</h4>
+								<div class="vendor-button">Visit {{ provider.name }}</div>
+							</div>
+						</a>
+						{% endif %}
+						{% endfor %}
+					</div>
 				</div>
-			</a>
-			{% endfor %}
-		</div>
-		<div class="add-your-company">
-			<div class="content-card card-vendor" style="max-width: 768px; margin: 0 auto;">
-				<div class="card-content" style="text-align: center;">
-					<h4>Add your company</h4>
-					<p>
-						If your company offers porting, or porting <em>and</em> publishing
-						services for Godot games, feel free to contact the Godot Foundation
-						to add your company to the list above.
-					</p>
-					<a href="mailto:contact@godotengine.org" class="vendor-button" style="display: inline-block; width: auto;">
-						Contact the Godot Foundation
-					</a>
+
+				<div class="porting-section">
+					<h2 class="section-title">Porting houses and services</h2>
+					<div class="grid-container grid-container-3x" id="porting-support">
+						{% for provider in page.providers %}
+						<a href="{{ provider.url }}" class="content-card card-vendor {% for platform in provider.platforms%}{{platform}} {% endfor %}">
+							<div class="card-image">
+								<img src="{{ provider.image }}" alt="{{ provider.name }}" />
+							</div>
+							<div class="card-content">
+								<h4>{{ provider.name }}</h4>
+								<div class="vendor-button">Visit {{ provider.name }}</div>
+							</div>
+						</a>
+						{% endfor %}
+					</div>
+				</div>
+				<div class="add-your-company">
+					<div class="content-card card-vendor add-your-company-card">
+						<div class="card-content add-your-company-content">
+							<h4>Add your company</h4>
+							<p>
+								If your company offers porting, or porting <em>and</em> publishing
+								services for Godot games, feel free to contact the Godot Foundation
+								to add your company to the list above.
+							</p>
+							<a href="mailto:contact@godotengine.org" class="vendor-button contact-button">
+								Contact the Godot Foundation
+							</a>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -348,11 +443,53 @@ providers:
 
 <script>
 	document.addEventListener("DOMContentLoaded", function () {
-		// Randomize the order of the vendor cards in #third-party-support
-		const container = document.getElementById("third-party-support");
-		const cards = Array.from(container.children);
-		cards.sort(() => Math.random() - 0.5);
-		cards.forEach((card) => container.appendChild(card));
+		function shuffleContainer(selector) {
+			const container = document.querySelector(selector);
+			if (!container) return;
+			
+			const items = [...container.children];
+			items.sort(() => Math.random() - 0.5)
+			items.forEach(item => container.appendChild(item));
+		}
+
+		// Shuffle both sections
+		shuffleContainer('#middleware-support');
+		shuffleContainer('#porting-support');
+
+		// Filtering
+		const checkboxes = document.querySelectorAll('.platform-filter');
+		const cards = document.querySelectorAll('.card-vendor:not(.add-your-company-card)');
+		const middlewareSection = document.querySelector('.middleware-section');
+		const portingSection = document.querySelector('.porting-section');
+
+		function filterVendors() {
+			// List of selected values, like ["switch", "xbox-series"]
+			const selected = [...checkboxes]
+				.filter(cb => cb.checked)
+				.map(cb => cb.value);
+
+			const counts = { middleware: 0, porting: 0 };
+
+			cards.forEach(card => {
+				const noCheckboxesChecked = selected.length === 0;
+				const containsSelectedPlatform = selected.some(platform => card.classList.contains(platform));
+				const show = noCheckboxesChecked || containsSelectedPlatform;
+				// Show/hide card
+				card.classList.toggle('hidden', !show);
+
+				if (show) {
+					const section = card.closest('#middleware-support') ? 'middleware' : 'porting';
+					counts[section]++;
+				}
+			});
+
+			// Show/hide sections
+			middlewareSection.classList.toggle('hidden', counts.middleware === 0);
+			portingSection.classList.toggle('hidden', counts.porting === 0);
+		}
+
+		checkboxes.forEach(cb => cb.addEventListener('change', filterVendors));
+		filterVendors();
 	});
 </script>
 


### PR DESCRIPTION
Make some tweaks and updates to the Consoles page:
- Improve the content, make the explanations more clear and concise.
- Split the company cards into two sections: "Middleware" and "Porting Services".
- Add a sidebar which enables filtering by supported platform.

<img width="3024" height="8250" alt="consoles-page-update" src="https://github.com/user-attachments/assets/ef54128f-68fb-4644-9368-8d908a6e3e4a" />

