### PR TITLE
UI incorrectly displayed

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -15,10 +15,12 @@ header {
 
   .container {
     background-color: var(--navbar-background-color);
-    overflow: initial;
+    overflow: visible;
 		width: 100%;
+    max-width: 100%;
     box-sizing: border-box;
-    padding: 0.2em 0.4em;
+    padding: 0.2em 6px;
+    gap: clamp(8px, 0.9vw, 18px);
 		border-radius: 16px;
   }
 
@@ -57,7 +59,23 @@ header {
     .container {
       border-radius: 0;
       margin-top: 0;
+      width: 100%;
+      max-width: 100%;
     }
+  }
+}
+
+/* Desktop: shrink-wrap the pill to nav content, centered in the viewport */
+@media (min-width: 1201px) {
+  header .container {
+    width: fit-content;
+    max-width: calc(100% - 2em);
+    margin-inline: auto;
+  }
+
+  #nav {
+    width: auto;
+    flex: 0 0 auto;
   }
 }
 
@@ -65,7 +83,6 @@ header {
 	.fund {
 		margin-right: 0px;
 		margin-left: 0px;
-		padding-left: 7px;
 		flex-shrink: 0;
 		&.desktop {
 			@media (max-width: 1200px) {
@@ -85,7 +102,7 @@ header {
 			background-color: #F35774 !important;
 			border-radius: var(--button-border-radius);
 			box-shadow: inset 0 0 0 2px #F35774;
-			padding: 13px;
+			padding: clamp(9px, 0.9vw, 13px);
 			white-space: nowrap;
 		}
 	}
@@ -125,14 +142,17 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-left: 26px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding-left: 0;
+  padding-right: 0;
 	a {
 		text-decoration: none;
-		font-size: clamp(14px, 1.25vw, 16px);
+		font-size: clamp(13px, 1.25vw, 16px);
 		font-weight: 400;
 		color: var(--navbar-link-color);
-		margin-left: 14px;
-		padding: clamp(8px, 0.85vw, 12px);
+		margin-left: clamp(4px, 0.9vw, 14px);
+		padding: clamp(6px, 0.7vw, 12px);
 		white-space: nowrap;
     position: relative;
     background-color: transparent;
@@ -155,6 +175,7 @@ header {
   display: flex;
   align-items: center;
   height: 100%;
+  min-width: 0;
 }
 
 #nav > ul > :first-child {
@@ -282,6 +303,7 @@ header {
   #nav {
     display: none;
 		padding-left: 0;
+    padding-right: 0;
   }
   #nav ul {
     align-items: flex-start;
@@ -372,6 +394,17 @@ header {
 
 .add-nav-gap {
   padding-top: 64px;
+}
+
+/* Prevent global .container child padding rules from breaking header symmetry */
+@media (min-width: 1400px) {
+  header .container > :first-child {
+    padding-left: 0;
+  }
+
+  header .container > :last-child:not(a.btn) {
+    padding-right: 0;
+  }
 }
 
 /* Language specific fixes */

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -66,6 +66,7 @@ header {
 		margin-right: 0px;
 		margin-left: 0px;
 		padding-left: 7px;
+		flex-shrink: 0;
 		&.desktop {
 			@media (max-width: 1200px) {
 				display: none;
@@ -85,6 +86,7 @@ header {
 			border-radius: var(--button-border-radius);
 			box-shadow: inset 0 0 0 2px #F35774;
 			padding: 13px;
+			white-space: nowrap;
 		}
 	}
 }
@@ -126,11 +128,12 @@ header {
   padding-left: 26px;
 	a {
 		text-decoration: none;
-		font-size: 16px;
+		font-size: clamp(14px, 1.25vw, 16px);
 		font-weight: 400;
 		color: var(--navbar-link-color);
 		margin-left: 14px;
-		padding: 12px;
+		padding: clamp(8px, 0.85vw, 12px);
+		white-space: nowrap;
     position: relative;
     background-color: transparent;
     transition: all 0.1s ease;
@@ -372,8 +375,4 @@ header {
 }
 
 /* Language specific fixes */
-html[lang="pl"] {
-  #nav a {
-    font-size: 15px;
-  }
-}
+/* font-size and padding are handled universally via clamp() on #nav a */


### PR DESCRIPTION
Closes #1237 

The navbar layout broke when switching to languages with longer words (e.g. Ukrainian, Russian). Nav links wrapped to a second line and the Donate button was clipped or hidden.

Changes: `assets/css/header.css`

- **`white-space: nowrap`** on all nav links, prevents any translated text from wrapping inside a link, regardless of language
- **`clamp()` on font-size and padding** — font and spacing scale down proportionally on tighter viewports instead of staying fixed.
- **`fit-content` pill width** — the navbar pill now sizes to its content and stays centered with `margin-inline: auto`, so it expands equally on both sides instead of overflowing to the right.
- **Symmetric container padding** — all outer inset consolidated on the container equally (left = right), removing previously inconsistent per-element offsets.

### Below are some images:
<table>
  <tr>
    <td align="center">
      <strong>English (Before)</strong><br>
      <img width="1280" height="665" alt="Screenshot 2026-06-30 at 01 00 07" src="https://github.com/user-attachments/assets/bff36099-0068-49bb-931c-f9a2f85df985" />
    </td>
    <td align="center">
      <strong>Russian</strong><br> 
      <img width="1280" height="661" alt="Screenshot 2026-06-30 at 00 58 55" src="https://github.com/user-attachments/assets/0ec34acc-b95f-4877-8d4d-bd382161a55e" />
    </td>
    <td align="center">
      <strong>Ukrainian</strong><br>
      <img width="1280" height="661" alt="Screenshot 2026-06-30 at 00 59 09" src="https://github.com/user-attachments/assets/e8e0c670-732b-48c6-8d42-44e9877cad12" />
    </td>
  </tr>
</table>