### PR TITLE
Add section links to 4.6 release notes

### DIFF
--- a/assets/css/releases/4.6.css
+++ b/assets/css/releases/4.6.css
@@ -235,6 +235,14 @@ body {
   line-height: 160%;
 }
 
+.card {
+  transition: box-shadow 0.2s ease-out;
+}
+
+.card:target {
+  box-shadow: 2px 3px var(--color-godot-but-darker);
+}
+
 @media (min-width: 620px) {
   #toc-nav{
     left: 2em;

--- a/assets/css/releases/4.6.css
+++ b/assets/css/releases/4.6.css
@@ -27,6 +27,8 @@
   --l: 1.6em;
   --xl: 2.6em;
   --xxl: 4.2em;
+
+  scroll-behavior: smooth;
 }
 
 @font-face {
@@ -225,6 +227,12 @@ body {
       font-weight: 600;
     }
   }
+}
+
+.title a {
+  color: inherit;
+  text-decoration: none;
+  line-height: 160%;
 }
 
 @media (min-width: 620px) {

--- a/pages/releases/4.6.html
+++ b/pages/releases/4.6.html
@@ -82,12 +82,12 @@ permalink: /releases/4.6/index.html
             <a href="https://fund.godotengine.org/" class="btn red">Join the Development Fund</a>
         </div>
         <section id="section-highlights" class="section-header">
-            <h3 class="title">Highlights</h3>
+            <h3 class="title"><a href="#section-highlights">Highlights</a></h3>
         </section>
         <section class="section-body">
             
 
-<div class="card large ">
+<div class="card large " id="new-theme">
     
         
 
@@ -110,7 +110,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Fresh look, fresh focus</p>
+        <h3 class="title"><a href="#new-theme">Fresh look, fresh focus</a>
 </h3>
         <h4 class="subtitle"><p>New editor theme: “Modern”</p>
 </h4>
@@ -149,7 +149,7 @@ permalink: /releases/4.6/index.html
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="jolt">
     
         
 
@@ -185,7 +185,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>We put a bolt on Jolt</p>
+        <h3 class="title"><a href="#jolt">We put a bolt on Jolt</a>
 </h3>
         <h4 class="subtitle"><p>Jolt Physics by default</p>
 </h4>
@@ -219,7 +219,7 @@ permalink: /releases/4.6/index.html
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="dock">
     
         
 
@@ -255,7 +255,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Dock your heart out</p>
+        <h3 class="title"><a href="#dock">Dock your heart out</a>
 </h3>
         <h4 class="subtitle"><p>Movable floatable docks and panels</p>
 </h4>
@@ -292,7 +292,7 @@ permalink: /releases/4.6/index.html
             </div>
             
 
-<div class="card large ">
+<div class="card large " id="ik-bones">
     
         
 
@@ -328,7 +328,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>B-B-B-B Back to the bone</p>
+        <h3 class="title"><a href="#ik-bones">B-B-B-B Back to the bone</a>
 </h3>
         <h4 class="subtitle"><p>Brand new IK framework</p>
 </h4>
@@ -366,7 +366,7 @@ permalink: /releases/4.6/index.html
 </div>
             
 
-<div class="card medium ">
+<div class="card medium " id="new-ssr">
     
         
 
@@ -402,7 +402,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Reflections got real</p>
+        <h3 class="title"><a href="#new-ssr">Reflections got real</a>
 </h3>
         <h4 class="subtitle"><p>Major SSR overhaul</p>
 </h4>
@@ -435,7 +435,7 @@ permalink: /releases/4.6/index.html
 
             
 
-            <div class="gdquest-card card medium">
+            <div class="gdquest-card card medium" id="gdquest">
                 <svg class="logo" version="1.1" viewBox="0 0 52.916666 16.404167" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
                     <g transform="translate(-7.0158 97.66)">
                     <path d="m12.479-96.311-0.77734 0.28516 0.0957 1.2891c-0.27872 0.1533-0.53758 0.33306-0.77734 0.53516l-1.2012-0.5-0.52734 0.62891 0.72266 1.0449c-0.16633 0.27491-0.30326 0.56742-0.41016 0.87305l-1.2695 0.1543-0.13477 0.80273 1.1426 0.54297c0 0.16079 0.00946 0.32283 0.023437 0.48633 0.016628 0.1634 0.041821 0.32496 0.074219 0.48242l-1.0156 0.75195 0.29297 0.75977 1.2754-0.08984c0.16553 0.27939 0.35857 0.53949 0.57617 0.77734l-0.50195 1.1621 0.64062 0.51562 1.0781-0.71875c0.27522 0.15254 0.56725 0.27972 0.87109 0.37695l0.16211 1.2812 0.81836 0.13281 0.58203-1.1836c0.15206-0.0025 0.30688-0.01224 0.46094-0.0293v2e-3l2.2324-0.21484-0.31836-3.1797-2.2324 0.21289 0.09961 0.99023h-2e-3c-1.4049 0.13526-2.655-0.87178-2.793-2.25-0.13788-1.3781 0.8902-2.6048 2.2949-2.7402l2.2324-0.21484-0.21875-2.1914-2.2344 0.21484c-0.1545 0.01266-0.30528 0.03182-0.45508 0.05859zm4.8496 2.6582-0.58398 1.1855c-0.15188 0.0025-0.30475 0.01039-0.45898 0.02734l-2.2324 0.21484 0.21875 2.1914 2.2324-0.21484c0.33403-0.03217 0.67106 9.6e-5 0.99219 0.0957 0.32118 0.09569 0.61951 0.25193 0.87891 0.46094 0.25935 0.20896 0.47468 0.46735 0.63281 0.75781 0.15813 0.29046 0.25627 0.60785 0.28906 0.93555 0.06608 0.66185-0.13812 1.3221-0.56836 1.8359-0.4302 0.51388-1.05 0.83937-1.7246 0.9043l-2.2344 0.2168 0.2207 2.1895 2.2324-0.21484c0.15454-0.01317 0.30573-0.03422 0.45508-0.06055l0.80859 1.0508 0.77539-0.28516-0.09375-1.2891c0.27854-0.15334 0.53771-0.33306 0.77734-0.53516l1.2012 0.5 0.52734-0.62891-0.72266-1.0449c0.16633-0.27495 0.30504-0.56738 0.41211-0.87305l1.2676-0.1543 0.13477-0.80273-1.1445-0.54297c0.0088-0.16074-0.0074-0.32284-0.02148-0.48633-0.01662-0.1634-0.04183-0.32491-0.07422-0.48242l1.0156-0.75195-0.29297-0.76172-1.2734 0.0918c-0.16562-0.27934-0.36052-0.53949-0.57812-0.77734l0.50195-1.1621-0.64062-0.51758-1.0781 0.71875c-0.27531-0.15259-0.5672-0.27772-0.87109-0.375l-0.16211-1.2832z"/>
@@ -474,7 +474,7 @@ permalink: /releases/4.6/index.html
     
 </div>
                 <div class="content">
-                    <h3 class="title">So... what changes for you?</h3>
+                    <h3 class="title"><a href="#gdquest">So... what changes for you?</a></h3>
                     <h4 class="subtitle">Differences you can expect in everyday development</h4>
                     <div class="body">
                         <p>With loads and loads of new features this release, it’s not always easy to tell at a quick glance which ones actually affect what you do day in and day out and which ones don’t.</p>
@@ -493,7 +493,7 @@ permalink: /releases/4.6/index.html
         </section>
 
         <section id="section-general" class="section-header">
-            <h3 class="title">General</h3>
+            <h3 class="title"><a href="#section-general">General</a></h3>
         </section>
 
         <section class="section-body">
@@ -502,10 +502,10 @@ permalink: /releases/4.6/index.html
 
             
 
-<div class="card large ">
+<div class="card large " id="unique-node-ids">
     
     <div class="content">
-        <h3 class="title"><p>A node <em>will</em> remember…</p>
+        <h3 class="title"><a href="#unique-node-ids">A node <em>will</em> remember…</a>
 </h3>
         <h4 class="subtitle"><p>Introducing unique Node IDs</p>
 </h4>
@@ -543,10 +543,10 @@ permalink: /releases/4.6/index.html
 </div>
             
 
-<div class="card 1 ">
+<div class="card 1 " id="libgodot">
     
     <div class="content">
-        <h3 class="title"><p>Godot as a library!</p>
+        <h3 class="title"><a href="#libgodot">Godot as a library!</a>
 </h3>
         <h4 class="subtitle"><p>Introducing LibGodot</p>
 </h4>
@@ -583,7 +583,7 @@ permalink: /releases/4.6/index.html
 
             
 
-<div class="card medium ">
+<div class="card medium " id="private-signals">
     
         
 
@@ -604,7 +604,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Getting mixed signals</p>
+        <h3 class="title"><a href="#private-signals">Getting mixed signals</a>
 </h3>
         <h4 class="subtitle"><p>Hidden underscored signals</p>
 </h4>
@@ -635,7 +635,7 @@ permalink: /releases/4.6/index.html
 
             
 
-<div class="card medium ">
+<div class="card medium " id="turn-2d-tiles">
     
         
 
@@ -671,7 +671,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>When the tile turns</p>
+        <h3 class="title"><a href="#turn-2d-tiles">When the tile turns</a>
 </h3>
         <h4 class="subtitle"><p>Rotatable scene tiles</p>
 </h4>
@@ -704,7 +704,7 @@ permalink: /releases/4.6/index.html
 
             
 
-<div class="card medium ">
+<div class="card medium " id="decoupled-select">
     
         
 
@@ -740,7 +740,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>I just wanna Select!</p>
+        <h3 class="title"><a href="#decoupled-select">I just wanna Select!</a>
 </h3>
         <h4 class="subtitle"><p>Decoupled Select and Transform modes</p>
 </h4>
@@ -773,7 +773,7 @@ permalink: /releases/4.6/index.html
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="grid-map-bresenham">
     
         
 
@@ -809,7 +809,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Mind the gap</p>
+        <h3 class="title"><a href="#grid-map-bresenham">Mind the gap</a>
 </h3>
         <h4 class="subtitle"><p>Bresenham line algorithm for GridMap drawing</p>
 </h4>
@@ -841,7 +841,7 @@ permalink: /releases/4.6/index.html
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="rotation-gizmo">
     
         
 
@@ -877,7 +877,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>However you spin it…</p>
+        <h3 class="title"><a href="#rotation-gizmo">However you spin it…</a>
 </h3>
         <h4 class="subtitle"><p>New rotation gizmo handle for view axis</p>
 </h4>
@@ -913,7 +913,7 @@ permalink: /releases/4.6/index.html
 
             
 
-<div class="card medium ">
+<div class="card medium " id="control-pivot">
     
         
 
@@ -947,7 +947,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Place a pivot</p>
+        <h3 class="title"><a href="#control-pivot">Place a pivot</a>
 </h3>
         <h4 class="subtitle"><p>Set the pivot point more easily for Control nodes</p>
 </h4>
@@ -980,7 +980,7 @@ permalink: /releases/4.6/index.html
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="separate-focus">
     
         
 
@@ -1014,7 +1014,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Click != Focus</p>
+        <h3 class="title"><a href="#separate-focus">Click != Focus</a>
 </h3>
         <h4 class="subtitle"><p>Separated mouse and keyboard focus</p>
 </h4>
@@ -1044,7 +1044,7 @@ permalink: /releases/4.6/index.html
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="control-margin">
     
         
 
@@ -1067,7 +1067,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Zero margin of error</p>
+        <h3 class="title"><a href="#control-margin">Zero margin of error</a>
 </h3>
         <h4 class="subtitle"><p>Visual feedback for MarginContainer nodes</p>
 </h4>
@@ -1101,10 +1101,10 @@ permalink: /releases/4.6/index.html
 
             
 
-<div class="card large ">
+<div class="card large " id="editor-loot">
     
     <div class="content">
-        <h3 class="title"><p>Editor loot drop!</p>
+        <h3 class="title"><a href="#editor-loot">Editor loot drop!</a>
 </h3>
         <h4 class="subtitle"><p>Small editor enhancements with big impact on workflow</p>
 </h4>
@@ -1179,7 +1179,7 @@ permalink: /releases/4.6/index.html
 
             
 
-<div class="card medium ">
+<div class="card medium " id="hover-tabbar">
     
         
 
@@ -1215,7 +1215,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Drag, hover ‘n’ drop</p>
+        <h3 class="title"><a href="#hover-tabbar">Drag, hover ‘n’ drop</a>
 </h3>
         <h4 class="subtitle"><p>Switch tabs on hover while dragging</p>
 </h4>
@@ -1246,7 +1246,7 @@ permalink: /releases/4.6/index.html
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="clickable-files">
     
         
 
@@ -1282,7 +1282,7 @@ permalink: /releases/4.6/index.html
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Error, error on the wall…</p>
+        <h3 class="title"><a href="#clickable-files">Error, error on the wall…</a>
 </h3>
         <h4 class="subtitle"><p>Clickable files in the Output panel</p>
 </h4>
@@ -1315,7 +1315,7 @@ But no more! Godot 4.6 brings two quality-of-life improvements to your bug hunti
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="objectdb-snapshots">
     
         
 
@@ -1336,7 +1336,7 @@ But no more! Godot 4.6 brings two quality-of-life improvements to your bug hunti
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Spot the difference</p>
+        <h3 class="title"><a href="#objectdb-snapshots">Spot the difference</a>
 </h3>
         <h4 class="subtitle"><p>ObjectDB snapshots and diffing for live object tracking</p>
 </h4>
@@ -1369,7 +1369,7 @@ But no more! Godot 4.6 brings two quality-of-life improvements to your bug hunti
             </div>
             
 
-<div class="card medium reverse">
+<div class="card medium reverse" id="resource-previews">
     
         
 
@@ -1405,7 +1405,7 @@ But no more! Godot 4.6 brings two quality-of-life improvements to your bug hunti
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Check it out now</p>
+        <h3 class="title"><a href="#resource-previews">Check it out now</a>
 </h3>
         <h4 class="subtitle"><p>Live previews in the Quick Open dialog</p>
 </h4>
@@ -1438,7 +1438,7 @@ Those days are over too!</p>
         </section>
 
         <section id="section-system" class="section-header">
-            <h3 class="title">Systems</h3>
+            <h3 class="title"><a href="#section-system">Systems</a></h3>
         </section>
 
         <section class="section-body">
@@ -1447,7 +1447,7 @@ Those days are over too!</p>
 
             
 
-<div class="card large ">
+<div class="card large " id="animation-editor">
     
         
 
@@ -1483,7 +1483,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Animation editor goodies</p>
+        <h3 class="title"><a href="#animation-editor">Animation editor goodies</a>
 </h3>
         <h4 class="subtitle"><p>Timeline control and quick action buttons</p>
 </h4>
@@ -1524,7 +1524,7 @@ Those days are over too!</p>
 
             
 
-<div class="card medium ">
+<div class="card medium " id="delta-pck">
     
         
 
@@ -1547,7 +1547,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Patch and play</p>
+        <h3 class="title"><a href="#delta-pck">Patch and play</a>
 </h3>
         <h4 class="subtitle"><p>Delta encoding for Patch PCKs</p>
 </h4>
@@ -1583,7 +1583,7 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="editor-shortcuts">
     
         
 
@@ -1604,7 +1604,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Power-use that editor</p>
+        <h3 class="title"><a href="#editor-shortcuts">Power-use that editor</a>
 </h3>
         <h4 class="subtitle"><p>Add custom keyboard shortcuts through EditorSettings</p>
 </h4>
@@ -1636,7 +1636,7 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="controller-color">
     
         
 
@@ -1672,7 +1672,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Light up your gamepads</p>
+        <h3 class="title"><a href="#controller-color">Light up your gamepads</a>
 </h3>
         <h4 class="subtitle"><p>Foundation for advanced joypad features support</p>
 </h4>
@@ -1709,7 +1709,7 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="faster-textures">
     
         
 
@@ -1732,7 +1732,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Faster than you can say: Texture</p>
+        <h3 class="title"><a href="#faster-textures">Faster than you can say: Texture</a>
 </h3>
         <h4 class="subtitle"><p>Betsy: Convert RGB to RGBA on the GPU</p>
 </h4>
@@ -1762,7 +1762,7 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="improved-lods">
     
         
 
@@ -1785,7 +1785,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>So far, so sharp</p>
+        <h3 class="title"><a href="#improved-lods">So far, so sharp</a>
 </h3>
         <h4 class="subtitle"><p>Component pruning for mesh simplifications</p>
 </h4>
@@ -1819,7 +1819,7 @@ Those days are over too!</p>
 
             
 
-<div class="card medium ">
+<div class="card medium " id="glow-blending">
     
         
 
@@ -1842,7 +1842,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Glow in the dark</p>
+        <h3 class="title"><a href="#glow-blending">Glow in the dark</a>
 </h3>
         <h4 class="subtitle"><p>Improved glow blending defaults</p>
 </h4>
@@ -1873,7 +1873,7 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="agx-parameters">
     
         
 
@@ -1910,7 +1910,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Tone it down</p>
+        <h3 class="title"><a href="#agx-parameters">Tone it down</a>
 </h3>
         <h4 class="subtitle"><p>Configurable AgX tonemapper parameters</p>
 </h4>
@@ -1940,7 +1940,7 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="octahedral-maps">
     
         
 
@@ -1977,7 +1977,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Lighten the load of reflections</p>
+        <h3 class="title"><a href="#octahedral-maps">Lighten the load of reflections</a>
 </h3>
         <h4 class="subtitle"><p>Octahedral maps for reflection and radiance probes</p>
 </h4>
@@ -2011,7 +2011,7 @@ Those days are over too!</p>
             <div class="sub-grid">
             
 
-<div class="card 1 ">
+<div class="card 1 " id="material-debanding">
     
         
 
@@ -2048,7 +2048,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Banding dismissed</p>
+        <h3 class="title"><a href="#material-debanding">Banding dismissed</a>
 </h3>
         <h4 class="subtitle"><p>Material debanding and improved HDR precision</p>
 </h4>
@@ -2084,10 +2084,10 @@ Those days are over too!</p>
 </div>
             
 
-<div class="card 1 ">
+<div class="card 1 " id="mobile-fixes">
     
     <div class="content">
-        <h3 class="title"><p>Mobile mended</p>
+        <h3 class="title"><a href="#mobile-fixes">Mobile mended</a>
 </h3>
         <h4 class="subtitle"><p>Vulkan Mobile crash fixes for Mali and Adreno GPUs</p>
 </h4>
@@ -2126,10 +2126,10 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="csv-translation">
     
     <div class="content">
-        <h3 class="title"><p>1 fish, 2 fishes?</p>
+        <h3 class="title"><a href="#csv-translation">1 fish, 2 fishes?</a>
 </h3>
         <h4 class="subtitle"><p>Improved CSV translation support and template generation</p>
 </h4>
@@ -2163,10 +2163,10 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="cs-translation">
     
     <div class="content">
-        <h3 class="title"><p>Bonjour, C#</p>
+        <h3 class="title"><a href="#cs-translation">Bonjour, C#</a>
 </h3>
         <h4 class="subtitle"><p>C# translation parser support</p>
 </h4>
@@ -2201,7 +2201,7 @@ Those days are over too!</p>
 
             
 
-<div class="card large ">
+<div class="card large " id="android-xr-editor">
     
         
 
@@ -2222,7 +2222,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Headsets <em>in</em> the loop</p>
+        <h3 class="title"><a href="#android-xr-editor">Headsets <em>in</em> the loop</a>
 </h3>
         <h4 class="subtitle"><p>XR Editor support for Android XR devices</p>
 </h4>
@@ -2255,10 +2255,10 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="openxr-1.1">
     
     <div class="content">
-        <h3 class="title"><p>Hello OpenXR 1.1</p>
+        <h3 class="title"><a href="#openxr-1.1">Hello OpenXR 1.1</a>
 </h3>
         <h4 class="subtitle"><p>Native OpenXR 1.1 support</p>
 </h4>
@@ -2288,10 +2288,10 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="openxr-spatial-entities">
     
     <div class="content">
-        <h3 class="title"><p>One API to rule them all</p>
+        <h3 class="title"><a href="#openxr-spatial-entities">One API to rule them all</a>
 </h3>
         <h4 class="subtitle"><p>Support for OpenXR spatial entities</p>
 </h4>
@@ -2324,7 +2324,7 @@ Those days are over too!</p>
         </section>
 
         <section id="section-platforms" class="section-header">
-            <h3 class="title">Platforms</h3>
+            <h3 class="title"><a href="#section-platforms">Platforms</a></h3>
         </section>
 
         <section class="section-body">
@@ -2333,7 +2333,7 @@ Those days are over too!</p>
 
             
 
-<div class="card medium ">
+<div class="card medium " id="scrcpy-support">
     
         
 
@@ -2369,7 +2369,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Coming to a big screen near you</p>
+        <h3 class="title"><a href="#scrcpy-support">Coming to a big screen near you</a>
 </h3>
         <h4 class="subtitle"><p>Scrcpy runs exports in the editor</p>
 </h4>
@@ -2401,7 +2401,7 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="android-gradle">
     
         
 
@@ -2422,7 +2422,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Pronto Gradle</p>
+        <h3 class="title"><a href="#android-gradle">Pronto Gradle</a>
 </h3>
         <h4 class="subtitle"><p>Android editor Gradle build support</p>
 </h4>
@@ -2454,7 +2454,7 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="android-saf">
     
         
 
@@ -2477,7 +2477,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Get <em>specific</em> consent</p>
+        <h3 class="title"><a href="#android-saf">Get <em>specific</em> consent</a>
 </h3>
         <h4 class="subtitle"><p>Storage Access Framework (SAF)</p>
 </h4>
@@ -2511,7 +2511,7 @@ Those days are over too!</p>
 
             
 
-<div class="card medium ">
+<div class="card medium " id="d3d-12">
     
         
 
@@ -2532,7 +2532,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Render parity</p>
+        <h3 class="title"><a href="#d3d-12">Render parity</a>
 </h3>
         <h4 class="subtitle"><p>Direct3D 12 as the new default on Windows</p>
 </h4>
@@ -2567,7 +2567,7 @@ Those days are over too!</p>
 
             
 
-<div class="card medium ">
+<div class="card medium " id="simple-collision-shapes">
     
         
 
@@ -2588,7 +2588,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Abracadabra, mesh to collision shape</p>
+        <h3 class="title"><a href="#simple-collision-shapes">Abracadabra, mesh to collision shape</a>
 </h3>
         <h4 class="subtitle"><p>Turn meshes into collision shapes</p>
 </h4>
@@ -2620,7 +2620,7 @@ Those days are over too!</p>
         </section>
 
         <section id="section-scripting" class="section-header">
-            <h3 class="title">Scripting</h3>
+            <h3 class="title"><a href="#section-scripting">Scripting</a></h3>
         </section>
 
         <section class="section-body">
@@ -2630,7 +2630,7 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="required-arguments">
     
         
 
@@ -2651,7 +2651,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>It’s required if you say it is…</p>
+        <h3 class="title"><a href="#required-arguments">It’s required if you say it is…</a>
 </h3>
         <h4 class="subtitle"><p>Mark object parameters and results as required</p>
 </h4>
@@ -2687,7 +2687,7 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="json-gdextension">
     
         
 
@@ -2708,7 +2708,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>JSON’s here!</p>
+        <h3 class="title"><a href="#json-gdextension">JSON’s here!</a>
 </h3>
         <h4 class="subtitle"><p>JSON-based GDExtension interface</p>
 </h4>
@@ -2744,7 +2744,7 @@ Those days are over too!</p>
 
             
 
-<div class="card medium ">
+<div class="card medium " id="step-out">
     
         
 
@@ -2765,7 +2765,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Get outta that function already</p>
+        <h3 class="title"><a href="#step-out">Get outta that function already</a>
 </h3>
         <h4 class="subtitle"><p>Script debugger: Step Out button</p>
 </h4>
@@ -2796,7 +2796,7 @@ Those days are over too!</p>
             <div class="sub-grid">
                 
 
-<div class="card 2 reverse">
+<div class="card 2 reverse" id="tracing-profilers">
     
         
 
@@ -2819,7 +2819,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>Go all Dick Tracy</p>
+        <h3 class="title"><a href="#tracing-profilers">Go all Dick Tracy</a>
 </h3>
         <h4 class="subtitle"><p>C++ tracing profilers</p>
 </h4>
@@ -2855,7 +2855,7 @@ Those days are over too!</p>
 </div>
                 
 
-<div class="card 1 ">
+<div class="card 1 " id="bbcode-to-markdown">
     
         
 
@@ -2876,7 +2876,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>It’s written in <strong>BOLD</strong></p>
+        <h3 class="title"><a href="#bbcode-to-markdown">It’s written in <strong>BOLD</strong></a>
 </h3>
         <h4 class="subtitle"><p>GDScript LSP: Improved BBCode to Markdown conversion</p>
 </h4>
@@ -2909,7 +2909,7 @@ Those days are over too!</p>
             </div>
             
 
-<div class="card medium ">
+<div class="card medium " id="string-placeholder-highlighting">
     
         
 
@@ -2930,7 +2930,7 @@ Those days are over too!</p>
 </div>
     
     <div class="content">
-        <h3 class="title"><p>I spy with my little eye</p>
+        <h3 class="title"><a href="#string-placeholder-highlighting">I spy with my little eye</a>
 </h3>
         <h4 class="subtitle"><p>String placeholder highlighting</p>
 </h4>


### PR DESCRIPTION
I just went ahead and added the section links I asked for in #1251.

Here's hoping I didn't do this in vain, because this definitely felt auto-generated in some form or another, but I couldn't find what generates it, if anything.

Fixes #1251.