### PR TITLE
Add GABE to Android download page

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -250,6 +250,25 @@ layout: default
 				</p>
 			</div>
 
+			{% if page.platform == 'Android' %}
+				<div class="other-download-card" id="gabe">
+					{% assign gabe_info = site.data.download_platforms | find: "name", "gabe" %}
+
+					<h3>Godot Android Build Environment (GABE)</h3>
+					<p>Separate app required to export Android projects from the Android or XR editor. This app is only necessary when exporting with Gradle; it is not required for non-Gradle exports or when exporting to other platforms.</p>
+					<p>
+						<a href="https://play.google.com/store/apps/details?id=org.godotengine.godot_gradle_build_environment">Google Play Store</a> -
+						<a href="https://www.meta.com/experiences/gabe/26529365196759917">Meta Horizon Store</a>
+					</p>
+					<p>Also available as a direct APK download (no automatic updates):</p>
+					<p>
+						<a href="https://github.com/godotengine/android-editor-buildenv-app/releases/latest/download/gabe-android.apk">Android</a> -
+						<a href="https://github.com/godotengine/android-editor-buildenv-app/releases/latest/download/gabe-horizonos.apk">Horizon OS</a> -
+						<a href="https://github.com/godotengine/android-editor-buildenv-app/releases/latest/download/gabe-picoos.apk">Pico OS</a>
+					</p>
+				</div>
+			{% endif %}
+
 		</div>
 	</div>
 


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-website/issues/1339.

## Preview

It's displayed in the *Other Godot downloads* section, but only when the Android download page is being viewed (as it's not relevant for other platforms):

<img width="603" height="424" alt="image" src="https://github.com/user-attachments/assets/636dc806-dce5-41ba-850a-1e78ce1f4b6c" />

It could be moved to the main section with the editor, but the data source isn't designed to accomodate something with a different versioning scheme. Also, from an UI perspective, it could lead to some people downloading GABE instead of the editor.