### PR TITLE
Add switch-2 to the list of supported platforms from W4 Games

### DIFF
--- a/pages/consoles.html
+++ b/pages/consoles.html
@@ -8,7 +8,7 @@ providers:
   - name: W4 Games
     url: https://www.w4games.com/
     image: /assets/images/consoles/w4-games.png
-    platforms: ["switch", "xbox-series", "playstation-5"]
+    platforms: ["switch", "switch-2", "xbox-series", "playstation-5"]
   - name: Lone Wolf Technology
     url: https://www.lonewolftechnology.com/
     image: /assets/images/consoles/lone-wolf.png


### PR DESCRIPTION
W4 games now offers a switch 2 port and joins the ranks of RAWRLAB and Pineapple Works!