### PR TITLE
Show downloads for mono AAR libraries

### DIFF
--- a/_data/download_configs.yml
+++ b/_data/download_configs.yml
@@ -14,6 +14,9 @@ defaults:
       windows.32: win32.exe.zip
       windows.arm64: windows_arm64.exe.zip
       web: web_editor.zip
+    extras:
+      aar_library: template_release.aar
+
     mono:
       templates: mono_export_templates.tpz
       editor:
@@ -25,8 +28,8 @@ defaults:
         windows.64: mono_win64.zip
         windows.32: mono_win32.zip
         windows.arm64: mono_windows_arm64.zip
-    extras:
-      aar_library: template_release.aar
+      extras:
+        aar_library: mono.template_release.aar
 
   3:
     templates: export_templates.tpz
@@ -227,10 +230,36 @@ overrides:
       extras:
         aar_library: template_release.aar
 
-  # Godot 4.2 beta 5 introduced Linux ARM builds.
+  # Godot 4.2 dev 3 re-added mono AAR libraries.
   - version: 4
     range:
       - "4.0-alpha17"
+      - "4.2-dev2"
+    config:
+      templates: export_templates.tpz
+      editor:
+        android.apk: android_editor.apk
+        linux.64: linux.x86_64.zip
+        linux.32: linux.x86_32.zip
+        macos.universal: macos.universal.zip
+        windows.64: win64.exe.zip
+        windows.32: win32.exe.zip
+        web: web_editor.zip
+      extras:
+        aar_library: template_release.aar
+      mono:
+        templates: mono_export_templates.tpz
+        editor:
+          linux.64: mono_linux_x86_64.zip
+          linux.32: mono_linux_x86_32.zip
+          macos.universal: mono_macos.universal.zip
+          windows.64: mono_win64.zip
+          windows.32: mono_win32.zip
+
+  # Godot 4.2 beta 5 introduced Linux ARM builds.
+  - version: 4
+    range:
+      - "4.2-dev3"
       - "4.2-beta4"
     config:
       templates: export_templates.tpz
@@ -242,6 +271,8 @@ overrides:
         windows.64: win64.exe.zip
         windows.32: win32.exe.zip
         web: web_editor.zip
+      extras:
+        aar_library: template_release.aar
       mono:
         templates: mono_export_templates.tpz
         editor:
@@ -250,8 +281,8 @@ overrides:
           macos.universal: mono_macos.universal.zip
           windows.64: mono_win64.zip
           windows.32: mono_win32.zip
-      extras:
-        aar_library: template_release.aar
+        extras:
+          aar_library: mono.template_release.aar
 
   # Godot 4.3 RC 1 introduced Windows ARM builds.
   - version: 4
@@ -270,6 +301,8 @@ overrides:
         windows.64: win64.exe.zip
         windows.32: win32.exe.zip
         web: web_editor.zip
+      extras:
+        aar_library: template_release.aar
       mono:
         templates: mono_export_templates.tpz
         editor:
@@ -280,8 +313,8 @@ overrides:
           macos.universal: mono_macos.universal.zip
           windows.64: mono_win64.zip
           windows.32: mono_win32.zip
-      extras:
-        aar_library: template_release.aar
+        extras:
+          aar_library: mono.template_release.aar
 
   # Godot 4.4 dev 2 introduced Android Horizon OS builds.
   - version: 4
@@ -301,6 +334,8 @@ overrides:
         windows.32: win32.exe.zip
         windows.arm64: windows_arm64.exe.zip
         web: web_editor.zip
+      extras:
+        aar_library: template_release.aar
       mono:
         templates: mono_export_templates.tpz
         editor:
@@ -312,8 +347,8 @@ overrides:
           windows.64: mono_win64.zip
           windows.32: mono_win32.zip
           windows.arm64: mono_windows_arm64.zip
-      extras:
-        aar_library: template_release.aar
+        extras:
+          aar_library: mono.template_release.aar
 
   # Godot 4.4 beta 3 introduced Android Pico OS builds.
   - version: 4
@@ -334,6 +369,8 @@ overrides:
         windows.32: win32.exe.zip
         windows.arm64: windows_arm64.exe.zip
         web: web_editor.zip
+      extras:
+        aar_library: template_release.aar
       mono:
         templates: mono_export_templates.tpz
         editor:
@@ -345,5 +382,5 @@ overrides:
           windows.64: mono_win64.zip
           windows.32: mono_win32.zip
           windows.arm64: mono_windows_arm64.zip
-      extras:
-        aar_library: template_release.aar
+        extras:
+          aar_library: mono.template_release.aar

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -248,6 +248,12 @@ layout: default
 						{% unless aar_library_info.caption == empty %} - {{ aar_library_info.caption }}{% endunless %}
 					</a>
 				</p>
+				<p>
+					<a href="{{ stable_version | make_download: "aar_library", true }}">
+						{{ aar_library_info.title }} - .NET / C#
+						{% unless aar_library_info.caption == empty %} {{ aar_library_info.caption }}{% endunless %}
+					</a>
+				</p>
 			</div>
 
 			{% if page.platform == 'Android' %}


### PR DESCRIPTION
When 4.0 was initially released, support for AAR libraries was dropped for mono builds. This functionality was re-added in 4.2-dev3, but this was never synced back up. This change restores support for showcasing the C# AAR library downloads, both in the "all downloads" view & in the primary "AAR library" banner