### PR TITLE
Fix logo license link in Press Kit

### DIFF
--- a/pages/press.html
+++ b/pages/press.html
@@ -24,7 +24,7 @@ layout: default
 		from better scaling and lower file sizes.
 	</p>
 	<p>
-		<a href="https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.txt">Godot logos are licensed under Creative
+		<a href="https://github.com/godotengine/godot/blob/master/misc/logo/LICENSE.txt">Godot logos are licensed under Creative
 			Commons Attribution 4.0 International.</a>
 	</p>
 


### PR DESCRIPTION
* This closes https://github.com/godotengine/godot-website/issues/1321.

