### PR TITLE
remove itch.io link for KinitoPET

### DIFF
--- a/collections/_showcase/kinitopet.md
+++ b/collections/_showcase/kinitopet.md
@@ -21,7 +21,6 @@ youtube_id: "6C2O1rzhKls"
 platforms: ["windows"]
 
 steam: https://store.steampowered.com/app/2075070/KinitoPET/?curator_clanid=41324400
-itch: https://kinito-interactive.itch.io/kinitopet
 
 featured_in_home: false
 


### PR DESCRIPTION
The only official download for KinitoPET is on Steam page where you can obtain the game legally. The itch.io version may contain malware which is a huge risk if someone downloads this as its directly from the godots official website,, if it doesnt have malware then its still considered piracy either way. Troy's website/portfolio [https://l-l.dev/] does NOT include this version so im sure that this isnt official.