### PR TITLE
Add Godot Hub information and remove outdated links

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -89,6 +89,16 @@ Canada:
       - title: Discord
         url: https://discord.gg/AemZhPjqyM
 China:
+  - name: Godot Hub
+    links:
+      - title: Forum/论坛
+        url: https://pd.qq.com/g/GodotHub999
+      - title: Groups/群聊
+        url: https://godothub.atomgit.net/festival2025/community
+      - title: Festival/大赛
+        url: https://godothub.com/festival
+      - title: Discord
+        url: https://discord.gg/a5kwptZJXP
   - name: Godot China
     links:
       - title: Discord

--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -95,10 +95,6 @@ China:
         url: https://discord.gg/R23VUTXwvz
       - title: QQ Group
         url: https://qm.qq.com/cgi-bin/qm/qr?k=EneMKrKt96ttI4ZFmQ8omTtpF0Sd0iL_&jump_from=webapi
-  - name: GodoterCN
-    links:
-      - title: Website
-        url: https://godoter.cn
   - name: Godoter Planet (Godoter 星球)
     links:
       - title: QQ Group
@@ -109,8 +105,6 @@ China:
         url: https://tieba.baidu.com/f?kw=godot
   - name: GodotCN (Godot中文社区)
     links:
-      - title: Website
-        url: http://godott.com
       - title: QQ Group
         url: https://qm.qq.com/cgi-bin/qm/qr?k=hEscGFbQTiOX0bhsTT2myxM3PifsAmIp&jump_from=webapi
 Croatia:


### PR DESCRIPTION
1. Remove outdated links about China Community.
2. Add Godot Hub information.

> The links to the two websites have been inaccessible for a long time, so I removed them. `Godot Hub` is the most active Godot community in China, featuring a forum, desktop app, group chats, and an annual development contest(since 2023). I’ve added relevant information about it.