### PR TITLE
Fix an author link in 4.6 release page

### DIFF
--- a/pages/releases/4.6.html
+++ b/pages/releases/4.6.html
@@ -2472,7 +2472,7 @@ Those days are over too!</p>
     
 
     
-    <a class="author" href=github.com/syntaxerror247>@Anish Kumar</a>
+    <a class="author" href=https://github.com/syntaxerror247>@Anish Kumar</a>
     
 </div>
     


### PR DESCRIPTION
Currently, clicking on author name points to https://godotengine.org/releases/4.6/github.com/syntaxerror247 instead of GitHub page.

This should fix that