### PR TITLE
Add "Godot Portugal" community

### DIFF
--- a/_data/communities.yml
+++ b/_data/communities.yml
@@ -354,9 +354,7 @@ Portugal:
   - name: Godot Portugal
     links:
       - title: Discord
-        url: https://discord.gg/nWMbpsFf
-      - title: Twitter
-        url: https://twitter.com/godot_pt
+        url: https://discord.gg/Xr6bjmaGEY
 Russia:
   - name: Godot Engine Russia
     links:


### PR DESCRIPTION
Replaces the defunct "Godot Portugal" links with ones from a new community group of the same name.

The old Discord server link has been dead for quite some years now, and the Twitter handle is also empty. From what I know, the original creator of this community just "vanished", and the community became stagnant.

We are preparing a new community of portuguese Godot users, thus re-using the same "Godot Portugal" name.