### PR TITLE
Update ZenVoid Madrid user group information

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -403,13 +403,13 @@ Spain:
         url: https://discord.com/invite/fp4Z7QmZGu
       - title: Facebook
         url: https://www.facebook.com/GodotEngineEnEspanol
-  - name: Zenvoid (Medialab Prado)
+  - name: Zenvoid
     coordinates:
-      - 40.4105013
-      - -3.6958529
+      -40.4085505
+      -3.6171139
     links:
       - title: Website
-        url: https://www.medialab-prado.es/actividades/zenvoid-studio-desarrollo-de-videojuegos
+        url: https://zenvoid-studio.com/
   - name: Todogodot
     links:
       - title: Telegram

--- a/pages/community/user-groups.html
+++ b/pages/community/user-groups.html
@@ -9,6 +9,7 @@ layout: default
 
 <main>
 	<div class="head">
+		<div class="add-nav-gap"></div>
 		<div class="container flex eqsize">
 			<div class="main">
 				<h1 class="intro-title">User Groups</h1>


### PR DESCRIPTION
Refresh contact information and geographic data for ZenVoid Spanish user group (Madrid)