### PR TITLE
Fix before/after comparison sliders not draggable on touchscreens

### DIFF
--- a/assets/css/releases/components/media_block.css
+++ b/assets/css/releases/components/media_block.css
@@ -72,6 +72,7 @@
     position: relative;
     width: 100%;
     height: 100%;
+    touch-action: pan-y pinch-zoom;
     img{
       user-select: none;
       pointer-events: none;


### PR DESCRIPTION
On the release pages, the before/after image comparison sliders can't be dragged properly on touchscreens. The browser interprets the drag as a page scroll and cancels the pointer event.

Adding `touch-action: pan-y pinch-zoom` to the `.media-compare` element fixes it. Vertical page scrolling and pinch zoom still work as normal, but horizontal drag is handled by the element itself. 

Here is a short video showing the bug and the fixed version:

https://github.com/user-attachments/assets/f4ab795f-7a9c-4ec5-a3a6-35a857ee77ea


