### PR TITLE
fix(blog): correct broken RC 1 article URL in 4.7 RC 2 post

### DIFF
--- a/collections/_article/release-candidate-godot-4-7-rc-2.md
+++ b/collections/_article/release-candidate-godot-4-7-rc-2.md
@@ -42,7 +42,7 @@ This section covers all changes made since the [RC 1 snapshot](/article/release-
 
 ## Changelog
 
-As we've tightened our policy on what kind of changes can be merged leading to the release candidate stage, there aren't a lot of changes in this snapshot. **7 contributors** submitted **10 fixes** for this release. See our [**interactive changelog**](https://godotengine.github.io/godot-interactive-changelog/#4.7-rc2) for the complete list of changes since [4.7 RC 1](/articlerelease-candidate-godot-4-7-rc-1/). You can also review [all changes included in 4.7](https://godotengine.github.io/godot-interactive-changelog/#4.7) compared to the previous [4.6 feature release](/releases/4.6/).
+As we've tightened our policy on what kind of changes can be merged leading to the release candidate stage, there aren't a lot of changes in this snapshot. **7 contributors** submitted **10 fixes** for this release. See our [**interactive changelog**](https://godotengine.github.io/godot-interactive-changelog/#4.7-rc2) for the complete list of changes since [4.7 RC 1](/article/release-candidate-godot-4-7-rc-1/). You can also review [all changes included in 4.7](https://godotengine.github.io/godot-interactive-changelog/#4.7) compared to the previous [4.6 feature release](/releases/4.6/).
 
 This release is built from commit [`3df26a02c`](https://github.com/godotengine/godot/commit/3df26a02c446710c979daa541b74f87edeca81b0).
 


### PR DESCRIPTION
## Description

The "since [4.7 RC 1]" link in the changelog paragraph of the 4.7 RC 2 blog post was missing a slash after `article`, so the URL resolved to `/articlerelease-candidate-godot-4-7-rc-1/` (404) instead of `/article/release-candidate-godot-4-7-rc-1/`. The correct URL is already used a few lines above in the "RC 1 snapshot" link, so this aligns the second occurrence with the existing one.

One-character fix: insert the missing `/` after `article`.

## Existing Issue

Fixes #1354

## Test Coverage

This repository has no automated test suite, and the change is a textual correction to a published blog post. Verified manually:

- On `master`: `grep "articlerelease-candidate" collections/_article/release-candidate-godot-4-7-rc-2.md` returns the broken link on line 45.
- On this branch: the same `grep` returns nothing, and `grep "/article/release-candidate-godot-4-7-rc-1/"` matches both line 30 (already-correct occurrence) and line 45 (newly-corrected occurrence).

## AI disclosure

This patch was written with the assistance of Claude. I have reviewed the diff and take responsibility for the change.
