### PR TITLE
Two hotfixes for the website

### DIFF
--- a/assets/js/releases/4.5.mjs
+++ b/assets/js/releases/4.5.mjs
@@ -826,7 +826,7 @@ if (intlBlockquote == null) {
 // Source for the translations: https://www.berlitz.com/blog/hello-different-languages
 const intlBlockquoteTextEntries = [
 	{ text: "Hello" }, // en (English)
-	{ text: "مرحبًا", rtl: true }, // ar (Arabic)
+	{ text: "مرحبًا", rtl: true, doNotBreakCharacters: true }, // ar (Arabic)
 	{ text: "你好" }, // zh (Chinese)
 	{ text: "Hallo" }, // nl (Dutch)
 	{ text: "Bonjour" }, // fr (French)
@@ -836,7 +836,7 @@ const intlBlockquoteTextEntries = [
 	{ text: "Ciao" }, // it (Italian)
 	{ text: "こんにちは" }, // ja (Japanese)
 	{ text: "안녕하세요" }, // ko (Korean)
-	{ text: "سلام", rtl: true }, // fa (Persian)
+	{ text: "سلام", rtl: true, doNotBreakCharacters: true }, // fa (Persian)
 	{ text: "Cześć" }, // pl (Polish)
 	{ text: "Olá" }, // pt (Portuguese)
 	{ text: "Oi" }, // pt-BR (Portuguese (Brazil))
@@ -853,6 +853,8 @@ for (const intlBlockquoteTextEntry of intlBlockquoteTextEntries) {
 	entry.classList.add("entry");
 	entry.textContent = intlBlockquoteTextEntry.text;
 	entry.style.direction = intlBlockquoteTextEntry?.rtl ? "rtl" : "ltr";
+	entry.dataset.doNotBreakCharacters =
+		intlBlockquoteTextEntry?.doNotBreakCharacters ?? false;
 	intlBlockquote.append(entry);
 }
 
@@ -864,10 +866,19 @@ const intlBlockquoteTimeline = createTimeline({
 });
 
 for (const intlBlockquoteEntry of intlBlockquoteEntries) {
-	const { chars } = text.split(intlBlockquoteEntry, {
-		chars: { wrap: "clip" },
-	});
-	const entryAnimation = animate(chars, {
+	let elements = null;
+	if (intlBlockquoteEntry.dataset.doNotBreakCharacters === "true") {
+		const { words } = text.split(intlBlockquoteEntry, {
+			words: { wrap: "clip" },
+		});
+		elements = words;
+	} else {
+		const { chars } = text.split(intlBlockquoteEntry, {
+			chars: { wrap: "clip" },
+		});
+		elements = chars;
+	}
+	const entryAnimation = animate(elements, {
 		y: [
 			{ to: ["120%", "0%"] },
 			{ to: "-120%", delay: prefersReducedMotion ? 0 : 750, ease: "in(3)" },

--- a/collections/_article/godot-4-4-a-unified-experience.md
+++ b/collections/_article/godot-4-4-a-unified-experience.md
@@ -3,7 +3,7 @@ title: Godot 4.4, a unified experience
 excerpt: Look forward to plenty of quality of life improvements hidden within this release. Faster load speeds, reduced stutter, streamlined processes — spotting all the optimizations that have been applied in the background will take some time.
 categories: ["release"]
 author: "Godot contributors"
-image: /storage/blog/covers/godot-4-4-a-unified-experience.webp
+image: /storage/blog/covers/godot-4-4-a-unified-experience.webp?cache=v2
 date: 2025-03-03 15:45:00
 redirect_to:
  - /releases/4.4/

--- a/collections/_article/godot-4-5-making-dreams-accessible.md
+++ b/collections/_article/godot-4-5-making-dreams-accessible.md
@@ -3,7 +3,7 @@ title: Godot 4.5, making dreams accessible
 excerpt: From mind-blowing effects now made possible by the stencil buffer to accessibilty descriptions of your GUI elements that opens up the possibility for some with disabilities to play your game — we are proud to present to you Godot 4.5.
 categories: ["release"]
 author: "Godot contributors"
-image: /storage/blog/covers/godot-4-5-making-dreams-accessible.webp
+image: /storage/blog/covers/godot-4-5-making-dreams-accessible.webp?cache=v2
 date: 2025-09-15 20:00:00
 redirect_to:
  - /releases/4.5/

--- a/pages/releases/4.4.html
+++ b/pages/releases/4.4.html
@@ -3,7 +3,7 @@ regenerate: true
 permalink: /releases/4.4/index.html
 title: Godot 4.4, a unified experience
 description: Look forward to plenty of quality of life improvements hidden within this release. Faster load speeds, reduced stutter, streamlined processes - spotting all the optimizations that have been applied in the background will take some time.
-image: /storage/blog/covers/godot-4-4-a-unified-experience.webp
+image: /storage/blog/covers/godot-4-4-a-unified-experience.webp?cache=v2
 layout: release
 
 todo_for_authors_list: >

--- a/pages/releases/4.5.html
+++ b/pages/releases/4.5.html
@@ -3,7 +3,7 @@ regenerate: true
 permalink: /releases/4.5/index.html
 title: Godot 4.5, making dreams accessible
 description: From mind-blowing effects now made possible by the stencil buffer to accessible descriptions of your GUI elements that opens up the possibility for people with disabilities to play your game — we are proud to present to you Godot 4.5.
-image: /storage/blog/covers/godot-4-5-making-dreams-accessible.webp
+image: /storage/blog/covers/godot-4-5-making-dreams-accessible.webp?cache=v2
 layout: release
 
 todo_for_authors_list: >


### PR DESCRIPTION
- Fix animation breaking Arabic + Persian word in the 4.5 release page.
  - Fixes #1163
- Fix cache issue with the 4.4 & 4.5 release thumbnails