### PR TITLE
style: wrap showcase flip arrows in container for better visibility

### DIFF
--- a/pages/features.html
+++ b/pages/features.html
@@ -202,7 +202,12 @@ layout: default
 		background-color: rgba(0, 0, 0, 0.32);
 		border-radius: 1rem;
 		padding: 1rem;
-	}
+
+		position: absolute;
+		top: 50%;
+		left: 12px;
+		z-index: 5;
+		}
 	.showcase-flip-container:hover{
 		background-color: rgba(0, 0, 0, 0.50);
 	}

--- a/pages/features.html
+++ b/pages/features.html
@@ -199,7 +199,7 @@ layout: default
 	}
 
 	.showcase-flip-container{
-		background-color: rgba(0, 0, 0, 0.31);
+		background-color: rgba(0, 0, 0, 0.32);
 		border-radius: 1rem;
 		padding: 1rem;
 	}

--- a/pages/features.html
+++ b/pages/features.html
@@ -198,6 +198,15 @@ layout: default
 		filter: brightness(0.85) saturate(0.75);
 	}
 
+	.showcase-flip-container{
+		background-color: rgba(0, 0, 0, 0.31);
+		border-radius: 1rem;
+		padding: 1rem;
+	}
+	.showcase-flip-container:hover{
+		background-color: rgba(0, 0, 0, 0.50);
+	}
+
 	.showcase-flip-left,
 	.showcase-flip-right {
 		position: absolute;
@@ -360,9 +369,13 @@ layout: default
 				{% endif %}
 				{% endfor %}
 			</div>
-
-			<div class="showcase-flip-left"></div>
-			<div class="showcase-flip-right"></div>
+		<!-- fix accesibility issue -->
+			<div class="showcase-flip-container">
+				<div class="showcase-flip-left"></div>
+			</div>
+			<div class="showcase-flip-container">
+				<div class="showcase-flip-right"></div>
+			</div>
 		</div>
 
 		<a href="/showcase/" class="btn btn-flat btn-flat-white btn-flat-frosted btn-see-showcase">


### PR DESCRIPTION
Added a `.showcase-flip-container` around the left and right arrows.
This provides padding, rounded background, and hover effect to improve
their contrast and usability.