### PR TITLE
Add showreel submission opening for 2026

### DIFF
--- a/collections/_article/submissions-open-godot-2026-showreel.md
+++ b/collections/_article/submissions-open-godot-2026-showreel.md
@@ -1,0 +1,32 @@
+---
+title: "Submissions open for Godot 2026 showreel"
+excerpt: "Showcase your Godot creations in 2026! We're inviting submissions of short videos featuring your published or in-progress Godot games or tools. Don't miss this chance to be a part of it!"
+categories: ["news"]
+author: Emi
+image: /storage/blog/covers/godot-showreel-2024.webp
+image_caption_description: Illustration by André Marí Coppola
+date: 2026-08-15 13:00:00
+---
+
+Showcase your Godot Engine 2026 creations! We invite you to submit videos featuring your published or in-progress games or tools so we can make the Godot 2026 Showreel.
+
+Our annual showreels are informative and celebratory showcases, to highlight the wide array of projects developed using the Godot Engine. If you want to participate this year and share your Godot-made game, app, or tool, submit your entry starting today.
+
+## Help us to decide!
+
+Like last year, we want to invite more people to participate in the voting phase. So, if you are a member of the <a href="https://fund.godotengine.org/">Development Fund</a>, you will be able to cast your votes alongside the Godot maintainers! To be eligible to vote, you need to have a recurrent donation active.
+
+
+## How to submit
+You can submit your entry in our [Godot Showreel website](https://showreel.godotengine.org/). Before submitting, please read the [submission guidelines](https://showreel.godotengine.org/about).
+
+- 📅 **Submissions close on October 1st 2026**
+- 📅 **Voting from October 2th until October 16th 2026**
+
+## Need inspiration?
+Check out our [showreel playlist](https://www.youtube.com/watch?v=7ZwEmxihlw4&list=PLeG_dAglpVo6EpaO9A1nkwJZOwrfiLdQ8&index=1) for some creative sparks and see what makes a great submission! Here is last year's showreel:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/7ZwEmxihlw4" frameborder="0" allowfullscreen style="width: 100%; aspect-ratio: 16 / 9; height: auto;"></iframe>
+
+
+Good luck! We can't wait to see your creations!

--- a/pages/community/community.html
+++ b/pages/community/community.html
@@ -159,8 +159,8 @@ layout: default
 				
 				<div class="events-upcoming">
 					<span>Next event:</span>
-					<span>GodotCon</span>
-					<span>April 2026</span>
+					<span>GodotFest</span>
+					<span>November 2026</span>
 				</div>
 				
 			</a>


### PR DESCRIPTION
To be published tomorrow (Aug 15, 2026).

Image might be also updated depending if I can get a new one in time. 

The submissions are already open, but there isn't any issue about that, technically people can already submit entries. 
