### PR TITLE
Update consoles page: RAWRLAB Games can port to Switch 2

### DIFF
--- a/pages/consoles.html
+++ b/pages/consoles.html
@@ -20,7 +20,7 @@ providers:
   - name: RAWRLAB Games
     url: https://www.rawrlab.com/
     image: /assets/images/consoles/rawrlab-games.png
-    platforms: ["switch"]
+    platforms: ["switch", "switch-2"]
   - name: mazette!
     url: https://mazette.games/
     image: /assets/images/consoles/mazette-games.png


### PR DESCRIPTION
I'm Pablo Navarro from RAWRLAB Games.

As mentioned in RAWRLAB Games website ( https://www.rawrlab.com/godot_nintendo_switch_free_port.html ), our Godot Engine ports already run on Nintendo Switch 2. We also offer porting for Nintendo Switch 2.

This is a small update to the consoles page to reflect that.