### PR TITLE
Fix Markdown display when used in post excerpts

### DIFF
--- a/_includes/download/version-card.html
+++ b/_includes/download/version-card.html
@@ -20,7 +20,7 @@
 					<div class="notes-summary">
 						<div class="notes-thumbnail" style="background-image: url('{{ release_article.image }}');"></div>
 						<div class="notes-excerpt">
-							{{ release_article.excerpt }}
+							{{ release_article.excerpt | markdownify | remove_first: '<p>' | remove: '</p>' | strip_newlines }}
 						</div>
 					</div>
 				{% endunless %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -142,7 +142,7 @@ collection: article
 						<span class="date">&nbsp;-&nbsp;{{ post.date | date: "%e %B %Y" }}</span>
 					</div>
 					<h3>{{ post.title }}</h3>
-					<p class="excerpt">{{ post.excerpt }}</p>
+					<p class="excerpt">{{ post.excerpt | markdownify | remove_first: '<p>' | remove: '</p>' | strip_newlines }}</p>
 				</div>
 			</article>
 		</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="author" content="Godot Engine">
-	<meta name="description" content="{% if page.description %}{{ page.description }}{% elsif page.excerpt %}{{ page.excerpt }}{% else %}{% t meta.description %}{% endif %}">
+	<meta name="description" content="{% if page.description %}{{ page.description }}{% elsif page.excerpt %}{{ page.excerpt | markdownify | strip_html | strip_newlines }}{% else %}{% t meta.description %}{% endif %}">
 
 	<!-- Plausible -->
 	<script defer data-domain="godotengine.org" src="https://plausible.godot.foundation/js/script.file-downloads.outbound-links.js"></script>

--- a/pages/home.html
+++ b/pages/home.html
@@ -74,7 +74,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "uk", "zh-cn", "zh
 				<div class="thumbnail" style="background-image: url('{{ post.image }}');"></div>
 				<div class="content">
 					<h3>{{ post.title }}</h3>
-					<p class="excerpt">{{ post.excerpt }}</p>
+					<p class="excerpt">{{ post.excerpt | markdownify | remove_first: '<p>' | remove: '</p>' | strip_newlines}}</p>
 					<span class="date" data-post-date="{{ post.date }}">{{ post.date | date: "%e %B %Y" }}</span>
 				</div>
 			</article>
@@ -90,7 +90,7 @@ localize: ["de", "en", "es", "fr", "ja", "ko", "pl", "pt-br", "uk", "zh-cn", "zh
 						<div class="thumbnail" style="background-image: url('{{ post.image }}');" href="{{ post.url }}"></div>
 						<div>
 							<h3>{{ post.title }}</h3>
-							<p class="excerpt">{{ post.excerpt | truncate: 103 }}</p>
+							<p class="excerpt">{{ post.excerpt | markdownify | strip_html | truncate: 103 }}</p>
 							<span class="date" data-post-date="{{ post.date }}">{{ post.date | date: "%e %B %Y" }}</span>
 						</div>
 					</article>


### PR DESCRIPTION
- Ensure Markdown is stripped from `meta description`s.
