### PR TITLE
Update link for Godot Toronto community

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -89,8 +89,8 @@ Canada:
       - 43.65348
       - -79.38394
     links:
-      - title: MeetUp
-        url: https://www.meetup.com/Godot-Toronto/
+      - title: Discord
+        url: https://discord.gg/sfsMXfqpZu
   - name: Godot Québec
     coordinates:
       - 45.50318


### PR DESCRIPTION
Replaced MeetUp link with Discord link for Godot Toronto.