### PR TITLE
[Release 4.5] Fix wrong link for FP16 feature

### DIFF
--- a/collections/_release_4_5/entry-systems-rendering-mobile-renderer-now-using-half-precision-floating-point-format-explicitly.md
+++ b/collections/_release_4_5/entry-systems-rendering-mobile-renderer-now-using-half-precision-floating-point-format-explicitly.md
@@ -17,5 +17,5 @@ text: |
 contributors:
 - name: Darío
   github: DarioSamo
-read_more: https://github.com/godotengine/godot/pull/102330
+read_more: https://github.com/godotengine/godot/pull/107119
 ---


### PR DESCRIPTION
Fixes the wrong link.