### PR TITLE
Fix Windows PR link in HDR output article

### DIFF
--- a/collections/_article/hdr-output-arrives-in-godot-4-7.md
+++ b/collections/_article/hdr-output-arrives-in-godot-4-7.md
@@ -77,7 +77,7 @@ Thanks to [Allen Pestaluky](https://github.com/allenwp), [Josh Jones](https://gi
 
 ## References
 
-- [Pull request for Windows](https://github.com/godotengine/godot/pull/102987)
+- [Pull request for Windows](https://github.com/godotengine/godot/pull/94496)
 - [Pull request for macOS, iOS, and visionOS](https://github.com/godotengine/godot/pull/106814)
 - [Pull request for Linux/Wayland](https://github.com/godotengine/godot/pull/102987)
 - [Demo project pull request](https://github.com/godotengine/godot-demo-projects/pull/1287)


### PR DESCRIPTION
Looks like the HDR output article links to the Linux PR twice.