### PR TITLE
Add a line to the 4.7-dev2 post about how to disable the monospace font for code symbols in the editor

### DIFF
--- a/collections/_article/dev-snapshot-godot-4-7-dev-2.md
+++ b/collections/_article/dev-snapshot-godot-4-7-dev-2.md
@@ -37,6 +37,8 @@ The editor got quite a lot of QOL love this snapshot, as [Malcolm Anderson](http
 <img src="/storage/blog/dev-snapshot-godot-4-7-dev-2/monospace-font-property.webp" alt="Monospaced fonts in property"/>
 <img src="/storage/blog/dev-snapshot-godot-4-7-dev-2/monospace-font-signal.webp" alt="Monospaced fonts in connection"/>
 
+Prefer the regular font for these spots in the editor? No problem! Simply disable **Interface > Theme > Use Monospace Font for Editor Symbols** in the Editor Settings.
+
 ### Animation: Collapse groups in animation track editor
 
 Malcolm isn't done yet, as the animation track editor got some love in [GH-113479](https://github.com/godotengine/godot/pull/113479), enabling users to collapse groups. This simple change should immediately resonate with users dealing with the absurd sizes animation trees can reach, though the benefits can be felt at all sizes.


### PR DESCRIPTION
A user [was not a fan of the monospace font in editor and wanted to disable it](https://github.com/godotengine/godot/pull/112219#issuecomment-3999233275). The feature is optional (can be disabled via the Editor Settings), but it was not made clear anywhere. During the PR's development, it was brought up that users may want to disable it, whether for aesthetic reasons or screen-space ones (i.e., the monospace font makes text strings wider and may not fit well on smaller screens.) Thus, it is important that users know they can disable it if they wish.

This PR adds a line to the 4.7-dev2 blog post explaining how to disable it.