### PR TITLE
Fix header z-index fighting

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -5,7 +5,7 @@ header {
   position: absolute;
   top: 0.5em;
   width: 100%;
-  z-index: 2;
+  z-index: 3;
 
   display: flex;
   align-items: center;


### PR DESCRIPTION
The header currently has the same z-index as "#future .container" from devfund.scss. This causes the header to be displayed wrong on https://fund.godotengine.org/:
<img width="1136" height="883" alt="z_index_fighting" src="https://github.com/user-attachments/assets/397b3803-ca66-4bcd-912e-8a74d7469524" />
Bumping the z-index to 3 should fix this issue.