### PR TITLE
Fix (for good) the comparison slider mobile issues

### DIFF
--- a/assets/css/releases/components/media_block.css
+++ b/assets/css/releases/components/media_block.css
@@ -73,6 +73,10 @@
     width: 100%;
     height: 100%;
     touch-action: pan-y pinch-zoom;
+	* {
+		pointer-events: none;
+		user-select: none;
+	}
     img{
       user-select: none;
       pointer-events: none;

--- a/assets/js/releases/media_compare.js
+++ b/assets/js/releases/media_compare.js
@@ -1,46 +1,105 @@
 (()=>{
-
-    function clamp(number, min, max) {
-        return Math.max(min, Math.min(number, max));
+    function clamp(pNumber, pMin, pMax) {
+        return Math.max(pMin, Math.min(pNumber, pMax));
     }
 
+    const compareBlocks = Array.from(document.querySelectorAll(".media-compare"));
 
-    let compareBlocks = document.querySelectorAll(".media-compare");
+    for (const compareBlock of compareBlocks) {
+        const slider = compareBlock.querySelector(".slider");
+        const beforeBlock = compareBlock.querySelector(".before");
+		let compareBlockData = {
+			isPressing: false,
+			requestAnimationFrameId: -1,
+			event: null,
+		};
 
-    compareBlocks.forEach((compareBlock) => {
-        let slider = compareBlock.querySelector(".slider");
-        let beforeBlock = compareBlock.querySelector(".before");
+		const cancelAnimationFrameRequest = () => {
+			if (compareBlockData.requestAnimationFrameId === -1) {
+				return;
+			}
+			window.cancelAnimationFrame(compareBlockData.requestAnimationFrameId);
+			compareBlockData.requestAnimationFrameId = -1;
+		};
 
-        let onMouseEvent = function(e){
-            let mousePressed = e.buttons == 1;
-            if (!mousePressed) return;
+        const onPointerEvent = (pEventName, pEvent) => {
+			const eventIs = {
+				touch: pEventName.startsWith("touch"),
+				move: pEventName.endsWith("move"),
+				up: pEventName.endsWith("up"),
+				down: pEventName.endsWith("down"),
+			};
 
-            e.stopPropagation();
-            e.preventDefault();
+			if (compareBlockData.isPressing) {
+				if (eventIs.up) {
+					compareBlockData.isPressing = false;
+				}
+			} else {
+				if (eventIs.down) {
+					compareBlockData.isPressing = true;
+				}
+			}
 
-            let percent = clamp(e.layerX / compareBlock.clientWidth, 0.0, 1.0) * 100.0;
+			if (!compareBlockData.isPressing) {
+				cancelAnimationFrameRequest();
+				return;
+			}
 
-            if(percent < 10) {
+            pEvent.stopPropagation();
+            pEvent.preventDefault();
+
+			// Do nothing if it's a touch PointerEvent.
+			// We handle the logic with TouchEvent.
+			if (!eventIs.touch && pEvent.touchType === "touch") {
+				return;
+			}
+
+			if (eventIs.move) {
+				compareBlockData.event = pEvent;
+
+				if (compareBlockData.requestAnimationFrameId === -1) {
+					compareBlockData.requestAnimationFrameId = window.requestAnimationFrame(() => {
+						compareBlockData.requestAnimationFrameId = -1;
+						const event = compareBlockData.event;
+						compareBlockData.event = null;
+
+						if (event == null || !compareBlockData.isPressing) {
+							return;
+						}
+
+						updateComparisonBlock(event);
+					});
+				}
+				return;
+			}
+
+			updateComparisonBlock(pEvent);
+        };
+
+		const updateComparisonBlock = (pEvent) => {
+            let percent = clamp(pEvent.layerX / compareBlock.clientWidth, 0.0, 1.0) * 100.0;
+            if (percent < 10) {
                 percent = 0;
                 compareBlock.classList.add("transition");
-            }else if(percent > 90) {
+            } else if (percent >= 90) {
                 percent = 100;
                 compareBlock.classList.add("transition");
-            }else{
-                if(compareBlock.classList.contains("transition")){
+            } else {
+                if (compareBlock.classList.contains("transition")){
                     compareBlock.classList.remove("transition");
                 }
-            };
+            }
 
             slider.style.left = `${percent}%`;
             beforeBlock.style.clipPath = `inset(0 ${100.0 - percent}% 0 0)`;
-        }
+		};
 
-        compareBlock.addEventListener("pointerdown", onMouseEvent);
-        compareBlock.addEventListener("pointermove", onMouseEvent);
+		for (const eventNameSuffix of ["down", "up", "move"]) {
+			let eventName = `pointer${eventNameSuffix}`;
+			compareBlock.addEventListener(eventName, onPointerEvent.bind(null, eventName), { passive: false });
 
-
-
-
-    });
+			eventName = `touch${eventNameSuffix}`;
+			compareBlock.addEventListener(eventName, onPointerEvent.bind(null, eventName), { passive: false });
+		}
+    }
 })();


### PR DESCRIPTION
Follow-up to #1372

This definitely fixes the release page comparison slider issues as it makes sure to prevent the default behavior of the touch events emitted.

Now, when dragging the slider, the scrolling is completely disabled.