### PR TITLE
Fix article links for 4.6 dev1 & dev2

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,11 +1,11 @@
 - name: "4.6"
   flavor: "dev2"
   release_date: "20 October 2025"
-  release_notes: "/article/release-candidate-godot-4-6-dev-2/"
+  release_notes: "/article/dev-snapshot-godot-4-6-dev-2/"
   releases:
     - name: "dev1"
       release_date: "30 September 2025"
-      release_notes: "/article/release-candidate-godot-4-6-dev-1/"
+      release_notes: "/article/dev-snapshot-godot-4-6-dev-1/"
 
 - name: "4.5.1"
   flavor: "stable"


### PR DESCRIPTION
I believe this migh fix #1184