### PR TITLE
[GH workflows] Update Ruby from 3.2 to 4.0

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,10 +18,10 @@ jobs:
 
     # Configure the build environment.
 
-    - name: Install Ruby 3.2
+    - name: Install Ruby 4.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: '4.0'
         # Runs 'bundle install' and caches installed gems automatically
         bundler-cache: true
 

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -23,10 +23,10 @@ jobs:
 
     # Configure the build environment.
 
-    - name: Install Ruby 3.2
+    - name: Install Ruby 4.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: '4.0'
         # Runs 'bundle install' and caches installed gems automatically
         bundler-cache: true
 


### PR DESCRIPTION
As we transitioned pretty much to Ruby 4.0 to build the website, why not update the GitHub workflow installs too.

I think it depends on #1346.