### PR TITLE
Use our own download server

### DIFF
--- a/_plugins/make_download.rb
+++ b/_plugins/make_download.rb
@@ -3,8 +3,7 @@
 # See `_data/download_configs.yml` for a reference table of slugs.
 
 HOST_TUXFAMILY = "https://downloads.tuxfamily.org/godotengine"
-HOST_GITHUB = "https://github.com/godotengine/godot/releases/download"
-HOST_GITHUB_BUILDS = "https://github.com/godotengine/godot-builds/releases/download"
+HOST_HETZNER = "https://downloads.godotengine.org"
 
 FLAVOR_MATRIX = {
   "dev"    => 1,
@@ -105,10 +104,9 @@ module MakeDownloadFilter
       end
     end
 
-    if host == "github"
-      return "#{HOST_GITHUB}/#{version_name}-#{version_flavor}/#{download_file}"
-    elsif host == "github_builds"
-      return "#{HOST_GITHUB_BUILDS}/#{version_name}-#{version_flavor}/#{download_file}"
+    if host == "github" or host == "github_builds"
+      # Use our custom download API that supports all github builds but will prefer S3 downloads
+      return "#{HOST_HETZNER}?version=#{version_name}&flavor=#{version_flavor}&slug=#{download_slug}&platform=#{platform}"
     elsif host == "tuxfamily"
       if version_flavor == "stable"
         return "#{HOST_TUXFAMILY}/#{version_name}#{mono_slug}/#{download_file}"


### PR DESCRIPTION
This will use the new `downloads.godotengine.org` domain for all github based downloads.

The new service will use our S3 bucket if the file is available there, and fall back to github releases only if the file does not exist in our S3 bucket. This should improve downloads for people in regions where github releases don't work properly or are slow.