### PR TITLE
Add missing Pico OS downloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     ffi (1.17.2-arm-linux-gnu)
     ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x64-mingw-ucrt)
     ffi (1.17.2-x86-linux-gnu)
     ffi (1.17.2-x86-linux-musl)
     ffi (1.17.2-x86_64-darwin)
@@ -34,6 +35,9 @@ GEM
       bigdecimal
       rake (>= 13)
     google-protobuf (4.31.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.31.1-x86-linux-gnu)
@@ -127,6 +131,8 @@ GEM
       google-protobuf (~> 4.31)
     sass-embedded (1.89.2-riscv64-linux-musl)
       google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x64-mingw-ucrt)
+      google-protobuf (~> 4.31)
     sass-embedded (1.89.2-x86_64-darwin)
       google-protobuf (~> 4.31)
     sass-embedded (1.89.2-x86_64-linux-android)
@@ -155,6 +161,7 @@ PLATFORMS
   riscv64-linux-gnu
   riscv64-linux-musl
   ruby
+  x64-mingw-ucrt
   x86-linux-gnu
   x86-linux-musl
   x86_64-darwin

--- a/_data/download_configs.yml
+++ b/_data/download_configs.yml
@@ -4,6 +4,7 @@ defaults:
     editor:
       android.apk: android_editor.apk
       android.horizonos: android_editor_horizonos.apk
+      android.picoos: android_editor_picoos.apk
       linux.64: linux.x86_64.zip
       linux.32: linux.x86_32.zip
       linux.arm64: linux.arm64.zip
@@ -159,6 +160,39 @@ overrides:
       templates: export_templates.tpz
       editor:
         android.apk: android_editor.apk
+        linux.64: linux.x86_64.zip
+        linux.32: linux.x86_32.zip
+        linux.arm64: linux.arm64.zip
+        linux.arm32: linux.arm32.zip
+        macos.universal: macos.universal.zip
+        windows.64: win64.exe.zip
+        windows.32: win32.exe.zip
+        windows.arm64: windows_arm64.exe.zip
+        web: web_editor.zip
+      mono:
+        templates: mono_export_templates.tpz
+        editor:
+          linux.64: mono_linux_x86_64.zip
+          linux.32: mono_linux_x86_32.zip
+          linux.arm64: mono_linux_arm64.zip
+          linux.arm32: mono_linux_arm32.zip
+          macos.universal: mono_macos.universal.zip
+          windows.64: mono_win64.zip
+          windows.32: mono_win32.zip
+          windows.arm64: mono_windows_arm64.zip
+      extras:
+        aar_library: template_release.aar
+
+  # Godot 4.4 beta 3 introduced Android Pico OS builds.
+  - version: 4
+    range:
+      - 4.4-dev2
+      - 4.5-beta2
+    config:
+      templates: export_templates.tpz
+      editor:
+        android.apk: android_editor.apk
+        android.horizonos: android_editor_horizonos.apk
         linux.64: linux.x86_64.zip
         linux.32: linux.x86_32.zip
         linux.arm64: linux.arm64.zip

--- a/_data/download_platforms.yml
+++ b/_data/download_platforms.yml
@@ -48,6 +48,14 @@
     - Meta Quest 3 & Pro
     - arm64
 
+- name: android.picoos
+  title: Pico OS
+  caption: APK - arm64
+  tags:
+    - APK download
+    - PICO 4
+    - arm64
+
 - name: "linux.32"
   title: "Linux"
   caption: "x86_32"


### PR DESCRIPTION
Pico OS downloads were added in 4.4 beta 3, but never got added to the expanded download section like Horizon OS was
<img width="1181" height="149" alt="25-08-31 10-17-13 chrome" src="https://github.com/user-attachments/assets/444034ea-e277-4494-bfbd-68f67e30ae3d" />
Also, `Gemfile.lock` was updated to account for insane people that build & serve the website on a Windows platform (me)