### PR TITLE
Added the div.add-nav-gap to user-groups.html (avoid overlap top menu)

### DIFF
--- a/pages/community/user-groups.html
+++ b/pages/community/user-groups.html
@@ -9,6 +9,7 @@ layout: default
 
 <main>
 	<div class="head">
+		<div class="add-nav-gap"></div>
 		<div class="container flex eqsize">
 			<div class="main">
 				<h1 class="intro-title">User Groups</h1>


### PR DESCRIPTION
Add spacing offset (.add-nav-gap) in user-groups.html to avoid header overlapping content
