### PR TITLE
fix(blog): render markdown in news preview excerpts

### DIFF
--- a/_includes/download/version-card.html
+++ b/_includes/download/version-card.html
@@ -20,7 +20,7 @@
 					<div class="notes-summary">
 						<div class="notes-thumbnail" style="background-image: url('{{ release_article.image }}');"></div>
 						<div class="notes-excerpt">
-							{{ release_article.excerpt }}
+							{{ release_article.excerpt | markdownify | remove_first: '<p>' | remove: '</p>' | strip_newlines }}
 						</div>
 					</div>
 				{% endunless %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -142,7 +142,7 @@ collection: article
 						<span class="date">&nbsp;-&nbsp;{{ post.date | date: "%e %B %Y" }}</span>
 					</div>
 					<h3>{{ post.title }}</h3>
-					<p class="excerpt">{{ post.excerpt }}</p>
+					<p class="excerpt">{{ post.excerpt | markdownify | remove_first: '<p>' | remove: '</p>' | strip_newlines }}</p>
 				</div>
 			</article>
 		</a>

--- a/pages/home.html
+++ b/pages/home.html
@@ -74,7 +74,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "uk", "zh-cn", "zh
 				<div class="thumbnail" style="background-image: url('{{ post.image }}');"></div>
 				<div class="content">
 					<h3>{{ post.title }}</h3>
-					<p class="excerpt">{{ post.excerpt }}</p>
+					<p class="excerpt">{{ post.excerpt | markdownify | remove_first: '<p>' | remove: '</p>' | strip_newlines }}</p>
 					<span class="date" data-post-date="{{ post.date }}">{{ post.date | date: "%e %B %Y" }}</span>
 				</div>
 			</article>
@@ -90,7 +90,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "uk", "zh-cn", "zh
 						<div class="thumbnail" style="background-image: url('{{ post.image }}');" href="{{ post.url }}"></div>
 						<div>
 							<h3>{{ post.title }}</h3>
-							<p class="excerpt">{{ post.excerpt | truncate: 103 }}</p>
+							<p class="excerpt">{{ post.excerpt | markdownify | strip_html | truncate: 103 }}</p>
 							<span class="date" data-post-date="{{ post.date }}">{{ post.date | date: "%e %B %Y" }}</span>
 						</div>
 					</article>

--- a/test/excerpt_markdown_test.rb
+++ b/test/excerpt_markdown_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# Regression test for issue #1381: Markdown not parsed in news preview.
+#
+# Reads the real Liquid expressions that render `post.excerpt` /
+# `release_article.excerpt` in `_layouts/blog.html`, `pages/home.html` and
+# `_includes/download/version-card.html`, evaluates them against excerpt
+# strings pulled from real article front matter that ships with the repo,
+# and asserts that the Markdown is rendered as HTML (`<em>`, `<strong>`)
+# instead of leaking the raw underscore / asterisk syntax into the rendered
+# preview cards.
+#
+# Usage:  bundle exec ruby test/excerpt_markdown_test.rb
+#
+# This test fails against the pre-fix templates (raw `{{ post.excerpt }}`
+# leaves `_Director's Cut_` showing literally on the home page and blog list)
+# and passes against the patched templates which pipe excerpts through
+# `markdownify`.
+
+require "jekyll"
+require "liquid"
+require "tmpdir"
+
+site_root = File.expand_path("..", __dir__)
+site = Jekyll::Site.new(
+  Jekyll.configuration(
+    "source"      => site_root,
+    "destination" => File.join(Dir.tmpdir, "_site_excerpt_test"),
+  )
+)
+registers = { site: site }
+
+# Fixtures: real excerpt strings from front matter in this repo. Pre-fix these
+# render with raw `_` / `**` visible to the reader; post-fix they render with
+# inline `<em>` / `<strong>`.
+fixtures = {
+  "italic (godot-4-7-lights-camera-action.md)" => {
+    excerpt: "Like a cult classic movie, Godot 4 has only gotten better with age. " \
+             "This brings us to Godot 4.7. With 3 years under its belt, the 4.7 " \
+             "_Director's Cut_ offers colors of never-before-reached intensity.",
+    expect_inline_html: "<em>Director",
+    raw_markdown:        "_Director",
+  },
+  "bold (warning-head-going-unstable.md)" => {
+    excerpt: "Starting now, and only for the upcoming 3.0 release, HEAD will break " \
+             "compatibility completely. Projects from Godot 1.x and 2.x **will not " \
+             "work** and this is expected.",
+    expect_inline_html: "<strong>will not work</strong>",
+    raw_markdown:        "**will",
+  },
+}
+
+# Extract the actual Liquid expression that wraps `post.excerpt` /
+# `release_article.excerpt` from a template file so we exercise the real code,
+# not a hand-copied filter chain.
+def extract_expression(path, variable)
+  contents = File.read(path, encoding: "UTF-8")
+  match = contents.match(/\{\{\s*#{Regexp.escape(variable)}\b[^}]*\}\}/)
+  raise "could not find #{variable} in #{path}" unless match
+  match[0]
+end
+
+call_sites = [
+  {
+    label:    "_layouts/blog.html (blog list card)",
+    path:     File.join(site_root, "_layouts/blog.html"),
+    variable: "post.excerpt",
+  },
+  {
+    label:    "pages/home.html (featured news card)",
+    path:     File.join(site_root, "pages/home.html"),
+    variable: "post.excerpt",
+  },
+  {
+    label:    "_includes/download/version-card.html (release notes preview)",
+    path:     File.join(site_root, "_includes/download/version-card.html"),
+    variable: "release_article.excerpt",
+  },
+]
+
+def render(template, variable, value, registers)
+  varname = variable.split(".", 2).first
+  bag     = {}
+  if variable.include?(".")
+    bag[varname] = { variable.split(".", 2).last => value }
+  else
+    bag[varname] = value
+  end
+  Liquid::Template.parse(template).render!(bag, registers: registers)
+end
+
+failures = []
+
+call_sites.each do |site_info|
+  expression = extract_expression(site_info[:path], site_info[:variable])
+
+  fixtures.each do |label, fx|
+    rendered = render(expression, site_info[:variable], fx[:excerpt], registers)
+
+    if rendered.include?(fx[:raw_markdown])
+      failures << "[#{site_info[:label]}] raw markdown leaked for #{label}: #{rendered.inspect}"
+      next
+    end
+
+    unless rendered.include?(fx[:expect_inline_html])
+      failures << "[#{site_info[:label]}] expected #{fx[:expect_inline_html].inspect} for #{label}, got: #{rendered.inspect}"
+    end
+  end
+end
+
+# The truncated variant on the home page (`pages/home.html` line ~93) intentionally
+# strips formatting so it stays safe to cut mid-string with `truncate`. Verify it
+# at least no longer leaks raw markdown syntax to readers.
+truncated_expression = File.read(File.join(site_root, "pages/home.html"), encoding: "UTF-8")
+  .scan(/\{\{\s*post\.excerpt[^}]*truncate[^}]*\}\}/)
+  .first
+
+if truncated_expression.nil?
+  failures << "[pages/home.html (small news list)] could not locate truncated excerpt expression"
+else
+  fixtures.each do |label, fx|
+    rendered = render(truncated_expression, "post.excerpt", fx[:excerpt], registers)
+    if rendered.include?(fx[:raw_markdown])
+      failures << "[pages/home.html (small news list)] raw markdown leaked for #{label}: #{rendered.inspect}"
+    end
+    if rendered.include?("<em>") || rendered.include?("<strong>")
+      failures << "[pages/home.html (small news list)] HTML tag leaked into truncated excerpt for #{label}: #{rendered.inspect}"
+    end
+  end
+end
+
+if failures.any?
+  warn "excerpt markdown regression test FAILED:"
+  failures.each { |f| warn "  - #{f}" }
+  exit 1
+end
+
+total_assertions = call_sites.size * fixtures.size + fixtures.size
+puts "excerpt markdown regression test passed (#{total_assertions} assertions across " \
+     "#{call_sites.size + 1} excerpt call sites)"


### PR DESCRIPTION
Fixes #1381.

Article excerpts are plain strings, so the listing templates that render `{{ post.excerpt }}` / `{{ release_article.excerpt }}` were leaking the raw underscore / asterisk syntax to readers. On the 4.7 release card, "_Director's Cut_" shows with the literal underscores instead of italics (per the screenshots on the issue).

Same bug shows up on:

- `_layouts/blog.html` (blog list card)
- `pages/home.html` (featured news card + the truncated small news list)
- `_includes/download/version-card.html` (release notes preview on the download page)

Piped each excerpt through `markdownify` so inline markdown renders. The inline call sites strip kramdown's wrapping `<p>` so they keep the existing `<p class="excerpt">` styling. The truncated variant on the home page (`truncate: 103`) strips HTML first so it stays safe to cut mid-string.

Added a small regression test under `test/excerpt_markdown_test.rb` that reads the actual Liquid expressions from each template and asserts they render `<em>` / `<strong>` instead of leaking `_` / `**`, using excerpt strings pulled from real article front matter in this repo. Test fails on `master` and passes with the fix.

### AI disclosure

This change was written with the assistance of Claude. I have reviewed the diff and the test and take responsibility for the code.
