### PR TITLE
Update godot_openxr_vendors v4 article for hot fix

### DIFF
--- a/collections/_article/godot-openxr-vendors-plugin-400.md
+++ b/collections/_article/godot-openxr-vendors-plugin-400.md
@@ -9,8 +9,6 @@ image_caption_description: "A multiplayer VR fighting game, by JD The 65th"
 date: 2025-07-22 12:00:00
 ---
 
-# Godot OpenXR Vendors Plugin v4
-
 OpenXR support has been built into Godot since the release of Godot 4.0. However, the [OpenXR Vendors plugin](https://github.com/GodotVR/godot_openxr_vendors) (maintained by Godot's XR team) includes extensions to OpenXR created by hardware vendors (e.g. Meta, Pico, HTC, etc.), which we've chosen to keep outside of Godot itself.
 
 We are happy to announce a new major release of the OpenXR Vendors plugin, which includes some exciting new features!
@@ -61,7 +59,7 @@ That's why in version 4.0.0 and beyond, there are now project settings to enable
 
 Nothing ever stands still in the world of Godot!
 
-We just released [version 4.1.0](https://github.com/GodotVR/godot_openxr_vendors/releases/tag/4.1.0-stable) which includes even more exciting features.
+We just released [version 4.1.1](https://github.com/GodotVR/godot_openxr_vendors/releases/tag/4.1.1-stable) which includes even more exciting features.
 
 ### Full Body Tracking
 


### PR DESCRIPTION
We made a minor mistake in the godot_openxr_vendors 4.1.0 release (forgot to update version number in the code), so we're going to do a quick "hot fix" release ~~(should be later today, but it isn't up just yet, so I'm marking this as DRAFT until it is)~~

**UPDATE:** Release is made, so taking out of draft :-)

This PR updates the link for the 4.1.0 release to actually point at the 4.1.1 release.

I didn't think it was worth changing it in the text, because it doesn't really matter to the content that it's 4.1.1 vs 4.1.0, I just don't want people who are reading the article in the next couple days to end up on the broken one. But if folks here think we should also update the text to say "4.1.1", I'd be happy to make that change too

Also, I didn't realize this until after it went live, but the article currently has the title twice:

<img width="962" height="313" alt="Selection_368" src="https://github.com/user-attachments/assets/db58aab6-b804-4d8a-bacc-b82a5bf44695" />

So, I've also made a "hot fix" to the article itself, removing the title duplication :-)