### PR TITLE
Update governance page to match current structure:

### DIFF
--- a/pages/governance.html
+++ b/pages/governance.html
@@ -36,8 +36,10 @@ current_tab: "governance"
 	<p>The Board of Directors currently consists of the following members:</p>
 	<ul>
 		<li>Ariel Manzur — <em>ariel@godotengine.org</em></li>
+		<li>Aurélien Condomines — <em>a.condomines@godotengine.org</em></li>
 		<li>Bastiaan Olij — <em>bastiaan@godotengine.org</em></li>
 		<li>Clay John — <em>clay@godotengine.org</em></li>
+		<li>Fredia Huya-Kouadio — <em>fhuya@godotengine.org</em></li>
 		<li>George Marques — <em>george@godotengine.org</em></li>
 		<li>HP van Braam — <em>hp@godotengine.org</em></li>
 		<li>Juan Linietsky — <em>juan@godotengine.org</em></li>
@@ -45,17 +47,9 @@ current_tab: "governance"
 		<li>Rémi Verschelde — <em>remi@godotengine.org</em></li>
 	</ul>
 
-	<h3 id="advisors">Advisors</h3>
-	<p>
-		The Board has enlisted the help of its most trusted and veteran contributors whom they call <em>the advisors</em>. The advisors are consulted on usage of funds as well as institutional matters. It is important to note, however, that while the advice of the advisory panel is weighed heavily, the final authority on these matters remains with the Board. In practice, the Board rarely makes an important decision without at least discussing it with the advisors first.
-	</p>
-	<p>
-		Like the Board, contributors do not apply to become advisors. Instead the process of joining the advisors group is organic; trusted contributors may be asked to join after showing dedication, expertise, and leadership within the Godot community.
-	</p>
-
 	<h3 id="funding-decisions">Funding decisions</h3>
 	<p>
-		All donations and sponsorships go directly to the Godot Foundation. The Board makes all decisions on how the funds are used, following rules established by the Foundation. These rules dictate that funding can only be used for the benefit of the project. Usage of funds generally includes:
+		All donations and sponsorships go directly to the Godot Foundation. The Board makes all decisions on how the funds are used by following rules established by the Foundation. These rules dictate that funding can only be used for the benefit of the project. Usage of funds generally includes:
 	</p>
 	<ul>
 		<li>Hiring contributors</li>
@@ -65,18 +59,17 @@ current_tab: "governance"
 	</ul>
 
 	<p>
-		At the end of each operating year the Foundation publishes audited financial statements outlining funds received, and how such funds were used in that year. Financial reports take time to prepare and audit, as such they are not available immediately at year end. They are available on the <a href="https://godot.foundation">Foundation's website</a> as soon as feasible after they are prepared.
+		At the end of each operating year the Foundation prepares audited financial statements outlining funds received, and how such funds were used in that year. Financial reports take time to prepare and audit, as such they are not available immediately at year end. They are available on the <a href="https://godot.foundation">Foundation's website</a> as soon as feasible after they are prepared.
 	</p>
 
 	<h3 id="technical-decisions">Technical decisions</h3>
-	<p>Technical decisions are made by Area Owners and the project leaders. Godot has the following established roles:</p>
-	<h4 id="leadership">Leadership</h4>
-	<ul>
-		<li>Juan Linietsky — Technical and Project Lead</li>
-		<li>Rémi Verschelde — Project Manager</li>
-	</ul>
+	<p>Technical decisions are made by Area Owners and the Technical Leadership Committee.</p>
+	<h4 id="leadership">Technical Leadership Committee</h4>
 	<p>
-		The project leaders have final say on all code merges. In theory, this means the leaders will have the final say when maintainers cannot agree. In practice, this authority rarely needs to be invoked because decisions are made by maintainers in consultation with the community.
+		The Technical Leadership Committee (TLC) is made up of veteran Godot maintainers who have deep experience with the engine internals and are area owners over their respective areas.
+	</p>
+	<p>
+		The Technical Leadership Committee has the final say on all code merges. In theory, this means the TLC will have the final say when maintainers cannot agree. In practice, this authority rarely needs to be invoked because decisions are made by maintainers in consultation with the community. The TLC mostly serves as a resource for area maintainers to seek help in making particularly difficult technical decisions.
 	</p>
 
 	<h4 id="teams-and-area-owners">Teams and area owners</h4>


### PR DESCRIPTION
- new board members
- No advisory committee
- TLC replaces leadership roles