### PR TITLE
Fix reflows when hovering over headings due to blog anchor links

### DIFF
--- a/assets/css/anchor-link.css
+++ b/assets/css/anchor-link.css
@@ -1,5 +1,6 @@
 .anchored-link {
-    display: none;
+    display: inline-block;
+    visibility: hidden;
     background-image: url(/assets/icons/link.svg);
     background-repeat: no-repeat;
     background-position: center;
@@ -26,7 +27,8 @@
 }
 
 .anchored:hover .anchored-link {
-    display: inline-block;
+    /* Change `visibility` instead of `display` to avoid reflows when hovering over the link. */
+    visibility: visible;
 }
 
 .anchored-toast {


### PR DESCRIPTION
This uses CSS `visibility` instead of `display` to toggle whether the anchor link is visible, so that it always takes up space in the layout.

- This closes https://github.com/godotengine/godot-website/issues/1406.

## Preview

### `master`

https://github.com/user-attachments/assets/d2dc010f-a44b-4507-b9be-c1141e8498bd

### This PR

https://github.com/user-attachments/assets/361b1418-e359-4446-8577-5597a06b843a