### PR TITLE
Fix FR i18n entry for "header.features"

### DIFF
--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1,7 +1,7 @@
 meta:
   description: Développez vos jeux en 2D et 3D, des projets cross-plateformes ou même des applications XR&nbsp;!
 header:
-  features: Fonctions
+  features: Fonctionnalités
   showcase: Vitrine
   blog: Actualités
   community: Communauté


### PR DESCRIPTION
Replace for the FR i18n the term "Fonctions" with "Fonctionnalités" (for "header.features")

"Fonctions" means "Functions" instead of "Features" in this context. Like, it means more "what it does" as a manual tool than as "what it does" as a package. See [la Vitrine linguistique's entry](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/26559312/fonctionnalite) on "functionnalité" as an equivalent term for "feature".

It was flagged to me by @gtibo.