### PR TITLE
Refresh nav style

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -4,216 +4,25 @@ layout: default
 
 {% include header.html %}
 
-<style>
-	body {
-		background-color: var(--background-color);
-	}
+<link rel="stylesheet" href="/assets/css/blog.css">
 
-	h1 {
-		margin-bottom: 8px;
-		margin-top: 32px;
-	}
-
-	:not(pre)>code {
-		background: var(--code-background-color);
-		padding: 1px 4px;
-		font-size: 0.95em;
-		border-radius: 3px;
-	}
-
-	pre {
-		background: var(--codeblock-background-color);
-		color: var(--codeblock-color);
-	}
-
-	pre code {
-		display: block;
-		overflow-x: auto;
-		padding: .5em;
-	}
-
-	.date-big {
-		line-height: 2;
-		margin-left: 32px;
-	}
-
-	article {
-		background-color: var(--base-color);
-		box-shadow: 0px 3px 2px 0px rgba(0, 0, 0, 0.15);
-	}
-
-	figure {
-		margin: 0;
-	}
-
-	figure img {
-		margin: 0;
-	}
-
-	article img,
-	article video {
-		max-width: 100%;
-		height: auto;
-		display: block;
-		margin: auto;
-		margin-top: 16px;
-		margin-bottom: 16px;
-	}
-
-	article h1 {
-		margin-top: 64px;
-	}
-
-	article h2,
-	article h3,
-	article h4 {
-		margin-top: 42px;
-	}
-
-	.article-info {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	.article-metadata {
-		display: flex;
-		gap: 24px;
-		align-items: center;
-		font-family: var(--header-font-family);
-		margin-bottom: 12px;
-	}
-
-	@media (max-width: 900px) {
-		.article-metadata {
-			flex-direction: column;
-			align-items: flex-start;
-			gap: 16px;
-		}
-	}
-
-	.article-author {
-		color: var(--base-color-text-subtitle-date);
-		font-weight: 700;
-		font-size: 18px;
-		flex-grow: 1;
-		display: flex;
-		gap: 12px;
-		align-items: center;
-	}
-
-	.article-author .avatar {
-		border-radius: 100%;
-		margin: 0;
-		background: transparent;
-	}
-
-	.article-author .by {
-		color: var(--base-color-text-subtitle);
-	}
-
-	.article-metadata .date {
-		color: var(--base-color-text-subtitle-date);
-	}
-
-	.article-metadata .date.post-recent-highlight {
-		color: var(--post-recent-highlight-color);
-		opacity: 0.8;
-	}
-
-	.article-metadata .date.post-recent-highlight::after {
-		font-size: 80%;
-		content: "NEW";
-		border: 2px solid var(--post-recent-highlight-color);
-		padding: 2px 3px;
-		margin-left: 8px;
-	}
-
-	.tag.active {
-		filter: saturate(0.75);
-	}
-
-	@media screen and (min-width: 900px) {
-		article .content {
-			width: 70%;
-			margin: auto;
-		}
-	}
-
-	@media (max-width: 900px) {
-		body {
-			background-color: var(--base-color);
-		}
-
-		article {
-			background-color: transparent;
-			box-shadow: none;
-		}
-
-		article img:first-child,
-		article video:first-child {
-			max-width: 100%;
-		}
-	}
-
-	/* Blog previous and next links */
-	.blog-navigation {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		padding-top: 30px;
-		padding-bottom: 60px;
-	}
-
-	.blog-navigation .next {
-		text-align: right;
-	}
-
-	@media (max-width: 900px) {
-		.blog-navigation {
-			grid-template-columns: 1fr;
-			gap: 20px;
-			border-top: 1px solid var(--code-background-color);
-		}
-		.blog-navigation .next {
-			text-align: left;
-		}
-	}
-
-	.blog-navigation span {
-		opacity: 0.6;
-		font-weight: 700;
-		margin-bottom: 5px;
-		display: block;
-	}
-
-	.blog-navigation a {
-		display: inline-block;
-		text-decoration: none;
-		color: inherit;
-		opacity: 0.6;
-		transition: opacity 0.2s;
-	}
-
-	.blog-navigation a:hover {
-		opacity: 1;
-	}
-</style>
+<div class="add-nav-gap"></div>
 
 <link rel="stylesheet" href="/assets/css/highlight.obsidian.min.css">
 <div class="container">
 	<article class="padded">
 		<div class="content article-container">
 			<figure class="article-cover">
+				<img src="{{ page.image }}" title="{{ page.image_caption_title }}"
+				alt="{{ page.image_caption_title }} {{ page.image_caption_description }}" class="rounded-lg"
+				style="width: 100%; height: auto; background-color: transparent;" />
+
 				{% if page.image_caption_title or page.image_caption_description %}
 				<figcaption>
 					<strong>{{ page.image_caption_title }}</strong>
 					<span style="margin-left: 0.75rem; font-size: 90%">{{ page.image_caption_description }}</span>
 				</figcaption>
 				{% endif %}
-
-				<img src="{{ page.image }}" title="{{ page.image_caption_title }}"
-					alt="{{ page.image_caption_title }} {{ page.image_caption_description }}" class="rounded-lg"
-					style="width: 100%; height: auto; background-color: transparent;" />
 			</figure>
 
 			<div class="article-info">
@@ -275,7 +84,7 @@ layout: default
 		window.applyAnchorLinks('.article-body');
 
 		// Add lightbox elements in blog articles for Tobii.
-		document.querySelectorAll('.article-cover img, .article-body img').forEach((articleImg) => {
+		document.querySelectorAll('.article-body img').forEach((articleImg) => {
 			if (articleImg.classList.contains('lightbox-ignore')) {
 				return;
 			}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -66,6 +66,7 @@ collection: article
 </style>
 
 <div class="head">
+	<div class="add-nav-gap"></div>
 	<div class="container flex eqsize responsive">
 		<div class="main">
 			<h1 class="intro-title">Blog</h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,8 +39,8 @@
 	<link rel="alternate" type="application/atom+xml" title="Godot News" href="/atom.xml" />
 	<link rel="icon" href="/assets/favicon.png" sizes="any">
 	<link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
-	<link rel="stylesheet" href="/assets/css/main.css?121">
-	<link rel="stylesheet" href="/assets/css/header.css?6">
+	<link rel="stylesheet" href="/assets/css/main.css?122">
+	<link rel="stylesheet" href="/assets/css/header.css?7">
 	<link rel="stylesheet" href="/assets/css/tobii.min.css">
 	<link rel="preload" as="font" href="/assets/fonts/Montserrat-Italic-VariableFont_wght.woff2" crossorigin>
 	<link rel="preload" as="font" href="/assets/fonts/Montserrat-VariableFont_wght.woff2" crossorigin>

--- a/_layouts/download-3.html
+++ b/_layouts/download-3.html
@@ -5,7 +5,7 @@ layout: default
 
 {% include header.html %}
 
-<link rel="stylesheet" href="/assets/css/transparent-nav.css?2">
+<link rel="stylesheet" href="/assets/css/transparent-nav.css?3">
 <link rel="stylesheet" href="/assets/css/download.css?3">
 <style>
 	.digital-stores .digital-store-list {

--- a/_layouts/download-archive.html
+++ b/_layouts/download-archive.html
@@ -41,6 +41,7 @@ layout: default
 </style>
 
 <div class="hero">
+	<div class="add-nav-gap"></div>
 	<div class="hero-wrapper">
 		<h1>Download<br>Godot {{ page.version_name }} <span class="hero-version-flavor">{{ page.version_flavor }}</span></h1>
 	</div>

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -5,7 +5,7 @@ layout: default
 
 {% include header.html %}
 
-<link rel="stylesheet" href="/assets/css/transparent-nav.css?2">
+<link rel="stylesheet" href="/assets/css/transparent-nav.css?3">
 <link rel="stylesheet" href="/assets/css/download.css?3">
 <style>
 	.hero {

--- a/_layouts/more.html
+++ b/_layouts/more.html
@@ -7,6 +7,7 @@ current_tab: ''
 {% include header.html %}
 
 <div class="head">
+	<div class="add-nav-gap"></div>
 	<div class="container flex eqsize" style="flex-direction: column">
 		<div class="main">
 			<h1 class="intro-title">{{ page.header_text }}</h1>

--- a/_layouts/showcase-item.html
+++ b/_layouts/showcase-item.html
@@ -45,6 +45,7 @@ layout: default
 </style>
 
 <div class="head">
+	<div class="add-nav-gap"></div>
 	<div class="container flex eqsize responsive">
 		<div class="main">
 

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -1,0 +1,202 @@
+body {
+	background-color: var(--background-color);
+}
+
+h1 {
+	margin-bottom: 8px;
+	margin-top: 32px;
+}
+
+:not(pre)>code {
+	background: var(--code-background-color);
+	padding: 1px 4px;
+	font-size: 0.95em;
+	border-radius: 3px;
+}
+
+pre {
+	background: var(--codeblock-background-color);
+	color: var(--codeblock-color);
+}
+
+pre code {
+	display: block;
+	overflow-x: auto;
+	padding: .5em;
+}
+
+.date-big {
+	line-height: 2;
+	margin-left: 32px;
+}
+
+article {
+	background-color: var(--base-color);
+	border-radius: 12px;
+  margin-top: 10px;
+}
+
+figure {
+	margin: 0;
+}
+
+figure img {
+	margin: 0;
+}
+
+article img,
+article video {
+	max-width: 100%;
+	height: auto;
+	display: block;
+	margin: auto;
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+article h1 {
+	margin-top: 64px;
+}
+
+article h2,
+article h3,
+article h4 {
+	margin-top: 42px;
+}
+
+.article-info {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.article-metadata {
+	display: flex;
+	gap: 24px;
+	align-items: center;
+	font-family: var(--header-font-family);
+	margin-bottom: 12px;
+}
+
+@media (max-width: 900px) {
+	.article-metadata {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 16px;
+	}
+}
+
+.article-author {
+	color: var(--base-color-text-subtitle-date);
+	font-weight: 700;
+	font-size: 18px;
+	flex-grow: 1;
+	display: flex;
+	gap: 12px;
+	align-items: center;
+}
+
+.article-author .avatar {
+	border-radius: 100%;
+	margin: 0;
+	background: transparent;
+}
+
+.article-author .by {
+	color: var(--base-color-text-subtitle);
+}
+
+.article-metadata .date {
+	color: var(--base-color-text-subtitle-date);
+}
+
+.article-metadata .date.post-recent-highlight {
+	color: var(--post-recent-highlight-color);
+	opacity: 0.8;
+}
+
+.article-metadata .date.post-recent-highlight::after {
+	font-size: 80%;
+	content: "NEW";
+	border: 2px solid var(--post-recent-highlight-color);
+	padding: 2px 3px;
+	margin-left: 8px;
+}
+
+.tag.active {
+	filter: saturate(0.75);
+}
+
+@media screen and (min-width: 900px) {
+	article .content {
+		width: 70%;
+		margin: auto;
+	}
+}
+
+@media (max-width: 900px) {
+	body {
+		background-color: var(--base-color);
+	}
+
+	article {
+		background-color: transparent;
+		box-shadow: none;
+	}
+
+	article img:first-child,
+	article video:first-child {
+		max-width: 100%;
+	}
+}
+
+/* Blog previous and next links */
+.blog-navigation {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	padding-top: 30px;
+	padding-bottom: 60px;
+}
+
+.blog-navigation .next {
+	text-align: right;
+}
+
+@media (max-width: 900px) {
+	.blog-navigation {
+		grid-template-columns: 1fr;
+		gap: 20px;
+		border-top: 1px solid var(--code-background-color);
+	}
+	.blog-navigation .next {
+		text-align: left;
+	}
+}
+
+.blog-navigation span {
+	opacity: 0.6;
+	font-weight: 700;
+	margin-bottom: 5px;
+	display: block;
+}
+
+.blog-navigation a {
+	display: inline-block;
+	text-decoration: none;
+	color: inherit;
+	opacity: 0.6;
+	transition: opacity 0.2s;
+}
+
+.blog-navigation a:hover {
+	opacity: 1;
+}
+
+figure.article-cover figcaption {
+  opacity: 0.8;
+  text-align: right;
+  margin-top: -13px;
+}
+figure.article-cover figcaption a {
+  color: inherit;
+}

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,57 +1,66 @@
 header {
+  background: none;
+
+  /* Offset the height of the nav */
+  margin-bottom: -64px;
+
   /* Show on top of GodotCon banner (if any). */
   position: relative;
   z-index: 2;
 
   height: 64px;
-  background-color: var(--navbar-background-color);
   display: flex;
   align-items: center;
-  box-shadow: var(--base-shadow);
 
+  
   .container {
+    background-color: var(--navbar-background-color);
     overflow: initial;
 		width: 100%;
+    box-sizing: border-box;
+    padding: 5px;
+		padding-bottom: 4px;
+  	padding-top: 1px;
+		border-radius: 16px;
+		margin-top: 9px;
   }
+
   #logo-link {
-    /* Make the logo's clickable area as tall as for other navigation links. */
-    padding: 0.2rem 0.5rem;
-    padding-top: 6px;
-    margin-left: -9px;
-    padding-right: 15px;
-    margin-right: -23px;
+		position: relative;
+  	top: 3px;
+	}
+
+  header .banner-container {
+    width: 100%;
+    height: min-content;
+    font-family: "Montserrat", sans-serif;
+    .banner {
+      width: 100%;
+      height: 100%;
+      margin: 0.25em 0;
+      text-align: center;
+      font-weight: 400;
+      color: black;
+      gap: 0.25em;
+      .banner-text {
+        display: inline-block;
+        margin: 0 0.25em;
+      }
+      a {
+        font-weight: 600;
+        color: black;
+        text-decoration-color: black;
+      }
+    }
   }
 }
-
-header .container {
-  box-sizing: border-box;
-}
-
-header .banner-container {
-  width: 100%;
-  height: min-content;
-  font-family: "Montserrat", sans-serif;
-}
-
-header .banner-container .banner {
-  width: 100%;
-  height: 100%;
-  margin: 0.25em 0;
-  text-align: center;
-  font-weight: 400;
-  color: black;
-  gap: 0.25em;
-}
-
-header .banner-container .banner .banner-text {
-  display: inline-block;
-  margin: 0 0.25em;
-}
-
-header .banner-container .banner a {
-  font-weight: 600;
-  color: black;
-  text-decoration-color: black;
+@media (max-width: 1200px) {
+  header {
+    .container {
+      border-radius: 0;
+      margin-top: 0;
+    }
+  }
 }
 
 #nav, #nav_head {
@@ -122,8 +131,12 @@ header .banner-container .banner a {
 		font-size: 16px;
 		font-weight: 400;
 		color: var(--navbar-link-color);
-		padding: 1.3175rem 1rem;
 		margin-left: 14px;
+		padding: 12px;
+    position: relative;
+    background-color: transparent;
+    transition: all 0.1s ease;
+    border-radius: 10px;
 	}
 	ul {
 		list-style: none;
@@ -133,6 +146,7 @@ header .banner-container .banner a {
 	}
 	a:hover, #logo-link:hover {
   	background-color: hsla(0, 0%, 50%, 0.1);
+    /* box-shadow: 0 2px 12px -4px #0006; */
 	}
 }
 
@@ -357,6 +371,10 @@ header .banner-container .banner a {
 			user-select: none;
 		}
 	}
+}
+
+.add-nav-gap {
+  padding-top: 64px;
 }
 
 /* Language specific fixes */

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -129,7 +129,7 @@
     --more-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
     --background-color: #202326;
     --navbar-background-color: #333639;
-    --head-background-color: #232f57;
+    --head-background-color: #007bd7;
     --card-background-color: #333639;
     --card-footer-color: #505356;
     --button-background-color: #333639;
@@ -284,8 +284,7 @@ body a {
   color: var(--link-color);
   text-decoration: underline;
   text-decoration-color: var(--link-underline-color);
-  /* Prevent color transitions from being too fast (for epilepsy). */
-  transition: 0.1s filter;
+  transition: 0.5s filter;
 }
 
 body a,
@@ -802,7 +801,7 @@ pre > code {
     width: 3rem;
     padding: 0;
     margin: 0;
-    background-color: var(--pagination-active-color);
+    background-color: #2d2d2d;
     color: var(--primary-color-text-title);
     border-radius: 0;
     img {
@@ -1204,14 +1203,6 @@ article table tbody tr td {
 	article table tbody tr:nth-of-type(odd) {
 		background-color: color-mix(in hsl longer hue, var(--base-color), white 1%);
 	}
-}
-
-figure.article-cover figcaption {
-  opacity: 0.8;
-  line-height: 1.5
-}
-figure.article-cover figcaption a {
-  color: inherit;
 }
 
 section.sponsors .grid {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -43,7 +43,7 @@
   --more-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
   --background-color: #d5daea;
   --navbar-background-color: #ffffff;
-  --head-background-color: var(--primary-color);
+  --head-background-color: #007bd7;
   --card-background-color: #ffffff;
   --card-footer-color: #eeeeee;
   --button-background-color: #ffffff;
@@ -129,7 +129,7 @@
     --more-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
     --background-color: #202326;
     --navbar-background-color: #333639;
-    --head-background-color: #007bd7;
+    --head-background-color: #001728;
     --card-background-color: #333639;
     --card-footer-color: #505356;
     --button-background-color: #333639;

--- a/assets/css/transparent-nav.css
+++ b/assets/css/transparent-nav.css
@@ -1,12 +1,10 @@
----
----
 /* Overwriting nav style */
 header {
-	box-shadow: none;
-	margin-bottom: -70px;
-	background-color: rgba(134, 144, 154, 0.15);
-	-webkit-backdrop-filter: blur(4px);
-	backdrop-filter: blur(4px);
+	.container {
+		backdrop-filter: blur(4px);
+		-webkit-backdrop-filter: blur(4px);
+		background-color: rgba(134,144,154,0.15);
+	}
 }
 
 @media (max-width: 1200px) {

--- a/collections/_showcase/buckshot-roulette.md
+++ b/collections/_showcase/buckshot-roulette.md
@@ -21,7 +21,7 @@ platforms: ["windows", "linux", "switch", "playstation", "xbox"]
 steam: https://store.steampowered.com/app/2835570/Buckshot_Roulette/?curator_clanid=41324400
 
 
-featured_in_home: false
+featured_in_home: true
 ---
 
 ## Shoot Your Friends

--- a/pages/community/community.html
+++ b/pages/community/community.html
@@ -133,6 +133,7 @@ layout: default
 </style>
 
 <div class="head">
+	<div class="add-nav-gap"></div>
 	<div class="container flex eqsize">
 		<div class="main">
 			<h1 class="intro-title">Community</h1>

--- a/pages/consoles.html
+++ b/pages/consoles.html
@@ -41,7 +41,7 @@ providers:
 
 {% include header.html %}
 
-<link rel="stylesheet" href="/assets/css/transparent-nav.css?2" />
+<link rel="stylesheet" href="/assets/css/transparent-nav.css?3" />
 <style>
 	.consoles-wrapper *,
 	.consoles-hero * {

--- a/pages/download/archive.html
+++ b/pages/download/archive.html
@@ -26,6 +26,7 @@ layout: default
 </style>
 
 <div class="hero">
+	<div class="add-nav-gap"></div>
 	<div class="hero-wrapper">
 		<h1>Godot archive</h1>
 

--- a/pages/download/preview.html
+++ b/pages/download/preview.html
@@ -7,7 +7,7 @@ layout: default
 
 {% include header.html %}
 
-<link rel="stylesheet" href="/assets/css/transparent-nav.css?2">
+<link rel="stylesheet" href="/assets/css/transparent-nav.css?3">
 <link rel="stylesheet" href="/assets/css/download.css?2">
 <link rel="stylesheet" href="/assets/css/download-version.css?2">
 <style>

--- a/pages/education.html
+++ b/pages/education.html
@@ -17,6 +17,7 @@ layout: default
 </style>
 
 <div class="head">
+	<div class="add-nav-gap"></div>
 	<div class="container flex eqsize">
 		<div class="main">
 			<h1 class="intro-title">Education</h1>

--- a/pages/events.html
+++ b/pages/events.html
@@ -15,6 +15,7 @@ description: "This page lists the upcoming and previous Godot community events."
 </style>
 
 <div class="head">
+	<div class="add-nav-gap"></div>
 	<div class="container flex eqsize responsive">
 		<div class="main">
 			<h1 class="intro-title">Events</h1>

--- a/pages/features.html
+++ b/pages/features.html
@@ -7,7 +7,7 @@ layout: default
 
 {% include header.html %}
 
-<link rel="stylesheet" href="/assets/css/transparent-nav.css?2">
+<link rel="stylesheet" href="/assets/css/transparent-nav.css?3">
 <style>
 	.features-why {
 		display: flex;

--- a/pages/home.html
+++ b/pages/home.html
@@ -20,7 +20,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 
 {% include header.html %}
 
-<link rel="stylesheet" href="/assets/css/transparent-nav.css?2">
+<link rel="stylesheet" href="/assets/css/transparent-nav.css?3">
 <style>
 	.main-download {
 		display: flex;

--- a/pages/press.html
+++ b/pages/press.html
@@ -8,6 +8,7 @@ layout: default
 {% include header.html %}
 
 <div class="head">
+	<div class="add-nav-gap"></div>
 	<div class="container flex eqsize" style="flex-direction: column">
 		<div class="main">
 			<h1 class="intro-title">Press Kit</h1>

--- a/pages/releases/4.3.html
+++ b/pages/releases/4.3.html
@@ -55,6 +55,7 @@ authors_list: "0x0ACB,8,8|0xafbf,1,1|20kdc,2,2|2nafish117,1,1|31,3,3|398utubzyt,
 
 <div id="top" class="release-header">
 	<div class="release-header-content">
+		<div class="add-nav-gap"></div>
 		<!-- Important to separate `.release-header-content` from `.container`. -->
 		<div class="container">
 			<h1 class="header-main-title"><span class="header-main-title-text">Godot 4.3 RELEASE</span></h1>

--- a/pages/releases/4.4.html
+++ b/pages/releases/4.4.html
@@ -68,6 +68,7 @@ authors_list: "0x0ACB,1,1|0x53A,1,1|0xafbf,1,1|0xcafeb33f,1,1|10Drenth,1,1|2nafi
 <div id="top" class="release-header">
 	<div class="release-header-background"></div>
 	<div class="release-header-content">
+		<div class="add-nav-gap"></div>
 		<!-- Important to separate `.release-header-content` from `.container`. -->
 		<div class="container">
 			<h1 class="header-main-title">

--- a/pages/releases/4.5.html
+++ b/pages/releases/4.5.html
@@ -57,6 +57,7 @@ authors_list: "100gold,1,1|aaronfranke,67,66|aaronjyoder,1,1|aaronp64,25,25|actu
 {% assign download_platforms = site.download %}
 {% assign stable_version = site.data.versions | find: "name", latest_patch %}
 
+<link rel="stylesheet" href="/assets/css/transparent-nav.css?3">
 <link rel="stylesheet" href="/assets/css/material-symbols-outlined.css" />
 <link rel="stylesheet" href="/assets/css/releases/{{release_version_number}}.css" />
 <script type="module" src="/assets/js/releases/{{release_version_number}}.mjs"></script>
@@ -75,6 +76,7 @@ authors_list: "100gold,1,1|aaronfranke,67,66|aaronjyoder,1,1|aaronp64,25,25|actu
 		></video>
 	</div>
 	<div class="release-header-content">
+		<div class="add-nav-gap"></div>
 		<!-- Important to separate `.release-header-content` from `.container`. -->
 		<div class="container">
 			<h1 class="header-main-title">

--- a/pages/showcase/index.html
+++ b/pages/showcase/index.html
@@ -8,6 +8,8 @@ layout: default
 
 {% include header.html %}
 
+<div class="add-nav-gap"></div>
+
 <section id="made_with_godot" class="container padded">
 	<h2>Showreel videos</h2>
 	<p>


### PR DESCRIPTION
This is the first in a series of PRs updating the website

## Changes included
- Update transparent and regular nav style
- Make default nav floating on every page
- Color update on old pages header
- Remove blog box-shadow
- Add transparent nav in 4.5 release page
- Move figcaption to bottom of blog post articles. Closes #1235
- Moved article style to its own css file
- Added Buckshot Roulette as a home featured game

Some screenshots:

<img width="1746" height="1066" alt="image" src="https://github.com/user-attachments/assets/b5a606c7-4666-4e6b-aa86-f911c1210b2a" />

<img width="1741" height="1019" alt="image" src="https://github.com/user-attachments/assets/be64c450-2bf2-4568-8746-1e4eefaf291e" />

<img width="1678" height="1003" alt="image" src="https://github.com/user-attachments/assets/cc24fa8e-0e79-4d20-80d1-372b60d4621e" />

<img width="1716" height="730" alt="image" src="https://github.com/user-attachments/assets/5c22bdef-03aa-4ea7-baf2-cc7ee37b89b6" />

