### PR TITLE
Added Godot Lyon's discord server

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -186,6 +186,10 @@ France or French-speaking:
     links:
       - title: Discord
         url: https://discord.gg/gZ3QJ5T
+  - name: Godot Lyon
+    links:
+      - title: Discord
+        url: https://discord.gg/mH27RzGxqK
 Germany:
   - name: Godot Germany
     links:


### PR DESCRIPTION
I'm adding my local godot community to the list.
This is a community based in Lyon (France) where we exchange about godot projects and meet monthly!