### PR TITLE
Split releases on home page news section

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -53,7 +53,7 @@ home:
   download_latest: Lade die neueste Version herunter
   looking_for: 'Auf der Suche nach <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download der für Langzeit unterstützten Version von Godot 3">Godot 3</a>, unseren <a href="/download/archive">experimentellen Veröffentlichungen</a>, oder <a href="/download/archive">früheren Versionen</a>?'
   latest_news: Aktuelle News (in Englisch)
-  latest_pre_releases: Aktuelle Vorabversionen
+  latest_releases: Aktuelle Veröffentlichungen
   view_all: Alle anzeigen
   more_news: Weitere Nachrichten
   cards:

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -53,6 +53,8 @@ home:
   download_latest: Lade die neueste Version herunter
   looking_for: 'Auf der Suche nach <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download der für Langzeit unterstützten Version von Godot 3">Godot 3</a>, unseren <a href="/download/archive">experimentellen Veröffentlichungen</a>, oder <a href="/download/archive">früheren Versionen</a>?'
   latest_news: Aktuelle News (in Englisch)
+  latest_pre_releases: Aktuelle Vorabversionen
+  view_all: Alle anzeigen
   more_news: Weitere Nachrichten
   cards:
     h2: Eine neue Art, Spiele zu entwickeln

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -54,6 +54,8 @@ home:
   download_latest: Download Latest
   looking_for: 'Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a>, our <a href="/download/archive">experimental releases</a>, or a <a href="/download/archive">previous version</a>?'
   latest_news: Latest news
+  latest_pre_releases: Latest pre-releases
+  view_all: View all
   more_news: More news
   cards:
     h2: A different way to make games

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -54,7 +54,7 @@ home:
   download_latest: Download Latest
   looking_for: 'Looking for <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Download the long-term support version of Godot 3">Godot 3</a>, our <a href="/download/archive">experimental releases</a>, or a <a href="/download/archive">previous version</a>?'
   latest_news: Latest news
-  latest_pre_releases: Latest pre-releases
+  latest_releases: Latest releases
   view_all: View all
   more_news: More news
   cards:

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -54,7 +54,7 @@ home:
   download_latest: Descargar Última Versión
   looking_for: '¿Buscas <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Descarga la versión de soporte a largo plazo de Godot 3">Godot 3</a>, nuestras <a href="/download/archive">versiones experimentales</a>, o una <a href="/download/archive">versión anterior</a>?'
   latest_news: Últimas noticias (en inglés)
-  latest_pre_releases: Últimos pre-releases
+  latest_releases: Últimas versiones
   view_all: Ver todos
   more_news: Más noticias
   cards:

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -54,6 +54,8 @@ home:
   download_latest: Descargar Última Versión
   looking_for: '¿Buscas <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Descarga la versión de soporte a largo plazo de Godot 3">Godot 3</a>, nuestras <a href="/download/archive">versiones experimentales</a>, o una <a href="/download/archive">versión anterior</a>?'
   latest_news: Últimas noticias (en inglés)
+  latest_pre_releases: Últimos pre-releases
+  view_all: Ver todos
   more_news: Más noticias
   cards:
     h2: Una forma diferente de hacer juegos

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -54,6 +54,8 @@ home:
   download_latest: Télécharger la dernière version
   looking_for: 'Vous cherchez <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Téléchargez la version supportée à long terme de Godot 3">Godot 3</a>, des <a href="/download/archive">versions expérimentales</a> ou une <a href="/download/archive">ancienne version</a>&nbsp;?'
   latest_news: Dernières actualités (en anglais)
+  latest_pre_releases: Dernières pré-versions
+  view_all: Voir tout
   more_news: Plus d'actualités
   cards:
     h2: Une manière différente de créer des jeux

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -54,7 +54,7 @@ home:
   download_latest: Télécharger la dernière version
   looking_for: 'Vous cherchez <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Téléchargez la version supportée à long terme de Godot 3">Godot 3</a>, des <a href="/download/archive">versions expérimentales</a> ou une <a href="/download/archive">ancienne version</a>&nbsp;?'
   latest_news: Dernières actualités (en anglais)
-  latest_pre_releases: Dernières pré-versions
+  latest_releases: Dernières versions
   view_all: Voir tout
   more_news: Plus d'actualités
   cards:

--- a/_i18n/ja.yml
+++ b/_i18n/ja.yml
@@ -54,6 +54,8 @@ home:
   download_latest: "最新版をダウンロード"
   looking_for: "<a href='/download/windows/' class='set-os-download-url' data-version='3' title='Download the long-term support version of Godot 3'>Godot 3</a>や<a href='/download/archive'>実験的バージョン</a>、または<a href='/download/archive'>過去のリリース</a>をお探しですか？"
   latest_news: "最新ニュース"
+  latest_pre_releases: "最新のプレリリース"
+  view_all: "すべてを見る"
   more_news: "過去のニュース"
   cards:
     h2: "ゲーム開発の新しいかたち"

--- a/_i18n/ja.yml
+++ b/_i18n/ja.yml
@@ -54,7 +54,7 @@ home:
   download_latest: "最新版をダウンロード"
   looking_for: "<a href='/download/windows/' class='set-os-download-url' data-version='3' title='Download the long-term support version of Godot 3'>Godot 3</a>や<a href='/download/archive'>実験的バージョン</a>、または<a href='/download/archive'>過去のリリース</a>をお探しですか？"
   latest_news: "最新ニュース"
-  latest_pre_releases: "最新のプレリリース"
+  latest_releases: "最新リリース"
   view_all: "すべてを見る"
   more_news: "過去のニュース"
   cards:

--- a/_i18n/ko.yml
+++ b/_i18n/ko.yml
@@ -54,6 +54,8 @@ home:
   download_latest: 최신 다운로드
   looking_for: '<a href="/download/windows/" class="set-os-download-url" data-version="3" title="Godot 3의 장기 지원 버전 다운로드">Godot 3</a>, 우리의 <a href="/download/archive">실험적인 릴리스</a>, 또는 <a href="/download/archive">이전 버전</a>을 찾고 계십니까?'
   latest_news: 최신 뉴스
+  latest_pre_releases: 최신 사전 릴리스
+  view_all: 모두 보기
   more_news: 뉴스 더 보기
   cards:
     h2: 게임을 만드는 다양한 방법

--- a/_i18n/ko.yml
+++ b/_i18n/ko.yml
@@ -54,7 +54,7 @@ home:
   download_latest: 최신 다운로드
   looking_for: '<a href="/download/windows/" class="set-os-download-url" data-version="3" title="Godot 3의 장기 지원 버전 다운로드">Godot 3</a>, 우리의 <a href="/download/archive">실험적인 릴리스</a>, 또는 <a href="/download/archive">이전 버전</a>을 찾고 계십니까?'
   latest_news: 최신 뉴스
-  latest_pre_releases: 최신 사전 릴리스
+  latest_releases: 최신 릴리스
   view_all: 모두 보기
   more_news: 뉴스 더 보기
   cards:

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -54,7 +54,7 @@ home:
   download_latest: Pobierz najnowszy
   looking_for: 'Szukasz <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Pobierz wersję z wsparciem długoterminowym Godota 3">Godota 3</a>, naszych <a href="/download/archive">wydań eksperymentalnych</a> lub <a href="/download/archive">poprzednich wersji</a>?'
   latest_news: Najnowsze wieści
-  latest_pre_releases: Najnowsze pre-releasy
+  latest_releases: Najnowsze wydania
   view_all: Zobacz wszystkie
   more_news: Więcej aktualności
   cards:

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -54,6 +54,8 @@ home:
   download_latest: Pobierz najnowszy
   looking_for: 'Szukasz <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Pobierz wersję z wsparciem długoterminowym Godota 3">Godota 3</a>, naszych <a href="/download/archive">wydań eksperymentalnych</a> lub <a href="/download/archive">poprzednich wersji</a>?'
   latest_news: Najnowsze wieści
+  latest_pre_releases: Najnowsze pre-releasy
+  view_all: Zobacz wszystkie
   more_news: Więcej aktualności
   cards:
     h2: Inny sposób tworzenia gier

--- a/_i18n/pt-br.yml
+++ b/_i18n/pt-br.yml
@@ -54,6 +54,8 @@ home:
   download_latest: Baixar Versão Mais Recente
   looking_for: 'Procurando pelo <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Baixe a versão de suporte de longo prazo do Godot 3">Godot 3</a>, nossas <a href="/download/archive">versões experimentais</a>, ou uma <a href="/download/archive">versão anterior</a>?'
   latest_news: Últimas notícias (em inglês)
+  latest_pre_releases: Últimos pré-lançamentos
+  view_all: Ver todos
   more_news: Mais notícias
   cards:
     h2: Uma maneira diferente de fazer jogos

--- a/_i18n/pt-br.yml
+++ b/_i18n/pt-br.yml
@@ -54,7 +54,7 @@ home:
   download_latest: Baixar Versão Mais Recente
   looking_for: 'Procurando pelo <a href="/download/windows/" class="set-os-download-url" data-version="3" title="Baixe a versão de suporte de longo prazo do Godot 3">Godot 3</a>, nossas <a href="/download/archive">versões experimentais</a>, ou uma <a href="/download/archive">versão anterior</a>?'
   latest_news: Últimas notícias (em inglês)
-  latest_pre_releases: Últimos pré-lançamentos
+  latest_releases: Últimas versões
   view_all: Ver todos
   more_news: Mais notícias
   cards:

--- a/_i18n/zh-cn.yml
+++ b/_i18n/zh-cn.yml
@@ -53,7 +53,7 @@ home:
   download_latest: 下载最新版
   looking_for: '想找 <a href="/download/windows/" class="set-os-download-url" data-version="3" title="下载 Godot 3 的长期支持版本">Godot 3</a>，<a href="/download/archive">测试版本</a>或是<a href="/download/archive">历史版本</a>？'
   latest_news: 最新消息
-  latest_pre_releases: 最新预发布版本
+  latest_releases: 最新版本
   view_all: 查看全部
   more_news: 更多消息
   cards:

--- a/_i18n/zh-cn.yml
+++ b/_i18n/zh-cn.yml
@@ -53,6 +53,8 @@ home:
   download_latest: 下载最新版
   looking_for: '想找 <a href="/download/windows/" class="set-os-download-url" data-version="3" title="下载 Godot 3 的长期支持版本">Godot 3</a>，<a href="/download/archive">测试版本</a>或是<a href="/download/archive">历史版本</a>？'
   latest_news: 最新消息
+  latest_pre_releases: 最新预发布版本
+  view_all: 查看全部
   more_news: 更多消息
   cards:
     h2: 制作游戏的独特方式

--- a/_i18n/zh-tw.yml
+++ b/_i18n/zh-tw.yml
@@ -53,7 +53,7 @@ home:
   download_latest: 下載最新版
   looking_for: '正在尋找 <a href="/download/windows/" class="set-os-download-url" data-version="3" title="下載 Godot 3 的長期支援版本">Godot 3</a>、我們的<a href="/download/archive">實驗性版本</a>，或是一個<a href="/download/archive">歷史版本</a>？'
   latest_news: 最近新聞
-  latest_pre_releases: 最近預發布版本
+  latest_releases: 最近版本
   view_all: 查看全部
   more_news: 更多新聞
   cards:

--- a/_i18n/zh-tw.yml
+++ b/_i18n/zh-tw.yml
@@ -53,6 +53,8 @@ home:
   download_latest: 下載最新版
   looking_for: '正在尋找 <a href="/download/windows/" class="set-os-download-url" data-version="3" title="下載 Godot 3 的長期支援版本">Godot 3</a>、我們的<a href="/download/archive">實驗性版本</a>，或是一個<a href="/download/archive">歷史版本</a>？'
   latest_news: 最近新聞
+  latest_pre_releases: 最近預發布版本
+  view_all: 查看全部
   more_news: 更多新聞
   cards:
     h2: 製作遊戲的另一種方式

--- a/pages/home.html
+++ b/pages/home.html
@@ -181,7 +181,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 		margin: 0;
 	}
 
-	.pre-releases {
+	.release-posts {
 		grid-template-columns: 1fr 1fr;
 		article.article-card.row {
 			grid-template-columns: 110px 1fr;
@@ -211,7 +211,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 		.news-list .button-container {
 			text-align: left;
 		}
-		.pre-releases {
+		.release-posts {
 			grid-template-columns: 1fr;
 		}
 	}
@@ -299,16 +299,16 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 </section>
 
 <section class="container padded">
-	<h2>{% t home.latest_pre_releases %}</h2>
+	<h2>{% t home.latest_releases %}</h2>
 	<div class="flex eqsize responsive" style="gap: 30px;">
 
 		{% assign latest_releases = site.article
 			| sort: "date"
 			| reverse
-			| where_exp: "post", "post.categories contains 'pre-release'"
+			| where_exp: "post", "post.categories contains 'pre-release' or post.categories contains 'release'"
 		%}
 		<div class="news-list">
-			<div class="pre-releases" style="display: grid; gap: 18px;">
+			<div class="release-posts" style="display: grid; gap: 18px;">
 				{% for post in latest_releases limit:6 offset:0 %}
 				{% if post != posts[0] %}
 				<a href="{{ post.url }}" style="text-decoration: none;">
@@ -324,7 +324,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 				{% endfor %}
 			</div>
 			<div class="button-container" style="margin-top: 10px;">
-				<a href="/blog/pre-release/" class="btn no-margin">{% t home.view_all %}</a>
+				<a href="/download/archive/" class="btn no-margin">{% t home.view_all %}</a>
 			</div>
 		</div>
 	</div>

--- a/pages/home.html
+++ b/pages/home.html
@@ -181,6 +181,14 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 		margin: 0;
 	}
 
+	.pre-releases {
+		grid-template-columns: 1fr 1fr;
+		article.article-card.row {
+			grid-template-columns: 110px 1fr;
+		}
+	}
+	
+
 	@media (max-width: 900px) {
 		.features-grid {
 			grid-template-columns: 1fr;
@@ -202,6 +210,9 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 	@media (max-width: 768px) {
 		.news-list .button-container {
 			text-align: left;
+		}
+		.pre-releases {
+			grid-template-columns: 1fr;
 		}
 	}
 </style>
@@ -244,7 +255,12 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 	<h2>{% t home.latest_news %}</h2>
 	<div class="flex eqsize responsive" style="gap: 30px;">
 
-		{% assign latest_posts = site.article | sort:"date" | reverse %}
+		{% assign latest_posts = site.article
+			| where_exp: "post", "post.categories contains 'news' or post.categories contains 'progress-report' or post.categories contains 'events' or post.categories contains 'showcase' or post.categories contains 'release'"
+			| sort: "date"
+			| reverse
+		%}
+
 		{% for post in latest_posts limit:1 %}
 		<a href="{{ post.url }}" style="text-decoration: none">
 			<article class="article-card">
@@ -277,6 +293,38 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "zh-cn", "zh-tw"]
 				<div class="button-container">
 					<a href="/blog/" class="btn no-margin">{% t home.more_news %}</a>
 				</div>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section class="container padded">
+	<h2>{% t home.latest_pre_releases %}</h2>
+	<div class="flex eqsize responsive" style="gap: 30px;">
+
+		{% assign latest_releases = site.article
+			| sort: "date"
+			| reverse
+			| where_exp: "post", "post.categories contains 'pre-release'"
+		%}
+		<div class="news-list">
+			<div class="pre-releases" style="display: grid; gap: 18px;">
+				{% for post in latest_releases limit:6 offset:0 %}
+				{% if post != posts[0] %}
+				<a href="{{ post.url }}" style="text-decoration: none;">
+					<article class="article-card row">
+						<div class="thumbnail" style="background-image: url('{{ post.image }}');" href="{{ post.url }}"></div>
+						<div>
+							<h3>{{ post.title }}</h3>
+							<span class="date" data-post-date="{{ post.date }}">{{ post.date | date: "%e %B %Y" }}</span>
+						</div>
+					</article>
+				</a>
+				{% endif %}
+				{% endfor %}
+			</div>
+			<div class="button-container" style="margin-top: 10px;">
+				<a href="/blog/pre-release/" class="btn no-margin">{% t home.view_all %}</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Since we publish way more pre-releases than anything else, it is very common for them to be hiding our regular blog posts. This change splits the home page section into news + releases, and pre-releases + releases:

<img width="1460" height="1169" alt="image" src="https://github.com/user-attachments/assets/90e1a587-2528-436c-a514-769221dc8c25" />


This is just the first step in many changes we are experimenting to refresh how we present new snapshots. 

I had to create two localization keys so if you speak any of the languages we currently support please make sure to review those translations as well, they are currently automatic. 